### PR TITLE
Allow null NetTerms

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,8 @@
 Unreleased
 ===============
 
+* fixed; NetTerms null exception for manual subscriptions
+
 1.4.2 (stable) / 2016-10-03
 ==================
 

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -751,8 +751,10 @@ namespace Recurly
             if (CollectionMethod.Like("manual"))
             {
                 xmlWriter.WriteElementString("collection_method", "manual");
-                xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
                 xmlWriter.WriteElementString("po_number", PoNumber);
+
+                if (NetTerms.HasValue)
+                    xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
             }
             else if (CollectionMethod.Like("automatic"))
                 xmlWriter.WriteElementString("collection_method", "automatic");


### PR DESCRIPTION
Addresses issue #155 

```csharp
// some account with billing info
var account = Accounts.Get("e0004e3c-216c-4254-8767-9be605cd0b03");
// any plan
var plan = Plans.Get("bukbu0i2b2");
// make a sub and set collection method to manual
var subscription = new Subscription(account, plan, "USD"); // account, plan, currency
subscription.CollectionMethod = "manual";

// it used to blow up here because NetTerms was not set
subscription.Create();

Console.WriteLine(subscription.Uuid);
Console.WriteLine(subscription.NetTerms);
```