### PR TITLE
Make po_number always available to write on Subscription

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -740,6 +740,7 @@ namespace Recurly
             xmlWriter.WriteElementString("customer_notes", CustomerNotes);
             xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
             xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
+            xmlWriter.WriteElementString("po_number", PoNumber);
 
             if (UnitAmountInCents.HasValue)
                 xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.Value.AsString());
@@ -767,7 +768,6 @@ namespace Recurly
             if (CollectionMethod.Like("manual"))
             {
                 xmlWriter.WriteElementString("collection_method", "manual");
-                xmlWriter.WriteElementString("po_number", PoNumber);
 
                 if (NetTerms.HasValue)
                     xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());


### PR DESCRIPTION
Create a non manual Subscription and set PoNumber, it should come back:

```csharp
var account = Accounts.Get("5fe32e112b724061bbe210200c86c97b");
var plan = Plans.Get("gold1");
var subscription = new Subscription(account, plan, "USD"); // account, plan, currency
                
// don't set to manual
//subscription.CollectionMethod = "manual";
subscription.PoNumber = "12397129837";

subscription.Create();

Console.WriteLine(subscription.PoNumber); // 12397129837
```