### PR TITLE
adds bulk parameter to sub. create method

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -81,6 +81,8 @@ namespace Recurly
 
         public string Currency { get; set; }
         public int Quantity { get; set; }
+        
+        public bool? Bulk { get; set; }
 
         /// <summary>
         /// Date the subscription started.
@@ -602,6 +604,9 @@ namespace Recurly
 
             if (FirstRenewalDate.HasValue)
                 xmlWriter.WriteElementString("first_renewal_date", FirstRenewalDate.Value.ToString("s"));
+            
+            if (Bulk.HasValue)
+                xmlWriter.WriteElementString("bulk", Bulk.ToString().ToLower());
 
             if (CollectionMethod.Like("manual"))
             {

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -87,6 +87,32 @@ namespace Recurly.Test
             Assert.Equal(5, sub1.TotalBillingCycles);
 
         }
+        
+        [Fact]
+        public void CreateBulkSubscriptions()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
+            {
+                Description = "Create Bulk Subscription Test"
+            };
+            plan.UnitAmountInCents.Add("USD", 100);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            for (int i = 1; i < 4; i++)
+            {
+              var sub = new Subscription(account, plan, "USD");
+              sub.Bulk = true;
+              sub.Create();
+
+              sub.ActivatedAt.Should().HaveValue().And.NotBe(default(DateTime));
+              sub.State.Should().Be(Subscription.SubscriptionState.Active);
+ 
+            }
+
+        }
 
         [Fact]
         public void CreateSubscriptionWithCoupon()


### PR DESCRIPTION
This feature can be used like this...

			Plan plan = Plans.Get("basic");
			Account account = Accounts.Get("439683");

			for (int i = 1; i < 4; i++)
			{
				var sub = new Subscription(account, plan, "USD");
				sub.Bulk = true;
				sub.Create();
			}