### PR TITLE
Bump to 1.2.7

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,4 @@
-Unreleased
+1.2.7 (stable) / 2015-11-17
 ==================
 
 * added; `Open` state to `Subscription`

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.6.0")]
-[assembly: AssemblyFileVersion("1.2.6.0")]
+[assembly: AssemblyVersion("1.2.7.0")]
+[assembly: AssemblyFileVersion("1.2.7.0")]

--- a/Test/ExtensionTest.cs
+++ b/Test/ExtensionTest.cs
@@ -129,9 +129,9 @@ namespace Recurly.Test
         InlineData(3, TestEnum.Three),
         InlineData(200, HttpStatusCode.OK),
         InlineData(304, HttpStatusCode.NotModified)]
-        public void Int_ParseAsEnum_parses_enums_correctly(int toParse, TestEnum expected)
+        public void Int_ParseAsEnum_parses_enums_correctly<T>(int toParse, T expected)
         {
-            var actual = toParse.ParseAsEnum<TestEnum>();
+            var actual = toParse.ParseAsEnum<T>();
             actual.Should().Be(expected);
         }
 


### PR DESCRIPTION
* added; `Open` state to `Subscription` https://github.com/recurly/recurly-client-net/pull/126
* fixed; Subscription Pending integration test https://github.com/recurly/recurly-client-net/pull/126
* fixed; referencing an `Invoice` from a `Subscription` returns the invoice https://github.com/recurly/recurly-client-net/pull/123

also fixes type on extension test