### PR TITLE
Do not attempt to parse an empty body response

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 Unreleased
 ==================
 
+* fixed; no content returning from the server will no longer throw "Root element is missing"
 * added; `TaxRegion` to `Invoice`
 * added; `ProductCode` to `Adjustment`
 

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -384,8 +384,11 @@ namespace Recurly
 
                     if (records >= 0)
                         readXmlListDelegate(xmlReader, records, start, next, prev);
-                    else
-                        readXmlDelegate(xmlReader);
+                    else if (response.StatusCode != HttpStatusCode.NoContent)
+                    {
+                       
+                            readXmlDelegate(xmlReader);
+                    }
                 }
             }
 #endif


### PR DESCRIPTION
fixes: https://github.com/recurly/recurly-client-net/issues/51

When a transaction is less than 3 cents, Recurly does not create a transaction since no money is transferred. Since there is no transaction, we return a 204, no content back, which breaks this SDK.

cc/ @bhelx 

test:

```
var account = Accounts.Get("pete");
var transaction = new Transaction(account, 0, "USD");
transaction.Create();
Console.WriteLine(transaction.AmountInCents); // Should be 0
```