### PR TITLE
Do not parse nil as a boolean for the accounts vat location valid

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* fixed; nil VatLocationValid on Account would throw a parse error
+
 1.1.8 (stable) / 2015-01-26
 ==================
 

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -350,7 +350,10 @@ namespace Recurly
                         break;
 
                     case "vat_location_valid":
-                        VatLocationValid = reader.ReadElementContentAsBoolean();
+                        if (reader.GetAttribute("nil") == null)
+                        {
+                            VatLocationValid = reader.ReadElementContentAsBoolean();
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
The parse blows up when parsing a `VatLocationValid` field of type `nil`. This will avoid trying to parse in such a case and allow that tri-state field to exist.

cc/ @bhelx 

tests:

  - with VAT location validation turned on and an account that is not in the EU
  - The following should not blow up and return `False`: 
```
var account = Accounts.get('<account_code>');
Console.WriteLine(account.VatLocationValid);
```

  - with an account in the EU (that has been validated)
  - the above snippet should reflect the validation of that account.