### PR TITLE
Remove x records header

### DIFF
--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -82,7 +82,7 @@ namespace Recurly
         /// </summary>
         /// <param name="xmlReader"></param>
         /// <param name="records"></param>
-        public delegate void ReadXmlListDelegate(XmlTextReader xmlReader, int records, string start, string next, string prev);
+        public delegate void ReadXmlListDelegate(XmlTextReader xmlReader, string start, string next, string prev);
 
         /// <summary>
         /// Delegate to write the XML request to the server.
@@ -353,16 +353,10 @@ namespace Recurly
             using (var xmlReader = new XmlTextReader(responseStream))
             {
                 // Check for pagination
-                var records = -1;
                 var cursor = string.Empty;
                 string start = null;
                 string next = null;
                 string prev = null;
-
-                if (null != response.Headers["X-Records"])
-                {
-                    Int32.TryParse(response.Headers["X-Records"], out records);
-                }
 
                 var link = response.Headers["Link"];
 
@@ -371,16 +365,12 @@ namespace Recurly
                     start = link.GetUrlFromLinkHeader("start");
                     next = link.GetUrlFromLinkHeader("next");
                     prev = link.GetUrlFromLinkHeader("prev");
-                }
-
-                if (records >= 0) {
-                    readXmlListDelegate(xmlReader, records, start, next, prev);
+                    readXmlListDelegate(xmlReader, start, next, prev);
                 }
                 else if (response.StatusCode != HttpStatusCode.NoContent)
                 {
                     readXmlDelegate(xmlReader);
                 }
-                    
             }
 
         }

--- a/Library/List/RecurlyList.cs
+++ b/Library/List/RecurlyList.cs
@@ -98,10 +98,9 @@ namespace Recurly
             return baseUrl + divider + "per_page=" + PerPage;
         }
 
-        internal void ReadXmlList(XmlTextReader xmlReader, int records, string start, string next, string prev)
+        internal void ReadXmlList(XmlTextReader xmlReader, string start, string next, string prev)
         {
-            Items = records > 0 ? new List<T>(records) : new List<T>();
-            _capacity = records;
+            Items = new List<T>();
             StartUrl = start;
             NextUrl = next;
             PrevUrl = prev;

--- a/Library/List/RecurlyList.cs
+++ b/Library/List/RecurlyList.cs
@@ -26,12 +26,6 @@ namespace Recurly
             }
         }
 
-        private int _capacity = -1;
-        public int Capacity
-        {
-            get { return _capacity < 0 ? Count : _capacity; }
-        }
-
         public abstract RecurlyList<T> Start { get; }
         public abstract RecurlyList<T> Next { get; }
         public abstract RecurlyList<T> Prev { get; }

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -207,7 +207,6 @@ namespace Recurly.Test
             invoice.State.Should().Be(Invoice.InvoiceState.Collected);
 
             Assert.Equal(1, invoice.Adjustments.Count);
-            Assert.Equal(1, invoice.Adjustments.Capacity);
 
             // refund
             var refundInvoice = invoice.Refund(adjustment, false);
@@ -269,7 +268,6 @@ namespace Recurly.Test
             invoice.State.Should().Be(Invoice.InvoiceState.Collected);
 
             Assert.Equal(1, invoice.Adjustments.Count);
-            Assert.Equal(1, invoice.Adjustments.Capacity);
 
             // refund
             var refundInvoice = invoice.RefundAmount(100); // 1 dollar

--- a/Test/List/AccountListTest.cs
+++ b/Test/List/AccountListTest.cs
@@ -61,7 +61,6 @@ namespace Recurly.Test
 
             var accounts = Accounts.List();
             accounts.Should().HaveCount(5);
-            accounts.Capacity.Should().BeGreaterOrEqualTo(5);
 
             accounts.Next.Should().NotBeEmpty();
         }

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -556,8 +556,7 @@ namespace Recurly.Test
                 var list = new System.Collections.Generic.List<SubscriptionAddOn>();
                 list.Add(subaddon);
                 sub.AddOns.AddRange(list);
-                Assert.Equal(1, sub.AddOns.Capacity);
-
+                Assert.Equal(1, sub.AddOns.Count);
 
                 sub.AddOns.AsReadOnly();
 


### PR DESCRIPTION
We forgot to remove parsing of this header.

I think we will also need something in the release notes saying that you can no longer use the `Capacity` method on `RecurlyList`.