### PR TITLE
Remove trial_requires_billing_info, it's actually in 2.6

### DIFF
--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -45,8 +45,6 @@ namespace Recurly
 
         public string TaxCode { get; set; }
 
-        public bool TrialRequiresBillingInfo { get; set; }
-
         private AddOnList _addOns;
 
         public RecurlyList<AddOn> AddOns
@@ -303,12 +301,6 @@ namespace Recurly
                         if (int.TryParse(reader.ReadElementContentAsString(), out totalBillingCycles))
                             TotalBillingCycles = totalBillingCycles;
                         break;
-
-                    case "trial_requires_billing_info":
-                        bool a;
-                        if (bool.TryParse(reader.ReadElementContentAsString(), out a))
-                            TrialRequiresBillingInfo = a;
-                        break;
                 }
             }
         }
@@ -356,8 +348,6 @@ namespace Recurly
 
             if(TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());
-
-            xmlWriter.WriteElementString("trial_requires_billing_info", TrialRequiresBillingInfo.AsString());
 
             xmlWriter.WriteStringIfValid("success_url", SuccessUrl);
             xmlWriter.WriteStringIfValid("cancel_url", CancelUrl);


### PR DESCRIPTION
Resolves #226 

The presence of this field was causing problems when creating plans. To verify it's fixed, just create a Plan:

```csharp
 class Program
    {
        static void Main(string[] args)
        {
            try
            {
                var recurlyPlan = new Plan("newcode", "newname");
                recurlyPlan.UnitAmountInCents.Add("USD", 10000);
                recurlyPlan.Create();
            } catch (ValidationException ex)
            {
                foreach(Error err in ex.Errors)
                {
                    Console.WriteLine(err.ToString());
                }
            }

#if DEBUG
            Console.WriteLine("Press enter to close...");
            Console.ReadLine();
#endif

        }
    }
```