### PR TITLE
Add TaxRegion to Invoice

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* added; `TaxRegion` to `Invoice`
+
 1.2.1 (stable) / 2015-05-26
 ==================
 

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -45,7 +45,7 @@ namespace Recurly
         /// Tax type as "vat" for VAT or "usst" for US Sales Tax.
         /// </summary>
         public string TaxType { get; private set; }
-
+        public string TaxRegion { get; private set; }
         public decimal? TaxRate { get; private set; }
 
         public int? NetTerms { get; private set; }
@@ -278,6 +278,10 @@ namespace Recurly
 
                     case "tax_rate":
                         TaxRate = reader.ReadElementContentAsDecimal();
+                        break;
+
+                    case "tax_region":
+                        TaxRegion = reader.ReadElementContentAsString();
                         break;
 
                     case "net_terms":


### PR DESCRIPTION
fixes https://github.com/recurly/recurly-client-net/issues/50

cc/ @bhelx 

test:

```c#
var invoice = Invoices.Get(<invoiceNumber>);
Console.WriteLine(invoice.TaxRegion);
```