### PR TITLE
Adds Invoice#InvoiceNumberPrefix and Invoice#InvoiceNumberWithPrefix

### DIFF
--- a/History.md
+++ b/History.md
@@ -7,6 +7,9 @@ Unreleased
  * `AccountNumber`
  * `LastFour`
  * `NameOnAccount`
+* added; `invoice.InvoiceNumberPrefix` and `invoice.InvoiceNumberWithPrefix()`
+* added; `transaction.GetInvoice()`
+* added; `invoice.GetOriginalInvoice()`
 
 1.1.9 (stable) / 2015-04-01
 ==================


### PR DESCRIPTION
With VAT 2015 rules, all VAT taxed invoices need to be prefixed with the billing countries code, ie: `GB1000` for a customer in Great Britain.

This is already supported in the API and thusly needs to be supported in this client library.

In order to maintain backwards compatibility, I have separated the `InvoiceNumber` and `InvoiceNumberPrefix` fields for all objects that deal with invoices (`Transaction`, `Invoice`, `OriginalInvoice`). In order to make full use of this feature, all integrators should update their integration to use the `invoice.InvoiceNumberWithPrefix()` method instead of `invoice.InvoiceNumber`. 

This also adds convenience methods to get a `Transaction`'s invoice: `transaction.GetInvoice()` and the `Invoice`'s original invoice: `invoice.GetOriginalInvoice()`

cc/ @bhelx  

tests:

  - Turn on the Country Invoice Sequencing feature with VAT taxes
  - Create a VAT taxed invoice 
  - `Invoices.Get("<invoice_number_with_prefix>").InvoiceNumberWithPrefix()` should find the correct invoice and return its full invoice number.