### PR TITLE
Referencing an `Invoice` from a `Subscription` returns the invoice

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* fixed; referencing an `Invoice` from a `Subscription` returns the invoice
+
 1.2.6 (stable) / 2015-11-04
 ==================
 

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -57,6 +57,16 @@ namespace Recurly
             get { return _account ?? (_account = Accounts.Get(_accountCode)); }
         }
 
+        private string _invoiceNumber;
+        private Invoice _invoice;
+        /// <summary>
+        /// Invoice in Recurly
+        /// </summary>
+        public Invoice Invoice
+        {
+            get { return _invoice ?? (_invoice = Invoices.Get(_invoiceNumber)); }
+        }
+
         private Plan _plan;
         private string _planCode; // TODO expose publicly, avoid need to hit API for the Plan
 
@@ -577,10 +587,8 @@ namespace Recurly
 
                     case "invoice":
                         href = reader.GetAttribute("href");
-                        //only parse the invoice xml if it's not just a link
-                        if (string.IsNullOrEmpty(href))
-                            InvoicePreview = new Invoice(reader);
-
+                        if (null != href)
+                            _invoiceNumber = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
                         break;
 
                     case "pending_subscription":


### PR DESCRIPTION
**Description**: Now, calling `subscription.Invoice` will return the invoices associated with that subscription. Finishes https://github.com/recurly/recurly-client-net/pull/115

**Testing**: See an invoice returned for a subscription. 
```
            var sub = Subscriptions.Get("35d0c3353c31fa244837c3402197a26f");
            var inv = sub.Invoice;
            Console.ReadLine();
```