### PR TITLE
allow addresses to be null, and don't force-create one when fetching …

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 Unreleased
 ===============
+* fixed; Account no longer lazy-creates its own Address object
 
 1.4.3 (stable) / 2016-10-21
 ===============

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -42,12 +42,7 @@ namespace Recurly
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
         public bool VatLocationValid { get; private set; }
-
-        public Address Address {
-			get { return _address; }
-            set { _address = value; }
-        }
-        private Address _address;
+        public Address Address { get; set; }
 
         private BillingInfo _billingInfo;
 
@@ -241,7 +236,7 @@ namespace Recurly
         public RecurlyList<Subscription> GetSubscriptions(Subscription.SubscriptionState state = Subscription.SubscriptionState.All)
         {
             return new SubscriptionList(UrlPrefix + Uri.EscapeUriString(AccountCode) + "/subscriptions/"
-                + Build.QueryStringWith(state.Equals(Subscription.SubscriptionState.All) ? "" :  "state=" + state.ToString().EnumNameToTransportCase()));
+                + Build.QueryStringWith(state.Equals(Subscription.SubscriptionState.All) ? "" : "state=" + state.ToString().EnumNameToTransportCase()));
         }
 
         /// <summary>
@@ -273,7 +268,7 @@ namespace Recurly
         /// <param name="accountingCode">Accounting code. Max of 20 characters.</param>
         /// <param name="taxExempt"></param>
         /// <returns></returns>
-        public Adjustment NewAdjustment(string currency, int unitAmountInCents, string description="", int quantity=1, string accountingCode="", bool taxExempt = false)
+        public Adjustment NewAdjustment(string currency, int unitAmountInCents, string description = "", int quantity = 1, string accountingCode = "", bool taxExempt = false)
         {
             // TODO All of the properties should be settable
             return new Adjustment(AccountCode, description, currency, unitAmountInCents, quantity, accountingCode, taxExempt);
@@ -285,7 +280,7 @@ namespace Recurly
         /// <param name="couponCode"></param>
         /// <param name="currency"></param>
         /// <returns></returns>
-        public CouponRedemption RedeemCoupon(string couponCode, string currency, string subscriptionUuid=null)
+        public CouponRedemption RedeemCoupon(string couponCode, string currency, string subscriptionUuid = null)
         {
             return CouponRedemption.Redeem(AccountCode, couponCode, currency, subscriptionUuid);
         }
@@ -315,7 +310,7 @@ namespace Recurly
 
             if (activeRedemptions == null || activeRedemptions.Count <= 0)
             {
-              return null;
+                return null;
             }
 
             return activeRedemptions.ToArray()[0];

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -44,7 +44,7 @@ namespace Recurly
         public bool VatLocationValid { get; private set; }
 
         public Address Address {
-            get { return _address ?? (_address = new Address()); }
+			get { return _address; }
             set { _address = value; }
         }
         private Address _address;

--- a/Library/Address.cs
+++ b/Library/Address.cs
@@ -17,7 +17,7 @@ namespace Recurly
             ReadXml(reader);
         }
 
-        internal Address() { }
+        public Address() { }
 
         internal override void ReadXml(XmlTextReader reader)
         {

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -18,19 +18,19 @@ namespace Recurly.Test
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void CreateAccountWithParameters()
         {
-			var acct = new Account(GetUniqueAccountCode())
-			{
-				Username = "testuser1",
-				Email = "testemail@test.com",
-				FirstName = "Test",
-				LastName = "User",
-				CompanyName = "Test Company",
-				AcceptLanguage = "en",
-				VatNumber = "my-vat-number",
-				TaxExempt = true,
-				EntityUseCode = "I",
-				CcEmails = "cc1@test.com,cc2@test.com",
-				Address = new Address()
+            var acct = new Account(GetUniqueAccountCode())
+            {
+                Username = "testuser1",
+                Email = "testemail@test.com",
+                FirstName = "Test",
+                LastName = "User",
+                CompanyName = "Test Company",
+                AcceptLanguage = "en",
+                VatNumber = "my-vat-number",
+                TaxExempt = true,
+                EntityUseCode = "I",
+                CcEmails = "cc1@test.com,cc2@test.com",
+                Address = new Address()
             };
 
             string address = "123 Faux Street";
@@ -53,11 +53,10 @@ namespace Recurly.Test
         }
 
         [Fact]
-        public void DontSerializeNullAddress() 
+        public void DontSerializeNullAddress()
         {
             var account = new Account("testAcct");
             account.Address.Should().BeNull();
-            
         }
 
         [Fact]

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -18,18 +18,19 @@ namespace Recurly.Test
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void CreateAccountWithParameters()
         {
-            var acct = new Account(GetUniqueAccountCode())
-            {
-                Username = "testuser1",
-                Email = "testemail@test.com",
-                FirstName = "Test",
-                LastName = "User",
-                CompanyName = "Test Company",
-                AcceptLanguage = "en",
-                VatNumber = "my-vat-number",
-                TaxExempt = true,
-                EntityUseCode = "I",
-                CcEmails = "cc1@test.com,cc2@test.com"
+			var acct = new Account(GetUniqueAccountCode())
+			{
+				Username = "testuser1",
+				Email = "testemail@test.com",
+				FirstName = "Test",
+				LastName = "User",
+				CompanyName = "Test Company",
+				AcceptLanguage = "en",
+				VatNumber = "my-vat-number",
+				TaxExempt = true,
+				EntityUseCode = "I",
+				CcEmails = "cc1@test.com,cc2@test.com",
+				Address = new Address()
             };
 
             string address = "123 Faux Street";
@@ -49,6 +50,14 @@ namespace Recurly.Test
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
             Assert.False(acct.VatLocationValid);
+        }
+
+        [Fact]
+        public void DontSerializeNullAddress() 
+        {
+            var account = new Account("testAcct");
+            account.Address.Should().BeNull();
+            
         }
 
         [Fact]


### PR DESCRIPTION
Resolves #179 

Allow addresses to be null, and don't force-create one when fetching it from the account