### PR TITLE
Bump 1.10.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,18 @@
 Unreleased
 ===============
 
+1.10.0 (stable) / 2018-03-06
+===============
+
+- Fix unit amounts exceptions when using percentage addons
+- Add filter to InvoiceList, redemption updated_at
+- Changed Coupon.Id from int to long
+- Implement Account Acquisition
+
+Upgrade Notes
+
+There is one very small breaking change. Coupon.Id changed from an `int` to a `long`. Your code will require a change if you explicitly reference it as an int.
+
 1.9.1 (stable) / 2018-01-22
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.1.0")]
-[assembly: AssemblyFileVersion("1.9.1.0")]
+[assembly: AssemblyVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]


### PR DESCRIPTION
- Fix unit amounts exceptions when using percentage addons #268 
- Add filter to InvoiceList, redemption updated_at #277
- Changed Coupon.Id from int to long #278 
- Implement Account Acquisition #279 

### Upgrade Notes

There is one very small breaking change. Coupon.Id changed from an `int` to a `long`. Your code will require a change if you explicitly reference it as an int.