### PR TITLE
Fix null Datetime Xml reading for Adjustment StartDate and UpdatedAt

### DIFF
--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -199,7 +199,9 @@ namespace Recurly
                         break;
 
                     case "start_date":
-                        StartDate = reader.ReadElementContentAsDateTime();
+                        DateTime startDate;
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out startDate))
+                            StartDate = startDate;                        
                         break;
 
                     case "end_date":
@@ -215,7 +217,9 @@ namespace Recurly
                         break;
 
                     case "updated_at":
-                        UpdatedAt = reader.ReadElementContentAsDateTime();
+                        DateTime updatedAt;
+                        if(DateTime.TryParse(reader.ReadElementContentAsString(), out updatedAt))
+                            UpdatedAt = updatedAt;
                         break;
 
                     case "state":


### PR DESCRIPTION
When calling subscription.Preview() I got the below exception due to an empty date field on Adjustment (called by Invoice Preview). The reason is that StartDate and UpdatedAt are trying to read directly as DateTime without checking if it is possible, like EndDate and CreatedAt does already. Just updated StartDate and UpdatedAt to the same pattern.

'subscription.Preview()' threw an exception of type 'System.FormatException'
    Data: {System.Collections.ListDictionaryInternal}
    HResult: -2146233033
    HelpLink: null
    InnerException: null
    Message: "The string '' is not a valid AllXsd value."
    Source: "System.Xml"
    StackTrace: "   at System.Xml.Schema.XsdDateTime..ctor(String text, XsdDateTimeFlags kinds)\r\n   at System.Xml.XmlConvert.ToDateTime(String s, XmlDateTimeSerializationMode dateTimeOption)\r\n   at System.Xml.XmlReader.ReadElementContentAsDateTime()\r\n   at Recurly.Adjustment.ReadXml(XmlTextReader reader) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Adjustment.cs:line 218\r\n   at Recurly.AdjustmentList.ReadXml(XmlTextReader reader) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\List\\AdjustmentList.cs:line 39\r\n   at Recurly.Invoice.ReadXml(XmlTextReader reader) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Invoice.cs:line 350\r\n   at Recurly.Subscription.ReadXml(XmlTextReader reader) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Subscription.cs:line 621\r\n   at Recurly.Client.ReadWebResponse(HttpWebResponse response, ReadXmlDelegate readXmlDelegate, ReadXmlListDelegate r
eadXmlListDelegate, ReadResponseDelegate responseDelegate) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Client.cs:line 382\r\n   at Recurly.Client.PerformRequest(HttpRequestMethod method, String urlPath, WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate, ReadXmlListDelegate readXmlListDelegate, ReadResponseDelegate reseponseDelegate) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Client.cs:line 170\r\n   at Recurly.Subscription.Preview(ChangeTimeframe timeframe) in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Subscription.cs:line 407\r\n   at Recurly.Subscription.Preview() in C:\\Users\\ben\\Documents\\GitHubVisualStudio\\recurly-client-net\\Library\\Subscription.cs:line 418"
    TargetSite: {Void .ctor(System.String, System.Xml.Schema.XsdDateTimeFlags)}
