### PR TITLE
fix unit amounts exceptions when using percentage addons

### DIFF
--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -63,14 +63,14 @@ namespace Recurly
         /// <param name="quantity">The quantity of the add-on. Optional, default is 1.</param>
         public void Add(AddOn planAddOn, int quantity = 1)
         {
-            int amount;
-            if (!planAddOn.UnitAmountInCents.TryGetValue(_subscription.Currency, out amount))
+            int amount = 0;
+            if (planAddOn.UnitAmountInCents.Count > 0 && !planAddOn.UnitAmountInCents.TryGetValue(_subscription.Currency, out amount))
             {
                 throw new ValidationException(
                     "The given AddOn does not have UnitAmountInCents for the currency of the subscription (" + _subscription.Currency + ")."
                     , new Errors());
             }
-            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, amount, quantity);
+            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, planAddOn.AddOnType, amount, quantity);
             base.Add(sub);
         }
 
@@ -89,7 +89,7 @@ namespace Recurly
         /// <param name="unitAmountInCents">Overrides the UnitAmountInCents of the add-on.</param>
         public void Add(AddOn planAddOn, int quantity, int unitAmountInCents)
         {
-            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, unitAmountInCents, quantity);
+            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, planAddOn.AddOnType, unitAmountInCents, quantity);
             base.Add(sub);
         }
 
@@ -102,9 +102,23 @@ namespace Recurly
             var sub = new SubscriptionAddOn(planAddOnCode, unitAmount, quantity);
             base.Add(sub);
         }
