### PR TITLE
Bump 1.9.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,15 @@
 Unreleased
 ===============
 
+1.9.0 (stable) / 2017-10-26
+===============
+
+- Add missing 'DinersClub' credit card type
+- Fix creation of an empty invoice when InvoiceList is empty
+- Make optional ints nullable
+- API v2.9 changes
+
+
 1.8.0 (stable) / 2017-10-26
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.8.1.0")]
-[assembly: AssemblyFileVersion("1.8.1.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]


### PR DESCRIPTION
- Add missing 'DinersClub' credit card type #258
- Fix creation of an empty invoice when InvoiceList is empty #260 
- Make optional ints nullable #263
- API v2.9 changes #264
- Fix revenue_schedule_type spelling #265 