### PR TITLE
WIP: Update to config with API Access

### DIFF
--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -52,6 +52,7 @@ namespace Recurly.Configuration
             get { return _instance ?? (_instance = new Settings()); }
         }
 
+
         public void InitializeFromConfig()
         {
             ApiKey = Section.Current.ApiKey;
@@ -68,13 +69,5 @@ namespace Recurly.Configuration
             PageSize = pageSize;
         }
 
-
-        //private Settings()
-        //{
-        //}
-
-        //internal Settings(string apiKey, string subdomain, string privateKey, int pageSize)
-        //{
-        //}
     }
 }

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -10,10 +10,57 @@ namespace Recurly.Configuration
     internal class Settings
     {
         // non-static, as these change per instance, likely
-        public string ApiKey { get; private set; }
-        public string PrivateKey { get; private set; }
-        public string Subdomain { get; private set; }
-        public int PageSize { get; private set; }
+        public string ApiKey
+        {
+            get
+            {
+                if (_hasLoaded == false)
+                {
+                    throw new Exception("The Recurly client has has no configuration initialized, please add your settings to web/app.config or call Recurly.Configuration.SettingsManager.Initialize(args)");
+                }
+                return _apiKey;
+            }
+            private set { _apiKey = value; }
+        }
+
+        public string PrivateKey
+        {
+            get
+            {
+                if (_hasLoaded == false)
+                {
+                    throw new Exception("The Recurly client has has no configuration initialized, please add your settings to web/app.config or call Recurly.Configuration.SettingsManager.Initialize(args)");
+                }
+                return _privateKey;
+            }
+            private set { _privateKey = value; }
+        }
+
+        public string Subdomain
+        {
+            get
+            {
+                if (_hasLoaded == false)
+                {
+                    throw new Exception("The Recurly client has has no configuration initialized, please add your settings to web/app.config or call Recurly.Configuration.SettingsManager.Initialize(args)");
+                }
+                return _subdomain;
+            }
+            private set { _subdomain = value; }
+        }
+
+        public int PageSize
+        {
+            get
+            {
+                if (_hasLoaded == false)
+                {
+                    throw new Exception("The Recurly client has has no configuration initialized, please add your settings to web/app.config or call Recurly.Configuration.SettingsManager.Initialize(args)");
+                }
+                return _pageSize;
+            }
+            private set { _pageSize = value; }
+        }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
         public const string RecurlyApiVersion = "2.2";
@@ -46,6 +93,11 @@ namespace Recurly.Configuration
         }
 
         private static Settings _instance;
+        private string _apiKey;
+        private string _privateKey;
+        private int _pageSize;
+        private bool _hasLoaded;
+        private string _subdomain;
 
         public static Settings Instance
         {
@@ -59,15 +111,31 @@ namespace Recurly.Configuration
             Subdomain = Section.Current.Subdomain;
             PrivateKey = Section.Current.PrivateKey;
             PageSize = Section.Current.PageSize;
+            _hasLoaded = true;
         }
 
-        public void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 200)
+        public void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 50)
         {
             ApiKey = apiKey;
             Subdomain = subdomain;
             PrivateKey = privateKey;
             PageSize = pageSize;
+            _hasLoaded = true;
         }
 
+        public Settings()
+        {
+            _hasLoaded = false;
+            try
+            {
+                // Will try and load the settings from the config file by default so not to break existing integrations.
+                InitializeFromConfig();
+            }
+            catch
+            {
+                // We can't find the settings, silently fail.
+                System.Diagnostics.Debug.WriteLine("Recurly is unable to load settings from web/app.config.");
+            }
+        }
     }
 }

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -52,7 +52,7 @@ namespace Recurly.Configuration
             get { return _instance ?? (_instance = new Settings()); }
         }
 
-        private Settings()
+        public void InitializeFromConfig()
         {
             ApiKey = Section.Current.ApiKey;
             Subdomain = Section.Current.Subdomain;
@@ -60,12 +60,21 @@ namespace Recurly.Configuration
             PageSize = Section.Current.PageSize;
         }
 
