### PR TITLE
Bump 1.4.13

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Unreleased
 ===============
 
+1.4.13 (stable) / 2017-05-04
+===============
+
+* Removing `trial_requires_billing_info` from Plan (which is in api 2.6)
+
 1.4.12 (stable) / 2017-04-06
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.12.0")]
-[assembly: AssemblyFileVersion("1.4.12.0")]
+[assembly: AssemblyVersion("1.4.13.0")]
+[assembly: AssemblyFileVersion("1.4.13.0")]


### PR DESCRIPTION
Only contains 1 bug fix

* Removing `trial_requires_billing_info` from Plan (which is in api 2.6) #227 [issue #226]