### PR TITLE
Add BankAccountAuthorizedAt to Subscriptions

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* added; `BankAccountAuthorizedAt` to `Subscription`
+
 1.2.0 (stable) / 2015-04-28
 ==================
 

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -106,6 +106,10 @@ namespace Recurly
         /// Date the trial started, if the subscription has a trial.
         /// </summary>
         public DateTime? TrialPeriodStartedAt { get; private set; }
+        /// <summary>
+        /// Date the Bank Account has been authorized for this subscription
+        /// </summary>
+        public DateTime? BankAccountAuthorizedAt { get; set; }
 
         /// <summary>
         /// Date the trial ends, if the subscription has/had a trial.
@@ -462,6 +466,11 @@ namespace Recurly
                             _trialPeriodEndsAt = dateVal;
                         break;
 
+                    case "bank_account_authorized_at":
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out dateVal))
+                            BankAccountAuthorizedAt = dateVal;
+                        break;
+
                     case "subscription_add_ons":
                         // overwrite existing list with what came back from Recurly
                         AddOns = new SubscriptionAddOnList(this);
@@ -581,6 +590,9 @@ namespace Recurly
 
             if (TrialPeriodEndsAt.HasValue)
                 xmlWriter.WriteElementString("trial_ends_at", TrialPeriodEndsAt.Value.ToString("s"));
+
+            if (BankAccountAuthorizedAt.HasValue)
+                xmlWriter.WriteElementString("bank_account_authorized_at", BankAccountAuthorizedAt.Value.ToString("s"));
 
             if (StartsAt.HasValue)
                 xmlWriter.WriteElementString("starts_at", StartsAt.Value.ToString("s"));


### PR DESCRIPTION
For back dating bank account authorization when importing subscriptions, the API user can specify a `BankAccountAuthorizedAt` timestamp of when that authorization occurred.

cc/ @bhelx   

tests:

```csharp
var account = Accounts.Get("<account_code>");
var plan = Plans.Get("<plan_code>");
var sub = new Subscription(account, plan, "USD");
sub.BankAccountAuthorizedAt = DateTime.Parse("2015-02-05");
sub.Create();
sub = Subscriptions.Get(sub.Uuid);
Console.WriteLine(sub.BankAccountAuthorizedAt); //> 2/5/205 12:00:00AM
```