### PR TITLE
Add 'TaxType', 'TaxRegion', 'TaxRate' to Adjustments

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,6 +10,7 @@ Unreleased
 * added; `invoice.InvoiceNumberPrefix` and `invoice.InvoiceNumberWithPrefix()`
 * added; `transaction.GetInvoice()`
 * added; `invoice.GetOriginalInvoice()`
+* added; `TaxType`, `TaxRate`, `TaxRegion` on Adjustment
 
 1.1.9 (stable) / 2015-04-01
 ==================
@@ -39,7 +40,6 @@ Unreleased
 
  * added; entity use code on accounts
  * added; amazon and paypal billing agreement id support
-
 
 1.1.5 (stable) / 2014-07-30
 ==================

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -37,6 +37,10 @@ namespace Recurly
         public bool TaxExempt { get; set; }
         public string TaxCode { get; set; }
 
+        public string TaxType { get; private set; }
+        public decimal? TaxRate { get; private set; }
+        public string TaxRegion { get; private set; }
+
         public AdjustmentState State { get; protected set; }
 
         public DateTime StartDate { get; protected set; }
@@ -174,6 +178,18 @@ namespace Recurly
 
                     case "tax_code":
                         TaxCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "tax_type":
+                        TaxType = reader.ReadElementContentAsString();
+                        break;
+
+                    case "tax_rate":
+                        TaxRate = reader.ReadElementContentAsDecimal();
+                        break;
+
+                    case "tax_region":
+                        TaxRegion = reader.ReadElementContentAsString();
                         break;
 
                     case "start_date":


### PR DESCRIPTION
The tax information has been brought down to from the Invoice level to the Adjustment level. This unlocks those fields.

cc/ @snodgrass23 

tests:

```c#
var invoice = Invoices.Get("<invoice_with_tax_number>");
foreach (var adjustment in invoice.Adjustments)
{
  Console.WriteLine("Adjustment: " + adjustment.Uuid + 
             ", Rate: " + adjustment.TaxRate + 
             ", Region: " + adjustment.TaxRegion +
             ", Type: " + adjustment.TaxType);
}
```

- should print out the tax info for the adjustments on that invoice