### PR TITLE
Update to API version 2.2

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -39,6 +39,7 @@ namespace Recurly
         public string CcEmails { get; set; }
         public string HostedLoginToken { get; private set; }
         public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
         public bool VatLocationValid { get; private set; }
 
         public Address Address {
@@ -363,6 +364,10 @@ namespace Recurly
 
                     case "created_at":
                         CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "address":

--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -6,11 +6,16 @@ namespace Recurly
 {
     public class AddOn : RecurlyEntity
     {
-
         public string PlanCode { get; set; }
         public string AddOnCode { get; set; }
         public string Name { get; set; }
-
+        public int DefaultQuantity { get; set; }
+        public bool? DisplayQuantityOnHostedPage { get; set; }
+        public string TaxCode { get; set; }
+        public bool? Optional { get; set; }
+        public string AccountingCode { get; set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         private Dictionary<string, int> _unitAmountInCents;
         /// <summary>
@@ -20,13 +25,6 @@ namespace Recurly
         {
             get { return _unitAmountInCents ?? (_unitAmountInCents = new Dictionary<string, int>()); }
         }
-
-
-        public int DefaultQuantity { get; set; }
-        public bool? DisplayQuantityOnHostedPage { get; set; }
-        public DateTime CreatedAt { get; private set; }
-        public string TaxCode { get; set; }
-
 
         private const string UrlPrefix = "/plans/";
         private const string UrlPostfix = "/add_ons/";
@@ -115,6 +113,10 @@ namespace Recurly
                         AddOnCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "accounting_code":
+                        AccountingCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "name":
                         Name = reader.ReadElementContentAsString();
                         break;
@@ -127,8 +129,16 @@ namespace Recurly
                         DefaultQuantity = reader.ReadElementContentAsInt();
                         break;
 
+                    case "optional":
+                        Optional = reader.ReadElementContentAsBoolean();
+                        break;
+
                     case "created_at":
                         CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "unit_amount_in_cents":
@@ -148,6 +158,14 @@ namespace Recurly
 
             xmlWriter.WriteElementString("add_on_code", AddOnCode);
             xmlWriter.WriteElementString("name", Name);
+            xmlWriter.WriteElementString("default_quantity", DefaultQuantity.AsString());
+            xmlWriter.WriteElementString("accounting_code", AccountingCode);
+
+            if (DisplayQuantityOnHostedPage.HasValue)
+                xmlWriter.WriteElementString("display_quantity_on_hosted_page", DisplayQuantityOnHostedPage.Value.AsString());
+
+            if (Optional.HasValue)
+                xmlWriter.WriteElementString("optional", Optional.Value.AsString());
 
             xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
                 pair => pair.Value.AsString());

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -48,6 +48,7 @@ namespace Recurly
         public DateTime? EndDate { get; protected set; }
 
         public DateTime? CreatedAt { get ; protected set; }
+        public DateTime UpdatedAt { get; private set; }
 
         private const string UrlPrefix = "/accounts/";
         private const string UrlPostfix = "/adjustments/";
@@ -211,6 +212,10 @@ namespace Recurly
                         DateTime createdAt;
                         if (DateTime.TryParse(reader.ReadElementContentAsString(), out createdAt))
                             CreatedAt = createdAt;
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "state":

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -72,7 +72,6 @@ namespace Recurly
         public string AccountNumber { get; set; }
         public BankAccountType AccountType { get; set; }
 
-
         public string Company { get; set; }
 
         /// <summary>

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -16,7 +16,7 @@ namespace Recurly.Configuration
         public int PageSize { get; private set; }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.1";
+        public const string RecurlyApiVersion = "2.2";
 
         // static, unlikely to change
         public string UserAgent

--- a/Library/Coupon.cs
+++ b/Library/Coupon.cs
@@ -79,7 +79,10 @@ namespace Recurly
         public Dictionary<string, int> DiscountInCents { get; private set; }
         public int? DiscountPercent { get; private set; }
 
-        private int? NumberOfUniqueCodes { get; set; } 
+        private int? NumberOfUniqueCodes { get; set; }
+
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         private string memberUrl()
         {
@@ -96,9 +99,6 @@ namespace Recurly
         {
             get { return _plans ?? (_plans = new List<string>()); }
         }
-
-        public DateTime CreatedAt { get; private set; }
-
 
         #region Constructors
 
@@ -308,8 +308,11 @@ namespace Recurly
                         break;
 
                     case "created_at":
-                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out date))
-                            CreatedAt = date;
+                        CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "plan_codes":

--- a/Library/CouponRedemption.cs
+++ b/Library/CouponRedemption.cs
@@ -18,6 +18,7 @@ namespace Recurly
         public int TotalDiscountedInCents { get; private set; }
 
         public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         public string State { get; private set; }
 
@@ -120,11 +121,12 @@ namespace Recurly
                         break;
 
                     case "created_at":
-                        DateTime date;
-                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out date))
-                            CreatedAt = date;
+                        CreatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
+                    case "updated_at":
+                        CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
                 }
             }
         }

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -38,6 +38,7 @@ namespace Recurly
         public int TotalInCents { get; protected set; }
         public string Currency { get; protected set; }
         public DateTime? CreatedAt { get; private set; }
+        public DateTime? UpdatedAt { get; private set; }
         public DateTime? ClosedAt { get; private set; }
 
         public Address Address
@@ -279,6 +280,10 @@ namespace Recurly
                         DateTime createdAt;
                         if (DateTime.TryParse(reader.ReadElementContentAsString(), out createdAt))
                             CreatedAt = createdAt;
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "closed_at":

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -37,6 +37,7 @@ namespace Recurly
         public string SetupFeeAccountingCode { get; set; }
 
         public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         public int? TotalBillingCycles { get; set; }
 
@@ -273,6 +274,10 @@ namespace Recurly
 
                     case "created_at":
                         CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
                         break;
 
                     case "tax_exempt":

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -97,6 +97,10 @@ namespace Recurly
         public bool? Bulk { get; set; }
 
         /// <summary>
+        /// Date the subscription was last updated.
+        /// </summary>
+        public DateTime? UpdatedAt { get; private set; }
+        /// <summary>
         /// Date the subscription started.
         /// </summary>
         public DateTime? ActivatedAt { get; private set; }
@@ -555,6 +559,11 @@ namespace Recurly
                     case "expires_at":
                         if (DateTime.TryParse(reader.ReadElementContentAsString(), out dateVal))
                             ExpiresAt = dateVal;
+                        break;
+
+                    case "updated_at":
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out dateVal))
+                            UpdatedAt = dateVal; ;
                         break;
 
                     case "current_period_started_at":

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -51,6 +51,7 @@ namespace Recurly
         public string AvsResultPostal { get; private set; }
 
         public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
 
         private Account _account;
 
@@ -252,11 +253,13 @@ namespace Recurly
                         break;
 
                     case "created_at":
-                        DateTime date;
-                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out date))
-                            CreatedAt = date;
+                        CreatedAt = reader.ReadElementContentAsDateTime();
                         break;
-                                               
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
                     case "details":
                         // API docs say not to load details into objects
                         break;


### PR DESCRIPTION
Updating to API version 2.2

I had to add support for `updated_at` in the appropriate places. I'd like to also add usage based billing but I think that might take some more time and I want to assess the demand. This is good enough to unblock us and get us to version 2.3.