### PR TITLE
Bump 1.8.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,19 @@
 Unreleased
 ===============
 
+1.8.0 (stable) / 2017-10-26
+===============
+
+* Adds giftcard redeem endpoint
+* Update the README with `Overview` section
+* Make TrialRequiresBillingInfo an optional
+* Implements missing `revenue_schedule_type`
+
+### Upgrade Notes
+
+There is one small breaking change in this API version. `TrialRequiresBillingInfo` is now an optional so you will have to unwrap it to use it.
+
+
 1.7.0 (stable) / 2017-10-17
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]


### PR DESCRIPTION
* Adds giftcard redeem endpoint #250 (Issue #249)
* Update the README with `Overview` section #251 
* Make TrialRequiresBillingInfo an optional #252 
* Implements missing `revenue_schedule_type` #253 

### Upgrade Notes

There is one small breaking change in this API version. `TrialRequiresBillingInfo` is now an optional so you will have to unwrap it to use it.