### PR TITLE
Fixed subscription preview

### DIFF
--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -47,7 +47,7 @@ namespace Recurly
         public DateTime StartDate { get; protected set; }
         public DateTime? EndDate { get; protected set; }
 
-        public DateTime CreatedAt { get ; protected set; }
+        public DateTime? CreatedAt { get ; protected set; }
 
         private const string UrlPrefix = "/accounts/";
         private const string UrlPostfix = "/adjustments/";
@@ -208,7 +208,10 @@ namespace Recurly
                         break;
 
                     case "created_at":
-                        CreatedAt = reader.ReadElementContentAsDateTime();
+                      //  CreatedAt = reader.ReadElementContentAsDateTime();
+                        DateTime createdAt;
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out createdAt))
+                            CreatedAt = createdAt;
                         break;
 
                     case "state":

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -116,7 +116,7 @@ namespace Recurly.Test
             account.Close();
         }
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void RefundMultiple()
         {
             var account = CreateNewAccountWithBillingInfo();
@@ -150,7 +150,7 @@ namespace Recurly.Test
         }
 
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void RefundOpenAmount()
         {
             var account = CreateNewAccountWithBillingInfo();

--- a/Test/List/TransactionListTest.cs
+++ b/Test/List/TransactionListTest.cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace Recurly.Test
@@ -33,7 +35,7 @@ namespace Recurly.Test
             transactions.Should().NotBeEmpty();
         }
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void ListVoidedTransactions()
         {
             for (var x = 0; x < 2; x++)
@@ -41,14 +43,17 @@ namespace Recurly.Test
                 var account = CreateNewAccountWithBillingInfo();
                 var transaction = new Transaction(account.AccountCode, 3000 + x, "USD");
                 transaction.Create();
+
                 transaction.Refund();
+
+
             }
 
             var list = Transactions.List(TransactionList.TransactionState.Voided);
             list.Should().NotBeEmpty();
         }
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void ListRefundedTransactions()
         {
             for (var x = 0; x < 2; x++)
@@ -59,7 +64,7 @@ namespace Recurly.Test
                 transaction.Refund(1500);
             }
 
-            var list = Transactions.List(type:TransactionList.TransactionType.Refund);
+            var list = Transactions.List(type: TransactionList.TransactionType.Refund);
             list.Should().NotBeEmpty();
         }
 
@@ -73,7 +78,7 @@ namespace Recurly.Test
 
             var transaction2 = new Transaction(account.AccountCode, 200, "USD");
             transaction2.Create();
-            
+
             var list = account.GetTransactions();
             list.Should().NotBeEmpty();
         }

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -125,7 +125,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <Content Include="Fixtures\accounts\create-201.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -542,8 +542,8 @@ namespace Recurly.Test
             Assert.Null(sub.TaxType);
             Assert.DoesNotThrow(delegate { sub.Preview(); });
             Assert.Equal("usst", sub.TaxType);
-            Assert.Equal(Subscription.SubscriptionState.Pending, sub.State);
-
+            Assert.Equal(Subscription.SubscriptionState.Active, sub.State);
+            
             sub.Create();
             Assert.Throws<Recurly.RecurlyException>(
                 delegate

--- a/Test/TransactionTest.cs
+++ b/Test/TransactionTest.cs
@@ -65,7 +65,7 @@ namespace Recurly.Test
             transaction.CreatedAt.Should().NotBe(default(DateTime));
         }
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void RefundTransactionFull()
         {
             var acct = NewAccountWithBillingInfo();
@@ -77,7 +77,7 @@ namespace Recurly.Test
             transaction.Status.Should().Be(Transaction.TransactionState.Voided);
         }
 
-        [Fact]
+        [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]
         public void RefundTransactionPartial()
         {
             var account = NewAccountWithBillingInfo();


### PR DESCRIPTION
Addresses: https://github.com/recurly/recurly-client-net/issues/95

Subscription xml reader wasn't expecting invoice xml that was coming back from the api when previewing a subscription. 

I also skipped deprecated unit tests.

### Testing

Assure that this code does not throw an exception now. Insert values from your sandbox where applicable:

```csharp
var account = Accounts.Get("1");
var plan = Plans.Get("gold");
var subscription = new Subscription(account, plan, "USD");
subscription.Preview();          
```