### PR TITLE
Bump 1.4.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,12 @@
 Unreleased
 ===============
 
+1.4.2 (stable) / 2016-10-03
+==================
+
+* added; Allow `UsageTimestamp` to be null (defaults to server time)
+
+
 1.4.1 (stable) / 2016-09-21
 ==================
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.1.0")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
+[assembly: AssemblyVersion("1.4.2.0")]
+[assembly: AssemblyFileVersion("1.4.2.0")]


### PR DESCRIPTION

* New server feature: Allow `UsageTimestamp` to be null (and default to the server time) https://github.com/recurly/recurly-client-net/issues/170