### PR TITLE
bump to 1.3.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,9 @@
-Unreleased
-=================
+1.3.0 (stable) / 2015-11-18
+==================
 
 * Retargeting to .NET version 4.5 for TLS headers
 * added; explicit TLS 1.2 and 1.1 settings
+* fixed; `Add(planAddOnCode, quantity)` method of `SubscriptionAddOnList`
 
 1.2.7 (stable) / 2015-11-17
 ==================

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.7.0")]
-[assembly: AssemblyFileVersion("1.2.7.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
* Retargeting to .NET version 4.5 for TLS headers [PR](https://github.com/recurly/recurly-client-net/pull/129)
* added; explicit TLS 1.2 and 1.1 settings [PR](https://github.com/recurly/recurly-client-net/pull/129)
* fixed; `Add(planAddOnCode, quantity)` method of `SubscriptionAddOnList` [PR](https://github.com/recurly/recurly-client-net/pull/128)