### PR TITLE
Set AddOn#PlanCode for GetAddOn

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -7,7 +7,7 @@ namespace Recurly
     public class AddOn : RecurlyEntity
     {
 
-        public string PlanCode { get; private set; }
+        public string PlanCode { get; set; }
         public string AddOnCode { get; set; }
         public string Name { get; set; }
 

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -146,7 +146,14 @@ namespace Recurly
                 UrlPrefix + Uri.EscapeUriString(PlanCode) + "/add_ons/" + Uri.EscapeUriString(addOnCode),
                 addOn.ReadXml);
 
-            return status == HttpStatusCode.OK ? addOn : null;
+            if (status != HttpStatusCode.OK) return null;
+
+            // PlanCode is needed to update the AddOn
+            // TODO: need a cleaner way of getting the plan code from xml
+            //       should be using the hrefs of the resources
+            addOn.PlanCode = PlanCode;
+
+            return addOn;
         }
 
         #region Read and Write XML documents


### PR DESCRIPTION
This is to address https://github.com/recurly/recurly-client-net/issues/140

This ensures that PlanCode can be publicly set and will be set when an addon is fetched so it can be updated. 

Ideally we would not expose the `PlanCode` setter here. This is something I can find a workaround for or something i can revert in the follow up PR.

We really should do a follow up where we change the Update() methods to use the resource's hrefs (which we should also be reading from xml) that way the resources don't have to track all of their parent resources and we don't need to encode routing logic into the objects. I'm going to do a follow up PR for that https://github.com/recurly/recurly-client-net/issues/142