### PR TITLE
Adding cc_emails attribute to Account class

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -36,6 +36,7 @@ namespace Recurly
         public bool? TaxExempt { get; set; }
         public string EntityUseCode { get; set; }
         public string AcceptLanguage { get; set; }
+        public string CcEmails { get; set; }
         public string HostedLoginToken { get; private set; }
         public DateTime CreatedAt { get; private set; }
         public bool VatLocationValid { get; private set; }
@@ -352,6 +353,10 @@ namespace Recurly
                         AcceptLanguage = reader.ReadElementContentAsString();
                         break;
 
+                    case "cc_emails":
+                        CcEmails = reader.ReadElementContentAsString();
+                        break;
+
                     case "hosted_login_token":
                         HostedLoginToken = reader.ReadElementContentAsString();
                         break;
@@ -387,6 +392,7 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("accept_language", AcceptLanguage);
             xmlWriter.WriteStringIfValid("vat_number", VatNumber);
             xmlWriter.WriteStringIfValid("entity_use_code", EntityUseCode);
+            xmlWriter.WriteStringIfValid("cc_emails", CcEmails);
 
             if (TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -28,7 +28,8 @@ namespace Recurly.Test
                 AcceptLanguage = "en",
                 VatNumber = "my-vat-number",
                 TaxExempt = true,
-                EntityUseCode = "I"
+                EntityUseCode = "I",
+                CcEmails = "cc1@test.com,cc2@test.com"
             };
 
             string address = "123 Faux Street";
@@ -42,6 +43,7 @@ namespace Recurly.Test
             acct.LastName.Should().Be("User");
             acct.CompanyName.Should().Be("Test Company");
             acct.AcceptLanguage.Should().Be("en");
+            acct.CcEmails.Should().Be("cc1@test.com,cc2@test.com");
             Assert.Equal("my-vat-number", acct.VatNumber);
             Assert.True(acct.TaxExempt.Value);
             Assert.Equal("I", acct.EntityUseCode);


### PR DESCRIPTION
Addresses https://github.com/recurly/recurly-client-net/issues/144

### Testing

Verify the attribute can be set and read from xml

```csharp
var account = new Account("myaccountcode")
{
  Email = "test@email.com",
  FirstName = "John",
  LastName = "Smith",
  CcEmails = "cc1@email.com,cc2@email.com"
};

account.Create();

var fetchedAccount = Accounts.Get("myaccountcode");

Console.WriteLine(fetchedAccount.CcEmails);
```