### PR TITLE
Make optional ints nullable

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -15,7 +15,7 @@ namespace Recurly
         public string PlanCode { get; set; }
         public string AddOnCode { get; set; }
         public string Name { get; set; }
-        public int DefaultQuantity { get; set; }
+        public int? DefaultQuantity { get; set; }
         public bool? DisplayQuantityOnHostedPage { get; set; }
         public string TaxCode { get; set; }
         public bool? Optional { get; set; }
@@ -180,8 +180,10 @@ namespace Recurly
 
             xmlWriter.WriteElementString("add_on_code", AddOnCode);
             xmlWriter.WriteElementString("name", Name);
-            xmlWriter.WriteElementString("default_quantity", DefaultQuantity.AsString());
             xmlWriter.WriteElementString("accounting_code", AccountingCode);
+
+            if (DefaultQuantity.HasValue)
+                xmlWriter.WriteElementString("default_quantity", DefaultQuantity.Value.AsString());
 
             if (AddOnType.HasValue)
                 xmlWriter.WriteElementString("add_on_type", AddOnType.Value.ToString().EnumNameToTransportCase());

--- a/Library/GiftCard.cs
+++ b/Library/GiftCard.cs
@@ -63,7 +63,7 @@ namespace Recurly
         /// has been redeemed. Can be used to create gift card balance
         /// displays for your customers.
         /// </summary>
-        public int BalanceInCents { get; set; }
+        public int? BalanceInCents { get; set; }
 
         /// <summary>
         /// Block of delivery information.

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -27,10 +27,10 @@ namespace Recurly
         public string UnitName { get; set; }
         public string PaymentPageTOSLink { get; set; }
 
-        public int PlanIntervalLength { get; set; }
+        public int? PlanIntervalLength { get; set; }
         public IntervalUnit PlanIntervalUnit { get; set; }
 
-        public int TrialIntervalLength { get; set; }
+        public int? TrialIntervalLength { get; set; }
         public IntervalUnit TrialIntervalUnit { get; set; }
 
         public string AccountingCode { get; set; }
@@ -333,15 +333,15 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("description", Description);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
             xmlWriter.WriteStringIfValid("setup_fee_accounting_code", SetupFeeAccountingCode);
-            if (PlanIntervalLength > 0)
+            if (PlanIntervalLength.HasValue)
             {
                 xmlWriter.WriteElementString("plan_interval_unit", PlanIntervalUnit.ToString().EnumNameToTransportCase());
-                xmlWriter.WriteElementString("plan_interval_length", PlanIntervalLength.AsString());
+                xmlWriter.WriteElementString("plan_interval_length", PlanIntervalLength.Value.AsString());
             }
-            if (TrialIntervalLength > 0)
+            if (TrialIntervalLength.HasValue)
             {
                 xmlWriter.WriteElementString("trial_interval_unit", TrialIntervalUnit.ToString().EnumNameToTransportCase());
-                xmlWriter.WriteElementString("trial_interval_length", TrialIntervalLength.AsString());
+                xmlWriter.WriteElementString("trial_interval_length", TrialIntervalLength.Value.AsString());
             }
 
             xmlWriter.WriteIfCollectionHasAny("setup_fee_in_cents", SetupFeeInCents, pair => pair.Key, pair => pair.Value.AsString());

--- a/Library/Usage.cs
+++ b/Library/Usage.cs
@@ -19,7 +19,7 @@ namespace Recurly
         public long? Id { get; private set; }
         public int? UnitAmountInCents { get; set; }
         public float? UsagePercentage { get; set; }
-        public int Amount{ get; set; }
+        public int Amount { get; set; }
         public String MerchantTag { get; set; }
         public Type UsageType { get; set; }
         public DateTime? UsageTimestamp { get; set; }


### PR DESCRIPTION
Some code were handling optional integer properties in ways that breaks expected behavior. In order to test if the programmer "set" the integer, it was checked against the default `0`. This has the means that you cannot set the value to 0. Example:

```csharp

var planCode = "aPlanCode";
var plan = Plans.Get(planCode);
 
Console.WriteLine(plan.TrialIntervalLength);
Console.WriteLine(plan.TrialIntervalUnit);
plan.TrialIntervalUnit= Plan.IntervalUnit.Months;
plan.TrialIntervalLength = 0;
plan.TrialRequiresBillingInfo = true;
plan.Update();
var updatedPlan = Plans.Get(planCode);
Console.WriteLine(updatedPlan.TrialRequiresBillingInfo);
Console.WriteLine(updatedPlan.TrialIntervalLength);
Console.WriteLine(updatedPlan.TrialIntervalUnit);
```

There are also cases where the xml elements are null but are presented to the user as `0`. See Issue #261 

There was also a case where 0 was always rendered causing an error. 

These problems are solved by making the integers nullable. It has the effect of needing to unpack the integer by using `.Value` which breaks the contract. Code accessing these values may need to be changed in your code:

- AddOn#DefaultQuantity
- Plan#PlanIntervalLength
- Plan#TrialIntervalLength
- GiftCard#BalanceInCents

