### PR TITLE
adds ability to get invoice from subscription

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -56,6 +56,16 @@ namespace Recurly
         {
             get { return _account ?? (_account = Accounts.Get(_accountCode)); }
         }
+        
+        private string _invoiceNumber;
+        private Invoice _invoice;
+        /// <summary>
+        /// Invoice in Recurly
+        /// </summary>
+        public Invoice Invoice
+        {
+            get { return _invoice ?? (_invoice = Invoices.Get(_invoiceNumber)); }
+        }
 
         private Plan _plan;
         private string _planCode; // TODO expose publicly, avoid need to hit API for the Plan
@@ -461,6 +471,12 @@ namespace Recurly
                         href = reader.GetAttribute("href");
                         if (null != href)
                             _accountCode = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
+                        break;
+                        
+                    case "invoice":
+                        href = reader.GetAttribute("href");
+                        if (null != href)
+                            _invoiceNumber = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
                         break;
 
                     case "plan":


### PR DESCRIPTION
Currently it is only possible to get the linked Account from a Subscription object. This PR provides an .Invoice method on the Subscription object that allows you to retrieve the linked Invoice.