### PR TITLE
Change Coupon.Id from int to long

### DIFF
--- a/Library/Coupon.cs
+++ b/Library/Coupon.cs
@@ -51,7 +51,7 @@ namespace Recurly
             UniqueCode
         }
 
-        public int Id { get; set; }
+        public long Id { get; private set; }
 
         public RecurlyList<CouponRedemption> Redemptions { get; private set; }
 
@@ -234,12 +234,12 @@ namespace Recurly
 
                 DateTime date;
                 int m;
+                long l;
                 switch (reader.Name)
                 {
                     case "id":
-                        int id;
-                        if (int.TryParse(reader.ReadElementContentAsString(), out id))
-                            Id = id;
+                        if (long.TryParse(reader.ReadElementContentAsString(), out l))
+                            Id = l;
                         break;
                     case "coupon_code":
                         CouponCode = reader.ReadElementContentAsString();


### PR DESCRIPTION
Resolves #274 

The problem is that using `int` for Coupon.Id was working when the ints were smaller. Once they got too large, the integer parser was failing to parse them. Should have been a `long` to begin with. All other resources that use druuid ids  use `long`.