### PR TITLE
add ability to specify the refund_apply_order in the API

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@ Unreleased
 * fixed; no content returning from the server will no longer throw "Root element is missing"
 * added; `TaxRegion` to `Invoice`
 * added; `ProductCode` to `Adjustment`
+* added; ability to specify either credit or transaction priority on refunds
 
 1.2.1 (stable) / 2015-05-26
 ==================

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -17,6 +17,12 @@ namespace Recurly
             PastDue
         }
 
+        public enum RefundOrderPriority
+        {
+            Credit,
+            Transaction
+        }
+
         public string AccountCode { get; private set; }
         public string SubscriptionUuid { get; private set; }
         public int OriginalInvoiceNumber { get; private set; }
@@ -139,17 +145,17 @@ namespace Recurly
         /// <param name="prorate"></param>
         /// <param name="quantity"></param>
         /// <returns>new Invoice object</returns>
-        public Invoice Refund(Adjustment adjustment, bool prorate = false, int quantity = 0)
+        public Invoice Refund(Adjustment adjustment, bool prorate = false, int quantity = 0, RefundOrderPriority refundPriority = RefundOrderPriority.Credit)
         {
             var adjustments = new List<Adjustment>();
             adjustments.Add(adjustment);
 
-            return Refund(adjustments, prorate, quantity);
+            return Refund(adjustments, prorate, quantity, refundPriority);
         }
 
-        public Invoice Refund(IEnumerable<Adjustment> adjustments, bool prorate = false, int quantity = 0)
+        public Invoice Refund(IEnumerable<Adjustment> adjustments, bool prorate = false, int quantity = 0, RefundOrderPriority refundPriority = RefundOrderPriority.Credit)
         {
-            var refunds = new RefundList(adjustments, prorate, quantity);
+            var refunds = new RefundList(adjustments, prorate, quantity, refundPriority);
             var invoice = new Invoice();
 
             var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
@@ -163,9 +169,10 @@ namespace Recurly
                 return null;
         }
 
-        public Invoice RefundAmount(int amountInCents) {
+        public Invoice RefundAmount(int amountInCents, RefundOrderPriority refundPriority = RefundOrderPriority.Credit)
+        {
             var refundInvoice = new Invoice();
-            var refund = new OpenAmountRefund(amountInCents);
+            var refund = new OpenAmountRefund(amountInCents, refundPriority);
                
             var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 memberUrl() + "/refund",

--- a/Library/List/RefundList.cs
+++ b/Library/List/RefundList.cs
@@ -7,8 +7,9 @@ namespace Recurly
     internal class RefundList : IEnumerable<Refund>
     {
         private List<Refund> Refunds = new List<Refund>();
-  
-        internal RefundList(IEnumerable<Adjustment> adjustments, bool prorate, int quantity = 0)
+        private Invoice.RefundOrderPriority RefundPriority;
+
+        internal RefundList(IEnumerable<Adjustment> adjustments, bool prorate, int quantity = 0, Invoice.RefundOrderPriority refundPriority = Invoice.RefundOrderPriority.Credit)
         {
             foreach (var adjustment in adjustments)
             {
@@ -19,11 +20,14 @@ namespace Recurly
                 var refund = new Refund(adjustment, prorate, count);
                 Refunds.Add(refund);
             }
+
+            RefundPriority = refundPriority;
         }
 
         internal void WriteXml(XmlTextWriter writer) 
         {
             writer.WriteStartElement("invoice");
+            writer.WriteElementString("refund_apply_order", RefundPriority.ToString().ToLower());
             writer.WriteStartElement("line_items");
 
             foreach (var refund in Refunds)

--- a/Library/OpenAmountRefund.cs
+++ b/Library/OpenAmountRefund.cs
@@ -5,10 +5,12 @@ namespace Recurly
     class OpenAmountRefund : RecurlyEntity
     {
         public int AmountInCents { get; protected set; }
+        private Invoice.RefundOrderPriority RefundPriority;
 
-        internal OpenAmountRefund(int amountInCents)
+        internal OpenAmountRefund(int amountInCents, Invoice.RefundOrderPriority refundPriority = Invoice.RefundOrderPriority.Credit)
         {
             AmountInCents = amountInCents;
+            RefundPriority = refundPriority;
         }
 
         internal override void ReadXml(XmlTextReader reader)
@@ -19,6 +21,7 @@ namespace Recurly
         internal override void WriteXml(XmlTextWriter writer)
         {
             writer.WriteStartElement("invoice");
+            writer.WriteElementString("refund_apply_order", RefundPriority.ToString().ToLower());
             writer.WriteElementString("amount_in_cents", AmountInCents.AsString());
             writer.WriteEndElement();
         }


### PR DESCRIPTION
cc/ @bhelx 

tests:

  - Create a new invoice and make sure it is paid
  - Attempt a transaction first line item refund:

```c#
var invoice = Invoices.Get("<invoice_number>");
var refInvoice =  invoice.Refund(invoice.Adjustments[0], refundPriority: Invoice.RefundOrderPriority.Transaction);
Console.WriteLine(refInvoice.InvoiceNumber);
```

  - Create another invoice and make sure it is paid
  - Attempt a transaction first open amount refund:

```c#
var invoice = Invoices.Get("<invoice_number>");
var refInvoice = invoice.RefundAmount(15, Invoice.RefundOrderPriority.Transaction);
Console.WriteLine(refInvoice.InvoiceNumber);
```