-        internal Settings(string apiKey, string subdomain, string privateKey, int pageSize)
+        public void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 200)
         {
             ApiKey = apiKey;
             Subdomain = subdomain;
             PrivateKey = privateKey;
             PageSize = pageSize;
         }
+
+
+        //private Settings()
+        //{
+        //}
+
+        //internal Settings(string apiKey, string subdomain, string privateKey, int pageSize)
+        //{
+        //}
     }
 }

--- a/Library/Configuration/SettingsManager.cs
+++ b/Library/Configuration/SettingsManager.cs
@@ -1,0 +1,15 @@
+﻿namespace Recurly.Configuration
+{
+    public static class SettingsManager
+    {
+        public static void InitializeFromConfig()
+        {
+            Settings.Instance.InitializeFromConfig();
+        }
+
+        public static void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 200)
+        {
+            Settings.Instance.Initialize(apiKey, subdomain, privateKey, pageSize);
+        }
+    }
+}

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Compile Include="Account.cs" />
     <Compile Include="Address.cs" />
+    <Compile Include="Configuration\SettingsManager.cs" />
     <Compile Include="OpenAmountRefund.cs" />
     <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />

--- a/Test/List/AccountListTest.cs
+++ b/Test/List/AccountListTest.cs
@@ -52,8 +52,11 @@ namespace Recurly.Test
         public void AccountList_supports_paging()
         {
             var testSettings = SettingsFixture.TestSettings;
-            var moddedSettings = new Settings(testSettings.ApiKey, testSettings.Subdomain,
+            var moddedSettings = new Settings();
+
+            moddedSettings.Initialize(testSettings.ApiKey, testSettings.Subdomain,
                 testSettings.PrivateKey, 5);
+
             Client.Instance.ApplySettings(moddedSettings);
 
             var accounts = Accounts.List();

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -94,6 +94,7 @@
     <Compile Include="List\TransactionListTest.cs" />
     <Compile Include="PlanTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SettingsManagerTest.cs" />
     <Compile Include="SubscriptionTest.cs" />
     <Compile Include="SystemTest.cs" />
     <Compile Include="TestCreditCardNumbers.cs" />

--- a/Test/SettingsFixture.cs
+++ b/Test/SettingsFixture.cs
@@ -8,8 +8,10 @@ namespace Recurly.Test
         {
             get
             {
-                return new Settings("8f1359864cfa4f378542d639e655229c", "client-lib-test",
+                var returnSettings = new Settings();
+                returnSettings.Initialize("8f1359864cfa4f378542d639e655229c", "client-lib-test",
                     "382c053318a04154905c4d27a48f74a6", 50);
+                return returnSettings;
             }
         }
     }

--- a/Test/SettingsManagerTest.cs
+++ b/Test/SettingsManagerTest.cs
@@ -1,0 +1,19 @@
+using Recurly.Configuration;
+using Xunit;
+
+namespace Recurly.Test
+{
+    public class SettingsManagerTest
+    {
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void SetApidKey()
+        {
+            SettingsManager.Initialize("api", "subdomain", "private", 100);
+
+            Assert.True("api" == Settings.Instance.ApiKey);
+            Assert.True("subdomain" == Settings.Instance.Subdomain);
+            Assert.True("private" == Settings.Instance.PrivateKey);
+            Assert.True(100 == Settings.Instance.PageSize);
+        }
+    }
+}


### PR DESCRIPTION
I have updated the settings component so it now does not load the settings by default, and allows you to specify how you load the config. I am looking for feedback if this is the direction being thought of and how it could be adjusted to fit more inline with your library.

The use case would now be inline with other libraries work where you either tell it to load from config, or inject the settings via parameters..

Usage would be to call one of the following when the app starts up.

```c#
Recurly.Configuration.SettingsManager.Initialize("api", "subdomain", "private", 100);

-or-

Recurly.Configuration.SettingsManager.InitializeFromConfig()
```

This would be a breaking change as it doesn't load from the config file by default in the current state, it may be preferred to try and load that so this is not breaking.
