### PR TITLE
Adding notes support for Invoice and Subscription

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,9 @@ Unreleased
 ==================
 
 * fixed; nil VatLocationValid on Account would throw a parse error
+* added; `subscription.UpdateNotes` will update the subscription's notes
+* added; `subscription.CustomerNotes`, `subscription.TermsAndConditions`, `subscription.VatReverseChargeNotes`
+* added; `invoice.CustomerNotes`, `invoice.TermsAndConditions`, `invoice.VatReverseChargeNotes`
 
 1.1.8 (stable) / 2015-01-26
 ==================

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -53,6 +53,9 @@ namespace Recurly
         public RecurlyList<Adjustment> Adjustments { get; private set; }
         public RecurlyList<Transaction> Transactions { get; private set; }
 
+        public string CustomerNotes { get; set; }
+        public string TermsAndConditions { get; set; }
+        public string VatReverseChargeNotes { get; set; }
 
         internal const string UrlPrefix = "/invoices/";
 
@@ -256,6 +259,18 @@ namespace Recurly
 
                     case "collection_method":
                         CollectionMethod = reader.ReadElementContentAsString();
+                        break;
+
+                    case "customer_notes":
+                        CustomerNotes = reader.ReadElementContentAsString();
+                        break;
+
+                    case "terms_and_conditions":
+                        TermsAndConditions = reader.ReadElementContentAsString();
+                        break;
+
+                    case "vat_reverse_charge_notes":
+                        VatReverseChargeNotes = reader.ReadElementContentAsString();
                         break;
 
                     case "line_items":

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -345,25 +345,16 @@ namespace Recurly
                 ReadXml);
         }
 
-        public bool UpdateNotes(String customerNotes, String termsAndConditions, String vatReverseChargeNotes)
+        public bool UpdateNotes(Dictionary<string, string> notes)
         {
-
-            if (customerNotes != null)
-                CustomerNotes = customerNotes;
-
-            if (termsAndConditions != null)
-                TermsAndConditions = termsAndConditions;
-
-            if (customerNotes != null)
-                VatReverseChargeNotes = vatReverseChargeNotes;
-
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                 UrlPrefix + Uri.EscapeUriString(Uuid) + "/notes",
-                WriteSubscriptionNotesXml,
+                WriteSubscriptionNotesXml(notes),
                 ReadXml);
 
-            // this method does not save the object
-            _saved = false;
+            CustomerNotes = notes["CustomerNotes"];
+            TermsAndConditions =  notes["TermsAndConditions"];
+            VatReverseChargeNotes = notes["VatReverseChargeNotes"];
 
             return true;
         }
@@ -524,7 +515,6 @@ namespace Recurly
                         VatReverseChargeNotes = reader.ReadElementContentAsString();
                         break;
 
-
                     case "address":
                         Address = new Address(reader);
                         break;
@@ -651,15 +641,18 @@ namespace Recurly
             xmlWriter.WriteEndElement(); // End: subscription
         }
 
-        protected void WriteSubscriptionNotesXml(XmlTextWriter xmlWriter)
+        internal Client.WriteXmlDelegate WriteSubscriptionNotesXml(Dictionary<string, string> notes)
         {
-            xmlWriter.WriteStartElement("subscription"); // Start: subscription
+            return delegate(XmlTextWriter xmlWriter)
+            {
+                xmlWriter.WriteStartElement("subscription"); // Start: subscription
 
-            xmlWriter.WriteElementString("customer_notes", CustomerNotes);
-            xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
-            xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
+                xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
+                xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
+                xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
 
-            xmlWriter.WriteEndElement(); // End: subscription
+                xmlWriter.WriteEndElement(); // End: subscription
+            };
         }
 
         #endregion

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -274,6 +274,30 @@ namespace Recurly.Test
         }
 
         [Fact]
+        public void UpdateNotesSubscription()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
+            {
+                Description = "Postpone Subscription Test"
+            };
+            plan.UnitAmountInCents.Add("USD", 100);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.Create();
+
+            sub.UpdateNotes("New Customer Notes", "New T and C", "New VAT Notes");
+
+            sub.CustomerNotes.Should().Be("New Customer Notes");
+            sub.TermsAndConditions.Should().Be("New T and C");
+            sub.VatReverseChargeNotes.Should().Be("New VAT Notes");
+
+        }
+
+        [Fact]
         public void CreateSubscriptionPlanWithAddons()
         {
             Plan plan = null;

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using System.Collections.Generic;
 using Xunit;
 using System.Linq;
 
@@ -289,11 +290,17 @@ namespace Recurly.Test
             var sub = new Subscription(account, plan, "USD");
             sub.Create();
 
-            sub.UpdateNotes("New Customer Notes", "New T and C", "New VAT Notes");
+            Dictionary<string, string> notes = new Dictionary<string, string>();
 
-            sub.CustomerNotes.Should().Be("New Customer Notes");
-            sub.TermsAndConditions.Should().Be("New T and C");
-            sub.VatReverseChargeNotes.Should().Be("New VAT Notes");
+            notes.Add("CustomerNotes", "New Customer Notes");
+            notes.Add("TermsAndConditions", "New T and C");
+            notes.Add("VatReverseChargeNotes", "New VAT Notes");
+
+            sub.UpdateNotes(notes);
+
+            sub.CustomerNotes.Should().Be(notes["CustomerNotes"]);
+            sub.TermsAndConditions.Should().Be(notes["TermsAndConditions"]);
+            sub.VatReverseChargeNotes.Should().Be(notes["VatReverseChargeNotes"]);
 
         }
 


### PR DESCRIPTION
Trying to catch .NET up to the other libraries with notes support.

#### Testing

You can run this and verify the notes have changed. If you run again you should be able to see they have persisted.

```csharp
var sub = Subscriptions.Get("2bf76b61f7874bb58c384d45759be62c");

Console.WriteLine(sub.CustomerNotes);
Console.WriteLine(sub.TermsAndConditions);
Console.WriteLine(sub.VatReverseChargeNotes);

Dictionary<string, string> notes = new Dictionary<string, string>();
notes.Add("CustomerNotes", "New Customer Notes");
notes.Add("TermsAndConditions", "New T and C");
notes.Add("VatReverseChargeNotes", "New VAT Notes");
sub.UpdateNotes(notes);

Console.WriteLine(sub.CustomerNotes);
Console.WriteLine(sub.TermsAndConditions);
Console.WriteLine(sub.VatReverseChargeNotes);
```

