### PR TITLE
Added support for Diners Club

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -15,7 +15,8 @@ namespace Recurly
             MasterCard,
             AmericanExpress,
             Discover,
-            JCB
+            JCB,
+            DinersClub,
         }
 
         /// <summary>

--- a/Library/Extensions/StringExtensions.cs
+++ b/Library/Extensions/StringExtensions.cs
@@ -69,6 +69,7 @@ namespace Recurly
             if (source.IsNullOrEmpty()) return source;
 
             source = source.Replace("_", " "); // so we know where the word breaks are
+            source = source.Replace("'", ""); // e.g. Diner's Club
             var words = source.Split(' '); // break into words (note that in this case 'words' means groups of letters separated by '_' or ' ', not real words)
             var newString = new StringBuilder();
 
@@ -184,6 +185,15 @@ namespace Recurly
 
             var firstFour = Int32.Parse(card.Substring(0, 4));
             var firstThree = Int32.Parse(card.Substring(0, 3));
+
+            if ((firstThree >= 300 && firstThree <= 305) || (firstThree == 309)
+               || (firstTwo == 36) || (firstTwo == 38) || (firstTwo == 39) || (firstTwo == 54) || (firstTwo == 55)
+               || (firstFour == 2014) || (firstFour == 2149))
+            {
+              type = BillingInfo.CreditCardType.DinersClub;
+              return card.Length == 14 && card.PassesLuhnsTest();
+            }
+
             switch (firstFour)
             {
                 case 1800:

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -105,6 +105,8 @@ namespace Recurly.Test
          InlineData(TestCreditCardNumbers.MasterCard2, true, CreditCardType.MasterCard),
          InlineData(TestCreditCardNumbers.JCB1, true, CreditCardType.JCB),
          InlineData(TestCreditCardNumbers.JCB2, true, CreditCardType.JCB),
+         InlineData(TestCreditCardNumbers.DinersClub1, true, CreditCardType.DinersClub),
+         InlineData(TestCreditCardNumbers.DinersClub2, true, CreditCardType.DinersClub),
          InlineData("not a card number", false, CreditCardType.Invalid),
          InlineData("1801 1234 1234 1234", false, CreditCardType.Invalid),
          InlineData("too short", false, CreditCardType.Invalid),
@@ -130,6 +132,8 @@ namespace Recurly.Test
          InlineData("1800 1234 1234 123", true),
          InlineData("3566 0020 2036 0505", true),
          InlineData("3530 1113 3330 0000", true),
+         InlineData("3056 930902 5904", true),
+         InlineData("3852 000002 3237", true),
          InlineData("not a card number", false)]
         public void LuhnsTest_behaves_correctly(string toTest, bool expected)
         {

--- a/Test/ExtensionTest.cs
+++ b/Test/ExtensionTest.cs
@@ -104,7 +104,8 @@ namespace Recurly.Test
 
         [Theory,
         InlineData("jcb", CreditCardType.JCB),
-        InlineData("master_card", CreditCardType.MasterCard)]
+        InlineData("master_card", CreditCardType.MasterCard),
+        InlineData("Diner's Club", CreditCardType.DinersClub)]
         public void String_ParseAsEnum_parses_CreditCardType_correctly(string toParse, CreditCardType expected)
         {
             var actual = toParse.ParseAsEnum<CreditCardType>();
@@ -156,7 +157,8 @@ namespace Recurly.Test
         InlineData("MaxedOut", "maxed_out"),
         InlineData("Active", "active"),
         InlineData("Closed, PastDue", "closed,past_due"),
-        InlineData("JCB", "jcb")]
+        InlineData("JCB", "jcb"),
+        InlineData("DinersClub", "diners_club")]
         public void EnumNameToTransportCase_should_remove_uppercase_and_add_underscores_at_words(string toConvert, string expected)
         {
             var actual = toConvert.EnumNameToTransportCase();

--- a/Test/TestCreditCardNumbers.cs
+++ b/Test/TestCreditCardNumbers.cs
@@ -20,5 +20,8 @@ namespace Recurly.Test
         public const string Visa1 = "4111111111111111";
         public const string Visa2 = "4012888888881881";
         public const string Visa3 = "4222222222222";
+
+        public const string DinersClub1 = "30569309025904";
+        public const string DinersClub2 = "38520000023237";
     }
 }


### PR DESCRIPTION
This is mainly to fix the exception that is thrown when using Diner's club:
> Requested value "Diner'sClub" was not found

The API seems to return "Diner's Club" as the card type, should really be Diners Club as in their branding.
