### PR TITLE
Fix AddOn.GetHashCode() exception

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -111,7 +111,6 @@ namespace Recurly
 
                 switch (reader.Name)
                 {
-
                     case "add_on_code":
                         AddOnCode = reader.ReadElementContentAsString();
                         break;
@@ -139,7 +138,6 @@ namespace Recurly
                     case "tax_code":
                         TaxCode = reader.ReadElementContentAsString();
                         break;
-
                 }
             }
         }
@@ -156,7 +154,6 @@ namespace Recurly
 
             xmlWriter.WriteEndElement();
         }
-
 
         #endregion
 
@@ -177,12 +174,6 @@ namespace Recurly
         {
             return PlanCode == plan.PlanCode;
         }
-
-        public override int GetHashCode()
-        {
-            return PlanCode.GetHashCode();
-        }
-
         #endregion
     }
 }

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -295,7 +295,7 @@ namespace Recurly
             xmlWriter.WriteElementString("name", Name);
             xmlWriter.WriteStringIfValid("description", Description);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
-            xmlWriter.WriteStringIfValid("setup_fee_accounting_code", AccountingCode);
+            xmlWriter.WriteStringIfValid("setup_fee_accounting_code", SetupFeeAccountingCode);
             if (PlanIntervalLength > 0)
             {
                 xmlWriter.WriteElementString("plan_interval_unit", PlanIntervalUnit.ToString().EnumNameToTransportCase());

--- a/Test/CouponRedemptionTest.cs
+++ b/Test/CouponRedemptionTest.cs
@@ -58,14 +58,14 @@ namespace Recurly.Test
 
             redemption.Delete();
 
-            Action getCoupon = () => account.GetActiveRedemption();
-            getCoupon.ShouldThrow<NotFoundException>();
+            var activeRedemption = account.GetActiveRedemption();
+            activeRedemption.Should().Be(null);
         }
 
         [Fact]
         public void LookupCouponInvoice()
         {
-            var discounts = new Dictionary<string,int> {{"USD", 1000}};
+            var discounts = new Dictionary<string, int> { { "USD", 1000 } };
             var coupon = new Coupon(GetMockCouponCode(), GetMockCouponName(), discounts);
             coupon.Create();
 

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -42,7 +42,7 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
             {
                 AccountingCode = "accountingcode123",
-                SetupFeeAccountingCode = "Setup Fee AC",
+                SetupFeeAccountingCode = "setupfeeac",
                 Description = "a test plan",
                 DisplayDonationAmounts = true,
                 DisplayPhoneNumber = false,
@@ -59,7 +59,7 @@ namespace Recurly.Test
 
             plan.CreatedAt.Should().NotBe(default(DateTime));
             plan.AccountingCode.Should().Be("accountingcode123");
-            plan.SetupFeeAccountingCode.Should().Be("Setup Fee AC");
+            plan.SetupFeeAccountingCode.Should().Be("setupfeeac");
             plan.Description.Should().Be("a test plan");
             plan.DisplayDonationAmounts.Should().HaveValue().And.Be(true);
             plan.DisplayPhoneNumber.Should().HaveValue().And.Be(false);


### PR DESCRIPTION
Primarily fixes #75 

Also fixed the following unit tests:
 - Create plan passed invalid characters to `SetupFeeAccountingCode`
  - The Plan WriteXML also incorrectly used the value for `AccountingCode` (instead of `SetupFeeAccountingCode`) when writing `setup_fee_accounting_code`
 - GetActiveRedemption returns null instead of throwing an exception so I check for null instead