### PR TITLE
Fix TLS preferences for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
+dist: trusty
 mono:
-  - weekly
+  - 4.0.5
 solution: Recurly.sln
-
 install:
   - nuget restore Recurly.sln
   - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - weekly
 solution: Recurly.sln
 
 install:

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -30,12 +30,7 @@ namespace Recurly
         protected Client(Settings settings)
         {
             Settings = settings;
-           
-            // Don't include this on Travis build
-            // .NET 4.0 does not have these constants
-#if NOT_RUNNING_ON_4_0
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
-#endif
         }
 
         internal static void ChangeInstance(Client client)

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -30,7 +30,12 @@ namespace Recurly
         protected Client(Settings settings)
         {
             Settings = settings;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+
+            // SecurityProtocolType values below not available in Mono < 4.3
+            const int SecurityProtocolTypeTls11 = 768;
+            const int SecurityProtocolTypeTls12 = 3072;
+
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType)(SecurityProtocolTypeTls12 | SecurityProtocolTypeTls11); 
         }
 
         internal static void ChangeInstance(Client client)

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -39,8 +39,6 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">RUNNING_ON_4_0</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFrameworkVersion)' != 'v4.0' ">NOT_RUNNING_ON_4_0</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
The release build did not contain the line of code with TLS preferences due to these constants not being present. Was discovered by a report from @rafdizzle86 and decompiling the nuget package :/

In order to test, build a release then decompile and check that this line is present: https://github.com/recurly/recurly-client-net/blob/master/Library/Client.cs#L37