### PR TITLE
Support open amount refund

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Unreleased
 * added; invoice address on previews
 * added; `invoice.OriginalInvoiceNumber`
 * added; VatLocationValid to Account
+* added; Open Amount Refunds to Invoice
 
 1.1.7 (stable) / 2014-12-19
 ==================

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -147,6 +147,21 @@ namespace Recurly
                 return null;
         }
 
+        public Invoice RefundAmount(int amountInCents) {
+            var refundInvoice = new Invoice();
+            var refund = new OpenAmountRefund(amountInCents);
+               
+            var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                UrlPrefix + InvoiceNumber + "/refund",
+                refund.WriteXml,
+                refundInvoice.ReadXml);
+
+            if (HttpStatusCode.Created == response || HttpStatusCode.OK == response)
+                return refundInvoice;
+            else
+                return null;
+        }
+
         #region Read and Write XML documents
 
         internal override void ReadXml(XmlTextReader reader)
@@ -264,7 +279,7 @@ namespace Recurly
 
         internal override void WriteXml(XmlTextWriter writer)
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         #endregion

--- a/Library/OpenAmountRefund.cs
+++ b/Library/OpenAmountRefund.cs
@@ -1,0 +1,26 @@
+﻿using System.Xml;
+
+namespace Recurly
+{
+    class OpenAmountRefund : RecurlyEntity
+    {
+        public int AmountInCents { get; protected set; }
+
+        internal OpenAmountRefund(int amountInCents)
+        {
+            AmountInCents = amountInCents;
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        internal override void WriteXml(XmlTextWriter writer)
+        {
+            writer.WriteStartElement("invoice");
+            writer.WriteElementString("amount_in_cents", AmountInCents.AsString());
+            writer.WriteEndElement();
+        }
+    }
+}

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <Compile Include="Account.cs" />
     <Compile Include="Address.cs" />
+    <Compile Include="OpenAmountRefund.cs" />
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\EnumExtensions.cs" />

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -148,5 +148,31 @@ namespace Recurly.Test
 
             account.Close();
         }
+
+
+        [Fact]
+        public void RefundOpenAmount()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+
+            var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
+            adjustment.Create();
+
+            var invoice = account.InvoicePendingCharges();
+
+            invoice.MarkSuccessful();
+
+            invoice.State.Should().Be(Invoice.InvoiceState.Collected);
+
+            Assert.Equal(1, invoice.Adjustments.Count);
+            Assert.Equal(1, invoice.Adjustments.Capacity);
+
+            // refund
+            var refundInvoice = invoice.RefundAmount(100); // 1 dollar
+            Assert.NotEqual(invoice.Uuid, refundInvoice.Uuid);
+            Assert.Equal(-91, refundInvoice.SubtotalInCents);  // 91 cents
+
+            account.Close();
+        }
     }
 }


### PR DESCRIPTION
Allows an open amount refund and returns a new refund invoice.

Approvers: @cbarton

### Testing

```csharp
var inv = Invoices.Get(1016);

Console.WriteLine(inv.InvoiceNumber);

// refund open amount for 50 cents
var refundInvoice = inv.RefundAmount(50);

Console.WriteLine(refundInvoice.InvoiceNumber);   // should be a new number [this is a new invoice]
Console.WriteLine(refundInvoice.SubtotalInCents);  // should be -50
```
