### PR TITLE
Fixing NullReferenceException in List() functions

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -558,7 +558,7 @@ namespace Recurly
         /// <returns></returns>
         public static RecurlyList<Account> List(Account.AccountState state, FilterCriteria filter)
         {
-            filter = filter.Equals(null) ? FilterCriteria.Instance : filter;
+            filter = filter ?? FilterCriteria.Instance;
             var parameters = filter.ToNamedValueCollection();
             parameters["state"] = state.ToString().EnumNameToTransportCase();
             return new AccountList(Account.UrlPrefix + "?" + parameters.ToString());

--- a/Library/Coupon.cs
+++ b/Library/Coupon.cs
@@ -559,7 +559,7 @@ namespace Recurly
         /// <returns></returns>
         public static RecurlyList<Coupon> List(Coupon.CouponState state, FilterCriteria filter)
         {
-            filter = filter.Equals(null) ? FilterCriteria.Instance : filter;
+            filter = filter ?? FilterCriteria.Instance;
             var parameters = filter.ToNamedValueCollection();
             if (state != Coupon.CouponState.All)
             {

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -62,7 +62,6 @@ namespace Recurly
         private string _invoiceNumber;
         private Invoice _invoice;
         /// <summary>
-        /// Invoice in Recurly
         /// </summary>
         public Invoice Invoice
         {
@@ -915,7 +914,7 @@ namespace Recurly
         /// <returns></returns>
         public static RecurlyList<Subscription> List(Subscription.SubscriptionState state, FilterCriteria filter)
         {
-            filter = filter.Equals(null) ? FilterCriteria.Instance : filter;
+            filter = filter ?? FilterCriteria.Instance;
             var parameters = filter.ToNamedValueCollection();
             parameters["state"] = state.ToString().EnumNameToTransportCase();
             return new SubscriptionList(Subscription.UrlPrefix + "?" + parameters.ToString());

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -380,7 +380,7 @@ namespace Recurly
             TransactionList.TransactionType type,
             FilterCriteria filter)
         {
-            filter = filter.Equals(null) ? FilterCriteria.Instance : filter;
+            filter = filter ?? FilterCriteria.Instance;
             var parameters = filter.ToNamedValueCollection();
             if (state != TransactionList.TransactionState.All)
             {

--- a/Library/Usage.cs
+++ b/Library/Usage.cs
@@ -196,7 +196,7 @@ namespace Recurly
         /// <returns></returns>
         public static RecurlyList<Usage> List(String subscriptionUuid, String subscriptionAddOnCode, FilterCriteria filter)
         {
-            filter = filter.Equals(null) ? FilterCriteria.Instance : filter;
+            filter = filter ?? FilterCriteria.Instance;
             return new UsageList(UrlPrefix(subscriptionUuid, subscriptionAddOnCode) + "?" + filter.ToNamedValueCollection().ToString());
         }
     }

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -12,6 +12,8 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
             plan.UnitAmountInCents.Add("USD", 100);
             plan.TaxExempt = true;
+            plan.TotalBillingCycles = 6;
+
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
 


### PR DESCRIPTION
Replaces the filter override code in List() functions with a similar code construct that avoids the NullReferenceException caused by calling filter.Equals(null). This error might be specific to newer .NET framework versions but it hobbles much of the functionality in the current packaged release.