### PR TITLE
Bump 1.5.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,14 @@
 Unreleased
 ===============
 
+1.5.0 (stable) / 2017-06-02
+===============
+
+* Added account balance endpoint
+* Added plan and subscription changes
+* Fixing NullReferenceException in List() functions
+* Fixed a probable NRE in Plans.List()
+
 1.4.13 (stable) / 2017-05-04
 ===============
 

--- a/History.md
+++ b/History.md
@@ -1,13 +1,24 @@
 Unreleased
 ===============
 
-1.5.0 (stable) / 2017-06-02
+1.5.0 (stable) / 2017-06-07
 ===============
 
 * Added account balance endpoint
 * Added plan and subscription changes
 * Fixing NullReferenceException in List() functions
 * Fixed a probable NRE in Plans.List()
+* Remove X-Records Header and RecurlyList #Capacity method
+
+### Upgrade Notes
+
+This release will upgrade us to API version 2.6. There are two breaking changes:
+
+1. To speed up your listing requests we’re no longer automatically computing the record counts for each requests. For our larger sites this could halve the response time. So in this release, we are removing the `RecurlyList#Capacity` method.
+to be cached for you. For more info see [PR #324](https://github.com/recurly/recurly-client-ruby/pull/324).
+2. For `POST /v2/subscriptions` Sending `null` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.
+Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.
+
 
 1.4.13 (stable) / 2017-05-04
 ===============

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -82,7 +82,7 @@ namespace Recurly
         /// </summary>
         /// <param name="xmlReader"></param>
         /// <param name="records"></param>
-        public delegate void ReadXmlListDelegate(XmlTextReader xmlReader, int records, string start, string next, string prev);
+        public delegate void ReadXmlListDelegate(XmlTextReader xmlReader, string start, string next, string prev);
 
         /// <summary>
         /// Delegate to write the XML request to the server.
@@ -353,16 +353,10 @@ namespace Recurly
             using (var xmlReader = new XmlTextReader(responseStream))
             {
                 // Check for pagination
-                var records = -1;
                 var cursor = string.Empty;
                 string start = null;
                 string next = null;
                 string prev = null;
-
-                if (null != response.Headers["X-Records"])
-                {
-                    Int32.TryParse(response.Headers["X-Records"], out records);
-                }
 
                 var link = response.Headers["Link"];
 
@@ -371,16 +365,12 @@ namespace Recurly
                     start = link.GetUrlFromLinkHeader("start");
                     next = link.GetUrlFromLinkHeader("next");
                     prev = link.GetUrlFromLinkHeader("prev");
-                }
-
-                if (records >= 0) {
-                    readXmlListDelegate(xmlReader, records, start, next, prev);
+                    readXmlListDelegate(xmlReader, start, next, prev);
                 }
                 else if (response.StatusCode != HttpStatusCode.NoContent)
                 {
                     readXmlDelegate(xmlReader);
                 }
-                    
             }
 
         }

--- a/Library/List/RecurlyList.cs
+++ b/Library/List/RecurlyList.cs
@@ -26,12 +26,6 @@ namespace Recurly
             }
         }
 
-        private int _capacity = -1;
-        public int Capacity
-        {
-            get { return _capacity < 0 ? Count : _capacity; }
-        }
-
         public abstract RecurlyList<T> Start { get; }
         public abstract RecurlyList<T> Next { get; }
         public abstract RecurlyList<T> Prev { get; }
@@ -98,10 +92,9 @@ namespace Recurly
             return baseUrl + divider + "per_page=" + PerPage;
         }
 
-        internal void ReadXmlList(XmlTextReader xmlReader, int records, string start, string next, string prev)
+        internal void ReadXmlList(XmlTextReader xmlReader, string start, string next, string prev)
         {
-            Items = records > 0 ? new List<T>(records) : new List<T>();
-            _capacity = records;
+            Items = new List<T>();
             StartUrl = start;
             NextUrl = next;
             PrevUrl = prev;

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.13.0")]
-[assembly: AssemblyFileVersion("1.4.13.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -207,7 +207,6 @@ namespace Recurly.Test
             invoice.State.Should().Be(Invoice.InvoiceState.Collected);
 
             Assert.Equal(1, invoice.Adjustments.Count);
-            Assert.Equal(1, invoice.Adjustments.Capacity);
 
             // refund
             var refundInvoice = invoice.Refund(adjustment, false);
@@ -269,7 +268,6 @@ namespace Recurly.Test
             invoice.State.Should().Be(Invoice.InvoiceState.Collected);
 
             Assert.Equal(1, invoice.Adjustments.Count);
-            Assert.Equal(1, invoice.Adjustments.Capacity);
 
             // refund
             var refundInvoice = invoice.RefundAmount(100); // 1 dollar

--- a/Test/List/AccountListTest.cs
+++ b/Test/List/AccountListTest.cs
@@ -61,7 +61,6 @@ namespace Recurly.Test
 
             var accounts = Accounts.List();
             accounts.Should().HaveCount(5);
-            accounts.Capacity.Should().BeGreaterOrEqualTo(5);
 
             accounts.Next.Should().NotBeEmpty();
         }

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -556,8 +556,7 @@ namespace Recurly.Test
                 var list = new System.Collections.Generic.List<SubscriptionAddOn>();
                 list.Add(subaddon);
                 sub.AddOns.AddRange(list);
-                Assert.Equal(1, sub.AddOns.Capacity);
-
+                Assert.Equal(1, sub.AddOns.Count);
 
                 sub.AddOns.AsReadOnly();
 


### PR DESCRIPTION
Going to hold off on this release until I can figure out how to make make this work with removal of `X-Records`

* Added account balance endpoint  #234 (issue #233)
* Added plan and subscription changes  #232
* Fixing NullReferenceException in List() functions  #231
* Fixed a probable NRE in Plans.List() #230
* Remove X-Records header #236 

### Upgrade Notes

This release will upgrade us to API version 2.6. There are two breaking changes:

1. To speed up your listing requests we’re no longer automatically computing the record counts for each requests. For our larger sites this could halve the response time. So in this release, we are removing the `RecurlyList#Capacity` method.
to be cached for you. For more info see [PR #324](https://github.com/recurly/recurly-client-ruby/pull/324).
2. For `POST /v2/subscriptions` Sending `null` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.
Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.
