### PR TITLE
Adding ip_address to Transaction

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ Unreleased
 ==================
 
 * added; `BankAccountAuthorizedAt` to `Subscription`
+* added; `IpAddress` to `Transaction`
 
 1.2.0 (stable) / 2015-04-28
 ==================

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -42,6 +42,8 @@ namespace Recurly
         public bool Voidable { get; private set; }
         public bool Refundable { get; private set; }
 
+        public string IpAddress { get; private set; }
+
         public string CCVResult { get; private set; }
         public string AvsResult { get; private set; }
         public string AvsResultStreet { get; private set; }
@@ -213,11 +215,15 @@ namespace Recurly
                         break;
 
                     case "voidable":
-                        Voidable =  reader.ReadElementContentAsBoolean();
+                        Voidable = reader.ReadElementContentAsBoolean();
                         break;
 
                     case "refundable":
-                        Refundable =  reader.ReadElementContentAsBoolean();
+                        Refundable = reader.ReadElementContentAsBoolean();
+                        break;
+
+                    case "ip_address":
+                        IpAddress = reader.ReadElementContentAsString();
                         break;
 
                     case "ccv_result":

--- a/Test/Fixtures/transactions/create-422.xml
+++ b/Test/Fixtures/transactions/create-422.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
     <test type="boolean">true</test>
     <voidable type="boolean">false</voidable>
     <refundable type="boolean">false</refundable>
+    <ip_address>127.0.0.1</ip_address>
     <transaction_error>
       <error_code>invalid_card_number</error_code>
       <error_category>hard</error_category>

--- a/Test/Fixtures/transactions/refund-202.xml
+++ b/Test/Fixtures/transactions/refund-202.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">false</voidable>
   <refundable type="boolean">false</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code=""></cvv_result>
   <avs_result code=""></avs_result>
   <avs_result_street nil="nil"></avs_result_street>

--- a/Test/Fixtures/transactions/show-200-error.xml
+++ b/Test/Fixtures/transactions/show-200-error.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">true</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <transaction_error>
     <error_code>invalid_card_number</error_code>
     <error_category>hard</error_category>

--- a/Test/Fixtures/transactions/show-200.xml
+++ b/Test/Fixtures/transactions/show-200.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">true</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="M">Match</cvv_result>
   <avs_result code="D">Street address and postal code match.</avs_result>
   <avs_result_street>Y</avs_result_street>


### PR DESCRIPTION
Adding `ip_address` to transactions now that it's exposed
https://docs.recurly.com/api/transactions#create-transaction

cc: @austinheap 

`var transaction = Transaction.Get(“<uuid>”)`;
`Console.WriteLine(transaction.IpAddress);`