### PR TITLE
Fix integration test and add open state

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+* added; `Open` state to `Subscription`
+* fixed; Subscription Pending integration test
 * fixed; referencing an `Invoice` from a `Subscription` returns the invoice
 
 1.2.6 (stable) / 2015-11-04

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -24,7 +24,8 @@ namespace Recurly
             InTrial = 16,
             Live = 32,
             PastDue = 64,
-            Pending = 128
+            Pending = 128,
+            Open    = 256
         }
 
         public enum ChangeTimeframe : short

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -542,7 +542,7 @@ namespace Recurly.Test
             Assert.Null(sub.TaxType);
             Assert.DoesNotThrow(delegate { sub.Preview(); });
             Assert.Equal("usst", sub.TaxType);
-            Assert.Equal(Subscription.SubscriptionState.Active, sub.State);
+            Assert.Equal(Subscription.SubscriptionState.Pending, sub.State);
             
             sub.Create();
             Assert.Throws<Recurly.RecurlyException>(


### PR DESCRIPTION
PreviewSubscription() integration test was failing due to not knowing about the Open state as well as thinking the subscription would be active.