### PR TITLE
Add error case for 400 status code

### DIFF
--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -203,6 +203,7 @@ namespace Recurly
                         errors = Error.ReadResponseAndParseErrors(response);
                         throw new InvalidCredentialsException(errors);
 
+                    case HttpStatusCode.BadRequest:
                     case HttpStatusCode.PreconditionFailed:
                         errors = Error.ReadResponseAndParseErrors(response);
                         throw new ValidationException(errors);

--- a/Library/Error.cs
+++ b/Library/Error.cs
@@ -93,7 +93,7 @@ namespace Recurly
 
             using (var responseStream = response.GetResponseStream())
             {
-                var errors = new List<Error>();
+                var errors = new List<Error>();              
 
                 try
                 {


### PR DESCRIPTION
I found this missing case for HTTP status code 400. It's possible this is being misapplied on the server but we should handle it nonetheless.