### PR TITLE
Fix creation of an empty invoice when InvoiceList is empty

### DIFF
--- a/Library/List/InvoiceList.cs
+++ b/Library/List/InvoiceList.cs
@@ -33,7 +33,7 @@ namespace Recurly
                 if (reader.Name == "invoices" && reader.NodeType == XmlNodeType.EndElement)
                     break;
 
-                if (reader.NodeType == XmlNodeType.Element)
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "invoice")
                 {
                     Add(new Invoice(reader));
                 }


### PR DESCRIPTION
Right now when the API returns an empty list of invoices, the library parses it as a list with one empty invoice.