### PR TITLE
Adding vat_location_valid field to Account

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@ Unreleased
 
 * added; invoice address on previews
 * added; `invoice.OriginalInvoiceNumber`
+* added; VatLocationValid to Account
 
 1.1.7 (stable) / 2014-12-19
 ==================

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -38,6 +38,7 @@ namespace Recurly
         public string AcceptLanguage { get; set; }
         public string HostedLoginToken { get; private set; }
         public DateTime CreatedAt { get; private set; }
+        public bool VatLocationValid { get; private set; }
 
         public Address Address {
             get { return _address ?? (_address = new Address()); }
@@ -346,6 +347,10 @@ namespace Recurly
 
                     case "address":
                         Address = new Address(reader);
+                        break;
+
+                    case "vat_location_valid":
+                        VatLocationValid = reader.ReadElementContentAsBoolean();
                         break;
                 }
             }

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -46,6 +46,7 @@ namespace Recurly.Test
             Assert.True(acct.TaxExempt.Value);
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
+            Assert.False(acct.VatLocationValid);
         }
 
         [Fact]


### PR DESCRIPTION
This field will show up when the account is elligible and has been
location verified according to the VAT rules. It will be true when
passed and false when failed.