### PR TITLE
Multiple Redemption support for Invoice

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* added; multiple redemption support `GetRedemptions` for `Invoice`
+
 1.2.4 (stable) / 2015-09-15
 ==================
 

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -127,10 +127,18 @@ namespace Recurly
         /// <returns></returns>
         public CouponRedemption GetRedemption()
         {
-            var cr = new CouponRedemption();
-            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Get, memberUrl() + "/redemption", cr.ReadXml);
+            var redemptionList = GetRedemptions();
+            return redemptionList.HasAny() ? redemptionList[0] : null;
+        }
 
-            return statusCode == HttpStatusCode.NotFound ? null : cr;
+        public RecurlyList<CouponRedemption> GetRedemptions()
+        {
+            var coupons = new CouponRedemptionList();
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
+                memberUrl() + "/redemptions/",
+                coupons.ReadXmlList);
+
+            return statusCode == HttpStatusCode.NotFound ? null : coupons;
         }
 
         public Invoice GetOriginalInvoice()


### PR DESCRIPTION
Adding support for multiple redemptions endpoint on `Invoice`. `GetRedemption` should still work by taking the first redemption in the list.

Approvers: @csmb 

### Testing

```csharp
// Also try invoices without any redemptions
var invoice = Invoices.Get(1379);

// Should be same redemption
Console.WriteLine(invoice.GetRedemption());
Console.WriteLine(invoice.GetRedemptions()[0]);
```