### PR TITLE
Bump 1.7.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,20 @@
 Unreleased
 ===============
 
+1.7.0 (stable) / 2017-10-17
+===============
+
+* ImportedTrial flag on Subscription
+* Purchases Notes Changes
+
+### Upgrade Notes
+
+This release will upgrade us to API version 2.8.
+
+There is one breaking change in this API version you must consider. All `country` fields must now contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html). If your code fails
+validation, you will receive a validation error. This affects anywhere and address is collected.
+
+
 1.6.1 (stable) / 2017-10-04
 ===============
 
@@ -12,6 +26,8 @@ Unreleased
 
 * Gift Card Support
 * Purchases Endpoint Support
+
+### Upgrade Notes
 
 This release will upgrade us to API version 2.7. There is only 1 breaking change in this library.
 

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -63,7 +63,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.7";
+        public const string RecurlyApiVersion = "2.8";
 
         // static, unlikely to change
         public string UserAgent

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1.0")]
-[assembly: AssemblyFileVersion("1.6.1.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -67,6 +67,33 @@ namespace Recurly
         }
         private List<string> _couponCodes;
 
+        /// <summary>
+        /// Optional notes field. This will default to the Customer Notes 
+        /// text specified on the Invoice Settings page in your Recurly admin.
+        /// Custom notes made on an invoice for a one time charge will
+        /// not carry over to subsequent invoices.
+        /// </summary>
+        public string CustomerNotes { get; set; }
+
+        /// <summary>
+        /// Optional Terms and Conditions field. This will default to the
+        /// Terms and Conditions text specified on the Invoice Settings page
+        /// in your Recurly admin. Custom notes will stay with a subscription
+        /// on all renewals.
+        /// </summary>
+        public string TermsAndConditions { get; set; }
+
+        /// <summary>
+        /// Optional VAT Reverse Charge Notes only appear if you have EU VAT
+        /// enabled or are using your own Avalara AvaTax account and the customer
+        /// is in the EU, has a VAT number, and is in a different country than
+        /// your own. This will default to the VAT Reverse Charge Notes text
+        /// specified on the Tax Settings page in your Recurly admin, unless
+        /// custom notes were created with the original subscription. Custom
+        /// notes will stay with a subscription on all renewals.
+        /// </summary>
+        public string VatReverseChargeNotes { get; set; }
+
         #region Constructors
 
         internal Purchase()
@@ -183,6 +210,15 @@ namespace Recurly
                 var gc = new GiftCard(GiftCardRedemptionCode);
                 gc.WriteRedemptionXml(xmlWriter);
             }
+
+            if (CustomerNotes != null)
+                xmlWriter.WriteElementString("customer_notes", CustomerNotes);
+
+            if (TermsAndConditions != null)
+                xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
+
+            if (VatReverseChargeNotes != null)
+                xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
 
             xmlWriter.WriteEndElement(); // End: purchase
         }

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -292,6 +292,11 @@ namespace Recurly
         /// </summary>
         public DateTime? ConvertedAt { get; private set; }
 
+        /// <summary>
+        /// Optionally set true to denote that this subscription was imported from a trial.
+        /// </summary>
+        public bool? ImportedTrial { get; set; }
+
         internal Subscription()
         {
             IsPendingSubscription = false;
@@ -702,6 +707,9 @@ namespace Recurly
                     case "no_billing_info_reason":
                         NoBillingInfoReason = reader.ReadElementContentAsString();
                         break;
+                    case "imported_trial":
+                        ImportedTrial = reader.ReadElementContentAsBoolean();
+                        break;
                 }
             }
         }
@@ -819,6 +827,11 @@ namespace Recurly
             if (ShippingAddressId.HasValue)
             {
                 xmlWriter.WriteElementString("shipping_address_id", ShippingAddressId.Value.ToString());
+            }
+
+            if (ImportedTrial.HasValue)
+            {
+                xmlWriter.WriteElementString("imported_trial", ImportedTrial.Value.ToString().ToLower());
             }
 
             xmlWriter.WriteEndElement(); // End: subscription


### PR DESCRIPTION
* ImportedTrial flag on Subscription [PR](https://github.com/recurly/recurly-client-net/pull/247)
* Purchases Notes Changes [PR](https://github.com/recurly/recurly-client-net/pull/246)

### Upgrade Notes

This release will upgrade us to API version 2.8.

There is one breaking change in this API version you must consider. All `country` fields must now contain valid [2 letter ISO 3166 country codes](https://www.iso.org/iso-3166-country-codes.html). If your code fails validation, you will receive a validation error. This affects anywhere and address is collected.