+
+        public void Add(string planAddOnCode, AddOn.Type addOnType, int quantity = 1)
+        {
+            var unitAmount = _subscription.Plan.AddOns.Find(ao => ao.AddOnCode == planAddOnCode).UnitAmountInCents[_subscription.Currency];
+            var sub = new SubscriptionAddOn(planAddOnCode, addOnType, unitAmount, quantity);
+            base.Add(sub);
+        }
+
         public void Add(string planAddOnCode, int quantity, int unitAmountInCents)
         {
             var sub = new SubscriptionAddOn(planAddOnCode, unitAmountInCents, quantity);
+            base.Add(sub);
+        }
+
+        public void Add(string planAddOnCode, AddOn.Type addOnType, int quantity, int unitAmountInCents)
+        {
+            var sub = new SubscriptionAddOn(planAddOnCode, addOnType, unitAmountInCents, quantity);
             base.Add(sub);
         }
     }

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -1,10 +1,12 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 
 namespace Recurly
 {
     public class SubscriptionAddOn : RecurlyEntity
     {
         public string AddOnCode { get; set; }
+        public AddOn.Type? AddOnType { get; set; }
         public int UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
@@ -14,9 +16,19 @@ namespace Recurly
             ReadXml(reader);
         }
 
+        // keep old constructor
         public SubscriptionAddOn(string addOnCode, int unitAmountInCents, int quantity = 1)
         {
             AddOnCode = addOnCode;
+            UnitAmountInCents = unitAmountInCents;
+            Quantity = quantity;
+        }
+
+        // new constructor including addOnType (recommended)
+        public SubscriptionAddOn(string addOnCode, AddOn.Type? addOnType, int unitAmountInCents, int quantity = 1)
+        {
+            AddOnCode = addOnCode;
+            AddOnType = addOnType;
             UnitAmountInCents = unitAmountInCents;
             Quantity = quantity;
         }
@@ -36,12 +48,18 @@ namespace Recurly
                         AddOnCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "add_on_type":
+                        AddOnType = reader.ReadElementContentAsString().ParseAsEnum<AddOn.Type>();
+                        break;
+
                     case "quantity":
                         Quantity = reader.ReadElementContentAsInt();
                         break;
 
                     case "unit_amount_in_cents":
-                        UnitAmountInCents = reader.ReadElementContentAsInt();
+                        int unitAmountInCents;
+                        if (Int32.TryParse(reader.ReadElementContentAsString(), out unitAmountInCents))
+                            UnitAmountInCents = unitAmountInCents;
                         break;
 
                     case "revenue_schedule_type":
@@ -56,7 +74,7 @@ namespace Recurly
             writer.WriteStartElement("subscription_add_on");
 
             writer.WriteElementString("add_on_code", AddOnCode);
-            writer.WriteElementString("quantity", Quantity.AsString());
+            writer.WriteElementString("quantity", Quantity.AsString());			
             writer.WriteElementString("unit_amount_in_cents", UnitAmountInCents.AsString());
 
             if (RevenueScheduleType.HasValue)

--- a/Test/ExtensionTest.cs
+++ b/Test/ExtensionTest.cs
@@ -244,8 +244,8 @@ namespace Recurly.Test
         {
             var list = new List<SubscriptionAddOn>
             {
-                new SubscriptionAddOn("addon1", 100),
-                new SubscriptionAddOn("addon2", 200, 2)
+                new SubscriptionAddOn("addon1", AddOn.Type.Fixed, 100),
+                new SubscriptionAddOn("addon2", AddOn.Type.Fixed, 200, 2)
             };
 
             var stringWriter = new StringWriter();

--- a/Test/List/SubscriptionAddOnListTest.cs
+++ b/Test/List/SubscriptionAddOnListTest.cs
@@ -20,6 +20,7 @@ namespace Recurly.Test.List
             
             var addOn = plan.NewAddOn("1", "test");
             addOn.UnitAmountInCents.Add(USD, 200);
+            addOn.AddOnType = AddOn.Type.Fixed;
             
             var sub = new Subscription(account, plan, GBP);
 
@@ -40,6 +41,7 @@ namespace Recurly.Test.List
 
             var addOn = plan.NewAddOn("1", "test");
             addOn.UnitAmountInCents.Add(USD, 200);
+            addOn.AddOnType = AddOn.Type.Fixed;
 
             var sub = new Subscription(account, plan, USD);
 
@@ -59,6 +61,7 @@ namespace Recurly.Test.List
 
             var addOn = plan.NewAddOn(addOnCode, "test");
             addOn.UnitAmountInCents.Add(USD, 200);
+            addOn.AddOnType = AddOn.Type.Fixed;
 
             var sub = new Subscription(account, plan, USD);
 

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -424,6 +424,7 @@ namespace Recurly.Test
                 addon1 = plan.NewAddOn("addon1", "addon1");
                 addon1.DisplayQuantityOnHostedPage = true;
                 addon1.UnitAmountInCents.Add("USD", 100);
+                addon1.AddOnType = AddOn.Type.Fixed;
                 addon1.DefaultQuantity = 1;
                 addon1.Create();
 
@@ -442,6 +443,7 @@ namespace Recurly.Test
                 addon2 = plan2.NewAddOn("addon1", "addon2");
                 addon2.DisplayQuantityOnHostedPage = true;
                 addon2.UnitAmountInCents.Add("USD", 200);
+                addon2.AddOnType = AddOn.Type.Fixed;
                 addon2.DefaultQuantity = 1;
                 addon2.Create();
 
@@ -451,7 +453,7 @@ namespace Recurly.Test
                 account = CreateNewAccountWithBillingInfo();
 
                 sub = new Subscription(account, plan, "USD");
-                sub.AddOns.Add(new SubscriptionAddOn("addon1", 100, 1)); // TODO allow passing just the addon code
+                sub.AddOns.Add(new SubscriptionAddOn("addon1", AddOn.Type.Fixed, 100, 1)); // TODO allow passing just the addon code
                 sub.Create();
 
                 // confirm that Create() doesn't duplicate the AddOns
@@ -517,6 +519,7 @@ namespace Recurly.Test
                     var name = "Addon" + i.AsString();
                     var addon = plan.NewAddOn(name, name);
                     addon.DisplayQuantityOnHostedPage = true;
+                    addon.AddOnType = AddOn.Type.Fixed;
                     addon.UnitAmountInCents.Add("USD", 1000 + i);
                     addon.DefaultQuantity = i + 1;
                     addon.Create();
@@ -528,13 +531,13 @@ namespace Recurly.Test
                 sub = new Subscription(account, plan, "USD");
                 Assert.NotNull(sub.AddOns);
 
-                sub.AddOns.Add(new SubscriptionAddOn("Addon0", 100, 1));
+                sub.AddOns.Add(new SubscriptionAddOn("Addon0", AddOn.Type.Fixed, 100, 1));
                 sub.AddOns.Add(addons[1]);
                 sub.AddOns.Add(addons[2], 2);
                 sub.AddOns.Add(addons[3], 3, 100);
-                sub.AddOns.Add(addons[4].AddOnCode);
-                sub.AddOns.Add(addons[5].AddOnCode, 4);
-                sub.AddOns.Add(addons[6].AddOnCode, 5, 100);
+                sub.AddOns.Add(addons[4].AddOnCode, addons[4].AddOnType.Value);
+                sub.AddOns.Add(addons[5].AddOnCode, addons[5].AddOnType.Value, 4);
+                sub.AddOns.Add(addons[6].AddOnCode, addons[6].AddOnType.Value, 5, 100);
 
                 sub.Create();
                 sub.State.Should().Be(Subscription.SubscriptionState.Active);
@@ -552,11 +555,12 @@ namespace Recurly.Test
                 sub.AddOns.Clear();
                 Assert.Equal(0, sub.AddOns.Count);
 
-                var subaddon = new SubscriptionAddOn("a", 1);
+                var subaddon = new SubscriptionAddOn("a", AddOn.Type.Fixed, 1);
                 var list = new System.Collections.Generic.List<SubscriptionAddOn>();
                 list.Add(subaddon);
                 sub.AddOns.AddRange(list);
                 Assert.Equal(1, sub.AddOns.Count);
+
 
                 sub.AddOns.AsReadOnly();
 


### PR DESCRIPTION
When we create a usage addon whose usage type is percentage, the UnitAmountInCents is not required; the mandatory value is the percentage for the addon. In recurly administration console when you select the usage type by percentage, the UnitAmountInCents fields are not shown. 
The problem we saw in "SubscriptionAddOn" and "SubscriptionAddOnList" classes, is that when managing the addons some exceptions are thrown because they are accessing the UnitAmountInCents always, in spite of the fact that the addons have that value as null, because they are defined as percentage (UnitAmountInCents is not needed)