### PR TITLE
Add tax_code to plan, add on and adjustment

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -25,6 +25,7 @@ namespace Recurly
         public int DefaultQuantity { get; set; }
         public bool? DisplayQuantityOnHostedPage { get; set; }
         public DateTime CreatedAt { get; private set; }
+        public string TaxCode { get; set; }
 
 
         private const string UrlPrefix = "/plans/";
@@ -133,6 +134,10 @@ namespace Recurly
 
                     case "unit_amount_in_cents":
                         ReadXmlUnitAmount(reader);
+                        break;
+
+                    case "tax_code":
+                        TaxCode = reader.ReadElementContentAsString();
                         break;
 
                 }

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -35,6 +35,7 @@ namespace Recurly
         public int TotalInCents { get; protected set; }
         public string Currency { get; set; }
         public bool TaxExempt { get; set; }
+        public string TaxCode { get; set; }
 
         public AdjustmentState State { get; protected set; }
 
@@ -169,6 +170,10 @@ namespace Recurly
 
                     case "tax_exempt":
                         TaxExempt = reader.ReadElementContentAsBoolean();
+                        break;
+
+                    case "tax_code":
+                        TaxCode = reader.ReadElementContentAsString();
                         break;
 
                     case "start_date":

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -41,6 +41,8 @@ namespace Recurly
 
         public bool? TaxExempt { get; set; }
 
+        public string TaxCode { get; set; }
+
         private AddOnList _addOns;
 
         public RecurlyList<AddOn> AddOns
@@ -263,6 +265,10 @@ namespace Recurly
 
                     case "tax_exempt":
                         TaxExempt = reader.ReadElementContentAsBoolean();
+                        break;
+
+                    case "tax_code":
+                        TaxCode = reader.ReadElementContentAsString();
                         break;
 
                     case "unit_amount_in_cents":


### PR DESCRIPTION
Used in tax calculations for VAT 2015 and Avalara integration taxes only.

Valid tax_code values for VAT 2015 taxes are unknown, digital and physical. Valid tax_code values for Avalara integration taxes can be found in the Avalara documentation.

Approvers: @cbarton

Tests:
On a site with VAT 2015 and Avalara integration taxes enabled:
- Create/Update a plan, add_on and adjustment with a valid tax_code and verify there isn't an error
- Get the created/updated plan, add_on and adjustment and verify that the tax_code is returned in the results
- Attempt to create/update a plan, add_on and adjustment with an invalid tax_code and verify that an error is returned in the results
  On a site without VAT 2015 and Avalara integration taxes enabled:
- Get a plan, add_on and adjustment and verify that the tax_code is not returned in the results
- Attempt to create/update a plan, add_on and adjustment with a tax_code and verify that an error is returned in the results
