### PR TITLE
Bump 1.9.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,12 @@
 Unreleased
 ===============
 
+1.9.1 (stable) / 2018-01-22
+===============
+
+- Set errors variable to a default instance of the Errors class
+- Handle empty revenue_schedule_type
+
 1.9.0 (stable) / 2017-10-26
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.0.0")]
-[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyVersion("1.9.1.0")]
+[assembly: AssemblyFileVersion("1.9.1.0")]


### PR DESCRIPTION
Some bug fixes for 1.9:

- Set errors variable to a default instance of the Errors class #271 
- Handle empty revenue_schedule_type #270 