### PR TITLE
Updated SubscriptionAddOnList.Add(AddOn, quantity) to address Issue #37

### DIFF
--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -1,5 +1,4 @@
 ﻿using System.Xml;
-using System.Collections.Generic;
 
 namespace Recurly
 {
@@ -45,15 +44,44 @@ namespace Recurly
             }
         }
 
-        //sub.AddOns.Add(planAddOn, quantity, unitInCents)
-        //sub.AddOns.Add(planAddOn, quantity) // unitInCents=this.Plan.UnitAmountInCents[this.Currency]
-        //sub.AddOns.Add(planAddOn) // default quantity=1, unitInCents=this.Plan.UnitAmountInCents[this.Currency]
-        public void Add(AddOn planAddOn, int quantity=1)
+        /// <summary>
+        /// Adds the given <see cref="T:Recurly.AddOn"/> to the current Subscription.
+        /// 
+        /// Sample usage:
+        /// <code>
+        /// sub.AddOns.Add(planAddOn, quantity, unitInCents)
+        /// sub.AddOns.Add(planAddOn, quantity) // unitInCents = planAddOn.UnitAmountInCents[this.Currency]
+        /// sub.AddOns.Add(planAddOn) // default quantity = 1, unitInCents = planAddOn.UnitAmountInCents[this.Currency]
+        /// </code>
+        /// </summary>
+        /// <param name="planAddOn">The <see cref="T:Recurly.AddOn"/> to add to the current Subscription.</param>
+        /// <param name="quantity">The quantity of the add-on. Optional, default is 1.</param>
+        public void Add(AddOn planAddOn, int quantity = 1)
         {
-            var unitAmount = _subscription.Plan.UnitAmountInCents[_subscription.Currency];
-            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, unitAmount, quantity);
+            int amount;
+            if (!planAddOn.UnitAmountInCents.TryGetValue(_subscription.Currency, out amount))
+            {
+                throw new ValidationException(
+                    "The given AddOn does not have UnitAmountInCents for the currency of the subscription (" + _subscription.Currency + ")."
+                    , null);
+            }
+            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, amount, quantity);
             base.Add(sub);
         }
+
+        /// <summary>
+        /// Adds the given <see cref="T:Recurly.AddOn"/> to the current Subscription.
+        /// 
+        /// Sample usage:
+        /// <code>
+        /// sub.AddOns.Add(planAddOn, quantity, unitInCents)
+        /// sub.AddOns.Add(planAddOn, quantity) // unitInCents = planAddOn.UnitAmountInCents[this.Currency]
+        /// sub.AddOns.Add(planAddOn) // default quantity = 1, unitInCents = planAddOn.UnitAmountInCents[this.Currency]
+        /// </code>
+        /// </summary>
+        /// <param name="planAddOn">The <see cref="T:Recurly.AddOn"/> to add to the current Subscription.</param>
+        /// <param name="quantity">The quantity of the add-on. Optional, default is 1.</param>
+        /// <param name="unitAmountInCents">Overrides the UnitAmountInCents of the add-on.</param>
         public void Add(AddOn planAddOn, int quantity, int unitAmountInCents)
         {
             var sub = new SubscriptionAddOn(planAddOn.AddOnCode, unitAmountInCents, quantity);

--- a/Test/List/SubscriptionAddOnListTest.cs
+++ b/Test/List/SubscriptionAddOnListTest.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Recurly.Test.List
+{
+    public class SubscriptionAddOnListTest : BaseTest
+    {
+        private const string USD = "USD";
+        private const string GBP = "GBP";
+
+        [Fact]
+        public void AddAddOnFailsValidationWhenCurrencyDoesNotMatch()
+        {
+            var account = new Account("1");
+
+            var plan = new Plan(GetMockPlanCode(), "add add on test");
+            plan.UnitAmountInCents.Add(USD, 100);
+            
+            var addOn = plan.NewAddOn("1", "test");
+            addOn.UnitAmountInCents.Add(USD, 200);
+            
+            var sub = new Subscription(account, plan, GBP);
+
+            Action a = () => sub.AddOns.Add(addOn);
+            a.ShouldThrow<ValidationException>()
+                .And
+                .Message.Should().Be("The given AddOn does not have UnitAmountInCents for the currency of the subscription (GBP).");
+
+        }
+
+        [Fact]
+        public void AddAddOnSucceedsWhenCurrencyMatches()
+        {
+            var account = new Account("1");
+
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName());
+            plan.UnitAmountInCents.Add(USD, 100);
+
+            var addOn = plan.NewAddOn("1", "test");
+            addOn.UnitAmountInCents.Add(USD, 200);
+
+            var sub = new Subscription(account, plan, USD);
+
+            Action a = () => sub.AddOns.Add(addOn);
+            a.ShouldNotThrow<ValidationException>();
+        }
+
+        [Fact]
+        public void AddAddOnMaintainsData()
+        {
+            const string addOnCode = "1";
+
+            var account = new Account("1");
+
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName());
+            plan.UnitAmountInCents.Add(USD, 100);
+
+            var addOn = plan.NewAddOn(addOnCode, "test");
+            addOn.UnitAmountInCents.Add(USD, 200);
+
+            var sub = new Subscription(account, plan, USD);
+
+            sub.AddOns.Add(addOn);
+
+            var newAddOn = sub.AddOns.First();
+            newAddOn.Should()
+                .Match<SubscriptionAddOn>(x => x.AddOnCode == addOnCode)
+                .And.Match<SubscriptionAddOn>(x => x.UnitAmountInCents == addOn.UnitAmountInCents[sub.Currency]);
+        }
+    }
+}

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -82,6 +82,7 @@
     <Compile Include="FixtureImporterTests.cs" />
     <Compile Include="Fixtures\FixtureImporter.cs" />
     <Compile Include="Fixtures\FixtureResponse.cs" />
+    <Compile Include="List\SubscriptionAddOnListTest.cs" />
     <Compile Include="QueryBuilderTest.cs" />
     <Compile Include="SettingsFixture.cs" />
     <Compile Include="InvoiceTest.cs" />


### PR DESCRIPTION
The Issue https://github.com/recurly/recurly-client-net/issues/37 stipulates that the Subscription price is overriding the Add On price when importing a Plan Add On in to a Subscription.

These changes update the SubscriptionAddOnList.Add(AddOn, quantity) logic to pull the UnitAmountInCents from the given AddOn. If the AddOn does not have a UnitAmountInCents for the given Subscription's currency, a ValidationException is thrown.

I have also included tests on SubscriptionAddOnList.Add(AddOn, quantity), covering a failure and success of importing the price, and data integrity through the import.
