### PR TITLE
adds Description parameter to Transaction constructor

### DIFF
--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -33,6 +33,7 @@ namespace Recurly
         public int AmountInCents { get; set; }
         public int TaxInCents { get; set; }
         public string Currency { get; set; }
+        public string Description { get; set; }
 
         public TransactionState Status { get; private set; }
 
@@ -200,6 +201,10 @@ namespace Recurly
                     case "currency":
                         Currency = reader.ReadElementContentAsString();
                         break;
+                        
+                    case "description":
+                        Description = reader.ReadElementContentAsString();
+                        break;
 
                     case "status":
                         var state = reader.ReadElementContentAsString();
@@ -261,6 +266,7 @@ namespace Recurly
 
             xmlWriter.WriteElementString("amount_in_cents", AmountInCents.AsString());
             xmlWriter.WriteElementString("currency", Currency);
+            xmlWriter.WriteStringIfValid("description", Description);
 
             if (Account != null)
             {

--- a/Test/TransactionTest.cs
+++ b/Test/TransactionTest.cs
@@ -23,10 +23,18 @@ namespace Recurly.Test
         {
             var account = NewAccountWithBillingInfo();
             var transaction = new Transaction(account, 5000, "USD");
+            transaction.Description = "Description";
 
             transaction.Create();
 
             transaction.CreatedAt.Should().NotBe(default(DateTime));
+            
+            var fromService = Transactions.Get(transaction.Uuid);
+            var invoice = fromService.GetInvoice();
+            var line_items = invoice.Adjustments;
+            
+            line_items[0].Description.Should().Be(transaction.Description);
+            
         }
 
         [Fact]


### PR DESCRIPTION
Adds the ability to give a transaction a 'description' when creating one via the API. This 'description' will then appear on the invoice that is generated.

### Testing

```csharp
var account = Accounts.Get("9637891");
var transaction = new Transaction(account, 5000, "USD");
transaction.Description = "Hey! Description";
transaction.Create();

var fromService = Transactions.Get(transaction.Uuid);
var invoice = fromService.GetInvoice();
var line_items = invoice.Adjustments;

Console.WriteLine("{0} ", line_items[0].Description);

```