### PR TITLE
AddOn deletes fail when done from a list of plan add-ons

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -35,8 +35,9 @@ namespace Recurly
         {
         }
 
-        internal AddOn(XmlTextReader xmlReader)
+        internal AddOn(string planCode, XmlTextReader xmlReader)
         {
+            PlanCode = planCode;
             ReadXml(xmlReader);
         }
 

--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -7,7 +7,7 @@ namespace Recurly
     public class AddOn : RecurlyEntity
     {
 
-        public string PlanCode { get; private set; }
+        public string PlanCode { get; internal set; }
         public string AddOnCode { get; set; }
         public string Name { get; set; }
 
@@ -35,9 +35,8 @@ namespace Recurly
         {
         }
 
-        internal AddOn(string planCode, XmlTextReader xmlReader)
+        internal AddOn(XmlTextReader xmlReader)
         {
-            PlanCode = planCode;
             ReadXml(xmlReader);
         }
 

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -51,6 +51,11 @@ namespace Recurly
 
         #region Constructors
 
+        internal Adjustment(string uuid)
+        {
+            this.Uuid = uuid;
+        }
+
         internal Adjustment()
         {
             
@@ -213,7 +218,7 @@ namespace Recurly
     {
         public static Adjustment Get(string uuid)
         {
-            var adjustment = new Adjustment();
+            var adjustment = new Adjustment(uuid);
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
                 "/adjustments/" + Uri.EscapeUriString(uuid),
                 adjustment.WriteXml);

--- a/Library/List/AddOnList.cs
+++ b/Library/List/AddOnList.cs
@@ -4,12 +4,15 @@ namespace Recurly
 {
     public class AddOnList : RecurlyList<AddOn>
     {
+        public string PlanCode { get; private set; }
+
         public AddOnList()
         {
         }
 
-        public AddOnList(string url) : base(Client.HttpRequestMethod.Get, url)
+        public AddOnList(string planCode, string url) : base(Client.HttpRequestMethod.Get, url)
         {
+            PlanCode = planCode;
         }
 
         internal override void ReadXml(XmlTextReader reader)
@@ -22,24 +25,24 @@ namespace Recurly
 
                 if (reader.NodeType == XmlNodeType.Element && reader.Name == "add_on")
                 {
-                    Add(new AddOn(reader));
+                    Add(new AddOn(PlanCode, reader));
                 }
             }
         }
 
         public override RecurlyList<AddOn> Start
         {
-            get { return HasStartPage() ? new AddOnList(StartUrl) : RecurlyList.Empty<AddOn>(); }
+            get { return HasStartPage() ? new AddOnList(PlanCode, StartUrl) : RecurlyList.Empty<AddOn>(); }
         }
 
         public override RecurlyList<AddOn> Next
         {
-            get { return HasNextPage() ? new AddOnList(NextUrl) : RecurlyList.Empty<AddOn>(); }
+            get { return HasNextPage() ? new AddOnList(PlanCode, NextUrl) : RecurlyList.Empty<AddOn>(); }
         }
 
         public override RecurlyList<AddOn> Prev
         {
-            get { return HasPrevPage() ? new AddOnList(PrevUrl) : RecurlyList.Empty<AddOn>(); }
+            get { return HasPrevPage() ? new AddOnList(PlanCode, PrevUrl) : RecurlyList.Empty<AddOn>(); }
         }
     }
 }

--- a/Library/List/AddOnList.cs
+++ b/Library/List/AddOnList.cs
@@ -13,6 +13,11 @@ namespace Recurly
         public AddOnList(string planCode, string url) : base(Client.HttpRequestMethod.Get, url)
         {
             PlanCode = planCode;
+
+            foreach (var addOn in this)
+            {
+                addOn.PlanCode = planCode;
+            }
         }
 
         internal override void ReadXml(XmlTextReader reader)
@@ -25,7 +30,7 @@ namespace Recurly
 
                 if (reader.NodeType == XmlNodeType.Element && reader.Name == "add_on")
                 {
-                    Add(new AddOn(PlanCode, reader));
+                    Add(new AddOn(reader));
                 }
             }
         }

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -143,6 +143,9 @@ namespace Recurly
                 UrlPrefix + Uri.EscapeUriString(PlanCode) + "/add_ons/" + Uri.EscapeUriString(addOnCode),
                 addOn.ReadXml);
 
+            if (null != addOn)
+                addOn.PlanCode = PlanCode;
+
             return status == HttpStatusCode.OK ? addOn : null;
         }
 

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -50,7 +50,7 @@ namespace Recurly
                 if (_addOns == null)
                 {
                     var url = UrlPrefix + Uri.EscapeUriString(PlanCode) + "/add_ons/";
-                    _addOns = new AddOnList(url);
+                    _addOns = new AddOnList(PlanCode, url);
                 }
                 return _addOns;
             }


### PR DESCRIPTION
The AddOn list that gets loaded from plan.AddOns returns AddOn objects that don't have a planCode associated with them, which causes certain operations to fail (Delete's in particular). I updated the AddOnList to store its associated plan code and update retrieved add-ins with this data.
