### PR TITLE
Bump 1.6.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,27 @@
 Unreleased
 ===============
 
+1.6.0 (stable) / 2017-09-06
+===============
+
+* Gift Card Support
+* Purchases Endpoint Support
+
+This release will upgrade us to API version 2.7. There is only 1 breaking change in this library.
+
+`Invoice` will now use an enum for the `CollectionMethod` property instead of a string. The enum has 2 values (Automatic and Manual). Example:
+
+```csharp
+// Setting
+invoice.CollectionMethod = Invoice.Collection.Manual;
+
+// Getting
+if (invoice.CollectionMethod == Invoice.Collection.Automatic)
+{
+  // do something
+}
+```
+
 1.5.1 (stable) / 2017-06-27
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]


### PR DESCRIPTION
This bumps the library version to 1.6.0. A Nuget release and doc updates will follow.

* Gift Card Support #241 
* Purchases Endpoint Support #240 

This release will upgrade us to API version 2.7. There is only 1 breaking change in this library.

`Invoice` will now use an enum for the `CollectionMethod` property instead of a string. The enum has 2 values (Automatic and Manual). Example:

```csharp
// Setting
invoice.CollectionMethod = Invoice.Collection.Manual;

// Getting
if (invoice.CollectionMethod == Invoice.Collection.Automatic)
{
  // do something
}
```