### PR TITLE
Add missing enum values

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -15,7 +15,12 @@ namespace Recurly
             MasterCard,
             AmericanExpress,
             Discover,
-            JCB
+            JCB,
+            Danokrt,
+            Maestro,
+            Forbrugsforeningen,
+            Laser,
+            Unknown
         }
 
         public enum BankAccountType : short

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -15,7 +15,8 @@ namespace Recurly
             Collected,
             Failed,
             PastDue,
-            Processing
+            Processing,
+            Pending
         }
 
         public enum RefundOrderPriority

--- a/Library/List/TransactionList.cs
+++ b/Library/List/TransactionList.cs
@@ -10,7 +10,8 @@ namespace Recurly
             All = 0,
             Successful,
             Failed,
-            Voided
+            Voided,
+            Chargeback
         }
 
         public enum TransactionType : short

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -16,7 +16,11 @@ namespace Recurly
             Failed,
             Voided,
             Declined,
-            Scheduled
+            Scheduled,
+            Pending,
+            Processing,
+            Error,
+            Chargeback
         }
 
         public enum TransactionType : short
@@ -26,7 +30,8 @@ namespace Recurly
             Authorization,
             Purchase,
             Refund,
-            Verify
+            Verify,
+            Capture
         }
 
         public string Uuid { get; private set; }


### PR DESCRIPTION
Related to #211

I've gone through and checked all the enums to make sure they are up to date with what is on the server models. Hopefully this fixes these errors for a while. Any new enum values will be on a future API version release and old versions of the client should be protected from them.