### PR TITLE
Adding setup_fee_accounting_code

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 Unreleased
 ==================
+* added; `SetupFeeAccountingCode` to `Plan`
 
 1.2.3 (stable) / 2015-08-14
 ==================

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -34,6 +34,7 @@ namespace Recurly
         public IntervalUnit TrialIntervalUnit { get; set; }
 
         public string AccountingCode { get; set; }
+        public string SetupFeeAccountingCode { get; set; }
 
         public DateTime CreatedAt { get; private set; }
 
@@ -259,6 +260,10 @@ namespace Recurly
                         AccountingCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "setup_fee_accounting_code":
+                        SetupFeeAccountingCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "created_at":
                         CreatedAt = reader.ReadElementContentAsDateTime();
                         break;
@@ -290,6 +295,7 @@ namespace Recurly
             xmlWriter.WriteElementString("name", Name);
             xmlWriter.WriteStringIfValid("description", Description);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
+            xmlWriter.WriteStringIfValid("setup_fee_accounting_code", AccountingCode);
             if (PlanIntervalLength > 0)
             {
                 xmlWriter.WriteElementString("plan_interval_unit", PlanIntervalUnit.ToString().EnumNameToTransportCase());

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Recurly .NET Client
 
-**This project is currently in Beta. The majority of the Recurly API v2 objects are supported, however there may be a few that are still in progress. Please report any questions or issues via Github.**
+**This project is currently in Beta. The majority of the Recurly API v2 objects are supported, however there may be a
+few that are still in progress. Please report any questions or issues via Github.**
 
 The Official .NET [Recurly API](https://dev.recurly.com/docs/getting-started) client library.
 
@@ -14,7 +15,9 @@ If you use [NuGet](http://www.nuget.org/), simply run the following:
 PM> Install-Package recurly-api-client
 ```
 
-You may also visit our [Releases](https://github.com/recurly/recurly-client-net/releases) page to download the latest version. Then add the `Recurly.dll` as a [reference](http://msdn.microsoft.com/en-us/library/hh708954.aspx) to your solution.
+You may also visit our [Releases](https://github.com/recurly/recurly-client-net/releases) page to
+download the latest version. Then add the `Recurly.dll` as a
+[reference](http://msdn.microsoft.com/en-us/library/hh708954.aspx) to your solution.
 
 Alternatively, you can use use [git](http://git-scm.com/) to work with the latest changes in **development**.
 
@@ -27,7 +30,8 @@ For more information about getting started with git, please check out the
 
 ## Configuration
 
-Specify your [API Key, site subdomain](https://app.recurly.com/go/developer/api_access), and (optionally) page size setting in your `app.config` or `web.config` file:
+Specify your [API Key, site subdomain](https://app.recurly.com/go/developer/api_access), and (optionally) page size
+setting in your `app.config` or `web.config` file:
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -46,7 +50,8 @@ Specify your [API Key, site subdomain](https://app.recurly.com/go/developer/api_
 
 ## Client Documentation
 
-Full C# API documentation [available here](./examples.md).
+Full C# API documentation is on our [developer docs site](https://dev.recurly.com/docs/getting-started)
+and in [examples.md](./examples.md).
 
 ### Example usage
 To create an account with `account code` and `name`:
@@ -94,20 +99,24 @@ Redeem that coupon on an account that uses US dollars, getting a `CouponRedempti
 var redemption = account.RedeemCoupon("WINTER", "USD");
 ```
 
-Each section of the API (Accounts, Invoices, Transactions, etc.) has static references for getting or listing their types and concrete implementations for manipulating concrete objects.
+Each section of the API (Accounts, Invoices, Transactions, etc.) has static references for getting or listing their
+types and concrete implementations for manipulating concrete objects.
 
 ## Recurly API Documentation
 
 Please see the [Recurly API](https://dev.recurly.com/docs/getting-started) for more information.
 
 ## Support
-Looking for help? Please contact [support@recurly.com](mailto:support@recurly.com) or visit [support.recurly.com](https://support.recurly.com).
+Looking for help? Please contact [support@recurly.com](mailto:support@recurly.com) or visit
+[support.recurly.com](https://support.recurly.com).
 
-[Stackoverflow](http://stackoverflow.com/questions/tagged/recurly) is also a great place to talk to the community and find answers to common questions.
+[Stackoverflow](http://stackoverflow.com/questions/tagged/recurly) is also a great place to talk to the community
+and find answers to common questions.
 
 ## Announcements
 
-For the latest API and client library announcements follow Recurly on [Twitter](https://twitter.com/recurly) and join our [Google Group](http://groups.google.com/group/recurly-api):
+For the latest API and client library announcements follow Recurly on [Twitter](https://twitter.com/recurly)
+and join our [Google Group](http://groups.google.com/group/recurly-api):
 
 - [@recurly](https://twitter.com/recurly)
 - [Recurly Google Group](http://groups.google.com/group/recurly-api)

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -42,6 +42,7 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
             {
                 AccountingCode = "accountingcode123",
+                SetupFeeAccountingCode = "Setup Fee AC",
                 Description = "a test plan",
                 DisplayDonationAmounts = true,
                 DisplayPhoneNumber = false,
@@ -58,6 +59,7 @@ namespace Recurly.Test
 
             plan.CreatedAt.Should().NotBe(default(DateTime));
             plan.AccountingCode.Should().Be("accountingcode123");
+            plan.SetupFeeAccountingCode.Should().Be("Setup Fee AC");
             plan.Description.Should().Be("a test plan");
             plan.DisplayDonationAmounts.Should().HaveValue().And.Be(true);
             plan.DisplayPhoneNumber.Should().HaveValue().And.Be(false);
@@ -76,7 +78,7 @@ namespace Recurly.Test
             plan.UnitAmountInCents.Add("USD", 100);
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
-            
+
             plan.UnitAmountInCents["USD"] = 5000;
             plan.SetupFeeInCents["USD"] = 100;
             plan.TaxExempt = false;
@@ -97,7 +99,7 @@ namespace Recurly.Test
             plan.UnitAmountInCents.Add("USD", 100);
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
-            
+
             plan = Plans.Get(plan.PlanCode);
             plan.CreatedAt.Should().NotBe(default(DateTime));
             plan.UnitAmountInCents.Should().Contain("USD", 100);


### PR DESCRIPTION
Exposing a `setup_fee_accounting` code to the client library since it's now available.

Also, added another link in the Readme to our docs site where folks can find examples of how to make calls with this lib and updated spacing.