### PR TITLE
Implements missing `revenue_schedule_type`

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -25,6 +25,7 @@ namespace Recurly
         public Usage.Type? UsageType { get; set; }
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
+        public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
 
         private Dictionary<string, int> _unitAmountInCents;
         /// <summary>
@@ -165,6 +166,10 @@ namespace Recurly
                     case "usage_type":
                         UsageType = reader.ReadElementContentAsString().ParseAsEnum<Usage.Type>();
                         break;
+
+                    case "revenue_schedule_type":
+                        RevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
                 }
             }
         }
@@ -195,6 +200,9 @@ namespace Recurly
 
             xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
                 pair => pair.Value.AsString());
+
+            if (RevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
 
             xmlWriter.WriteEndElement();
         }

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -23,6 +23,14 @@ namespace Recurly
             Invoiced
         }
 
+        public enum RevenueSchedule : short
+        {
+            Evenly = 0,
+            Never,
+            AtRangeStart,
+            AtRangeEnd
+        }
+
         public string AccountCode { get; private set; }
         public string Uuid { get; protected set; }
         public string Description { get; set; }
@@ -37,6 +45,7 @@ namespace Recurly
         public string Currency { get; set; }
         public bool TaxExempt { get; set; }
         public string TaxCode { get; set; }
+        public RevenueSchedule? RevenueScheduleType { get; set; }
 
         public string TaxType { get; private set; }
         public decimal? TaxRate { get; private set; }
@@ -234,6 +243,9 @@ namespace Recurly
                         State = reader.ReadElementContentAsString().ParseAsEnum<AdjustmentState>();
                         break;
 
+                    case "revenue_schedule_type":
+                        RevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
                 }
             }
         }
@@ -258,6 +270,8 @@ namespace Recurly
             xmlWriter.WriteElementString("tax_exempt", TaxExempt.AsString());
             if (!embedded)
                 xmlWriter.WriteElementString("currency", Currency);
+            if (RevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
             xmlWriter.WriteEndElement(); // End: adjustment
         }
 

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -47,6 +47,9 @@ namespace Recurly
 
         public bool? TrialRequiresBillingInfo { get; set; }
 
+        public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
+        public Adjustment.RevenueSchedule? SetupFeeRevenueScheduleType { get; set; }
+
         private AddOnList _addOns;
 
         public RecurlyList<AddOn> AddOns
@@ -309,6 +312,14 @@ namespace Recurly
                         if (bool.TryParse(reader.ReadElementContentAsString(), out b))
                             TrialRequiresBillingInfo = b;
                         break;
+
+                    case "revenue_schedule_type":
+                        RevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
+
+                    case "setup_fee_revenue_schedule_type":
+                        SetupFeeRevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
                 }
             }
         }
@@ -362,6 +373,12 @@ namespace Recurly
 
             xmlWriter.WriteStringIfValid("success_url", SuccessUrl);
             xmlWriter.WriteStringIfValid("cancel_url", CancelUrl);
+
+            if (RevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+
+            if (SetupFeeRevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("setup_fee_revenue_schedule_type", SetupFeeRevenueScheduleType.Value.ToString().EnumNameToTransportCase());
 
             xmlWriter.WriteEndElement();
         }

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -297,6 +297,8 @@ namespace Recurly
         /// </summary>
         public bool? ImportedTrial { get; set; }
 
+        public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
+
         internal Subscription()
         {
             IsPendingSubscription = false;
@@ -710,6 +712,10 @@ namespace Recurly
                     case "imported_trial":
                         ImportedTrial = reader.ReadElementContentAsBoolean();
                         break;
+
+                    case "revenue_schedule_type":
+                        RevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
                 }
             }
         }
@@ -833,6 +839,9 @@ namespace Recurly
             {
                 xmlWriter.WriteElementString("imported_trial", ImportedTrial.Value.ToString().ToLower());
             }
+
+            if (RevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
 
             xmlWriter.WriteEndElement(); // End: subscription
         }

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -7,6 +7,7 @@ namespace Recurly
         public string AddOnCode { get; set; }
         public int UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
+        public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
 
         public SubscriptionAddOn(XmlTextReader reader)
         {
@@ -42,6 +43,10 @@ namespace Recurly
                     case "unit_amount_in_cents":
                         UnitAmountInCents = reader.ReadElementContentAsInt();
                         break;
+
+                    case "revenue_schedule_type":
+                        RevenueScheduleType = reader.ReadContentAsString().ParseAsEnum<Adjustment.RevenueSchedule>();
+                        break;
                 }
             }
         }
@@ -53,6 +58,9 @@ namespace Recurly
             writer.WriteElementString("add_on_code", AddOnCode);
             writer.WriteElementString("quantity", Quantity.AsString());
             writer.WriteElementString("unit_amount_in_cents", UnitAmountInCents.AsString());
+
+            if (RevenueScheduleType.HasValue)
+                writer.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
 
             writer.WriteEndElement();
         }


### PR DESCRIPTION
Allows you to set and read RevenueScheduleTypes with the enum `Adjustment.RevenueSchedule`. Example:

```csharp
var plan = new Plan("gold12345", "Gold plan"); // plan code, name
plan.UnitAmountInCents.Add("USD", 1000);
plan.SetupFeeInCents.Add("USD", 6000);
plan.PlanIntervalLength = 1;
plan.PlanIntervalUnit = Plan.IntervalUnit.Months;
plan.RevenueScheduleType = Adjustment.RevenueSchedule.Evenly;
plan.SetupFeeRevenueScheduleType = Adjustment.RevenueSchedule.AtRangeEnd;
plan.Create();
Console.WriteLine(plan.SetupFeeRevenueScheduleType.ToString());
Console.WriteLine(plan.RevenueScheduleType.ToString());
```