### PR TITLE
Allow null UsageTimestamp (defaults to server time)

### DIFF
--- a/Library/Usage.cs
+++ b/Library/Usage.cs
@@ -22,7 +22,7 @@ namespace Recurly
         public int Amount{ get; set; }
         public String MerchantTag { get; set; }
         public Type UsageType { get; set; }
-        public DateTime UsageTimestamp { get; set; }
+        public DateTime? UsageTimestamp { get; set; }
         public DateTime? RecordingTimestamp { get; set; }
         public DateTime? BilledAt { get; set; }
         public DateTime? CreatedAt { get; private set; }
@@ -161,7 +161,8 @@ namespace Recurly
             if (RecordingTimestamp.HasValue)
                 xmlWriter.WriteElementString("recording_timestamp", RecordingTimestamp.Value.ToString("s"));
 
-            xmlWriter.WriteElementString("usage_timestamp", UsageTimestamp.ToString("s"));
+            if (UsageTimestamp.HasValue)
+                xmlWriter.WriteElementString("usage_timestamp", UsageTimestamp.Value.ToString("s"));
 
             if (BilledAt.HasValue)
                 xmlWriter.WriteElementString("billed_at", BilledAt.Value.ToString("s"));


### PR DESCRIPTION
Addresses issue #170

## Usage

```csharp
// UsageTimestamp can be null now
var usage = new Usage(subscription.Uuid, addon.AddOnCode)
{
  Amount = 100,
  MerchantTag = "100 Marketing emails sent by the customer",
  //RecordingTimestamp = DateTime.Now,
  //UsageTimestamp = DateTime.Now,
};

usage.Create();

Console.WriteLine(usage);
Console.WriteLine(usage.UsageTimestamp);
```