### PR TITLE
Adding missing description readers to Coupon

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,7 @@ Unreleased
 ==================
 
 * added; multiple redemption support `GetRedemptions` for `Invoice`
+* added; description readers to `Coupon` ReadXml
 
 1.2.4 (stable) / 2015-09-15
 ==================

--- a/Library/Coupon.cs
+++ b/Library/Coupon.cs
@@ -235,6 +235,14 @@ namespace Recurly
                             MaxRedemptionsPerAccount = m;
                         break;
 
+                    case "description":
+                        HostedDescription = reader.ReadElementContentAsString();
+                        break;
+
+                    case "invoice_description":
+                        InvoiceDescription = reader.ReadElementContentAsString();
+                        break;
+
                     case "created_at":
                         if (DateTime.TryParse(reader.ReadElementContentAsString(), out date))
                             CreatedAt = date;


### PR DESCRIPTION
Looks like the description readers were missing: https://github.com/recurly/recurly-client-net/issues/48