### PR TITLE
Retargeting .NET v4.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,9 @@
+Unreleased
+=================
+
+* Retargeting to .NET version 4.5 for TLS headers
+* added; explicit TLS 1.2 and 1.1 settings
+
 1.2.7 (stable) / 2015-11-17
 ==================
 

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -30,6 +30,12 @@ namespace Recurly
         protected Client(Settings settings)
         {
             Settings = settings;
+           
+            // Don't include this on Travis build
+            // .NET 4.0 does not have these constants
+#if NOT_RUNNING_ON_4_0
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+#endif
         }
 
         internal static void ChangeInstance(Client client)

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Recurly</RootNamespace>
     <AssemblyName>Recurly</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -39,9 +39,12 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">RUNNING_ON_4_0</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' != 'v4.0' ">NOT_RUNNING_ON_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -51,6 +54,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Test/App.config
+++ b/Test/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <section name="recurly" type="Recurly.Configuration.Section, Recurly"/>
@@ -9,4 +9,4 @@
          subdomain="client-lib-test"
          pageSize="50" />
 
-</configuration>
+<startup><supportedRuntime version="v4.5" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Recurly.Test</RootNamespace>
     <AssemblyName>Recurly.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.2.0.0" targetFramework="net35" />
+  <package id="FluentAssertions" version="2.2.0.0" targetFramework="net35" requireReinstallation="true" />
   <package id="xunit" version="1.9.2" targetFramework="net35" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
* Retargeting .net v4.5 so we can use TLS headers.
* Adding explicit TLS 1.2 and 1.1 settings.