### PR TITLE
Set Errors variable to a default instance of the Errors class.

### DIFF
--- a/Library/Errors.cs
+++ b/Library/Errors.cs
@@ -52,7 +52,7 @@ namespace Recurly
             if (response == null)
                 return null;
 
-            Errors errors = null;
+            Errors errors = new Errors();
 
             using (var responseStream = response.GetResponseStream())
             {


### PR DESCRIPTION
A NullReference exception is getting thrown inside the Exception class due a default instance not being set. 
The RecurlyException class is expecting that the passing parameter is always initialized but this is not always the case: 
![image](https://user-images.githubusercontent.com/8289977/34681968-70ea9822-f46b-11e7-91f8-0109e8aca216.png)

The exception gets triggered when an exception occurs trying parse the XML response here:
![image](https://user-images.githubusercontent.com/8289977/34682049-b05035b2-f46b-11e7-8e7f-96bdcf4b47f1.png)

The NullReference exception is masking other errors occurring in the consumer so this fix will ensure a default instance is always set.