### PR TITLE
Bump 1.4.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,22 @@
 Unreleased
 ===============
 
-* added; `Currency` attribute on `BillingInfo`
-* added; `PaymentMethod` attribute on `Transaction`
+1.4.0 (stable) / 2016-09-19
+==================
 
+This release brings us to API version 2.3
+
+* added; `PlanCode` public reader on Subscription
+* fixed; bug with updating an AddOn
+* fixed; TLS preferences missing constants
+* added; `cc_emails` to `Account`
+* fixed; `Adjustment#Get` and related tests
+* added; `Currency` attribute on `BillingInfo`
+* added; Changes for API v2.2
+* added; `PaymentMethod` attribute on `Transaction`
+* added; new optional config loading with `SettingsManager`
+* added; error case for http status code 400
+* added; Usage based billing support
 
 1.3.1 (stable) / 2015-11-19
 ==================

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]


### PR DESCRIPTION
This brings us up to API v2.3

* Exposed subscription 'PlanCode' publicly #139
* Set AddOn#PlanCode for GetAddOn #141 
* Fix TLS preferences for releases #143 
* Adding cc_emails attribute to Account class #147 
* Fixed Get Adjustment and related test #150 
* Add Currency attribute to BillingInfo #151 
* Update to API version 2.2 #154 
* Adding `PaymentMethod` attribute on `Transaction` #159 
* Update to config with API Access #162 
* Add error case for 400 status code #164 
* Usage Based Billing Support #165 
