### PR TITLE
API v2.10

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -230,29 +230,31 @@ namespace Recurly
         /// <summary>
         /// Posts pending charges on an account
         /// </summary>
-        public Invoice InvoicePendingCharges(Invoice invoice = null)
+        public InvoiceCollection InvoicePendingCharges(Invoice invoice = null)
         {
-            var i = invoice ?? new Invoice();
+            invoice = invoice ?? new Invoice();
+            var collection = new InvoiceCollection();
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 UrlPrefix + Uri.EscapeDataString(AccountCode) + "/invoices",
-                i.WriteXml,
-                i.ReadXml);
+                invoice.WriteXml,
+                collection.ReadXml);
 
-            return i;
+            return collection;
         }
 
         /// <summary>
         /// Previews a new invoice for the pending charges on an account
         /// </summary>
-        public Invoice PreviewInvoicePendingCharges(Invoice invoice = null)
+        public InvoiceCollection PreviewInvoicePendingCharges(Invoice invoice = null)
         {
-            var i = invoice ?? new Invoice();
+            invoice = invoice ?? new Invoice(); 
+            var collection = new InvoiceCollection();
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 UrlPrefix + Uri.EscapeDataString(AccountCode) + "/invoices/preview",
-                i.WriteXml,
-                i.ReadXml);
+                invoice.WriteXml,
+                collection.ReadXml);
 
-            return i;
+            return collection;
         }
 
         /// <summary>

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -53,6 +53,9 @@ namespace Recurly
 
         public AdjustmentState State { get; protected set; }
 
+        public string CreditReasonCode { get; set; }
+        public string OriginalAjustmentUuid { get; set; }
+
         public DateTime StartDate { get; protected set; }
         public DateTime? EndDate { get; protected set; }
 
@@ -213,6 +216,14 @@ namespace Recurly
 
                     case "tax_region":
                         TaxRegion = reader.ReadElementContentAsString();
+                        break;
+
+                    case "credit_reason_code":
+                        CreditReasonCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "original_adjustment_uuid":
+                        OriginalAjustmentUuid = reader.ReadElementContentAsString();
                         break;
 
                     case "start_date":

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -63,7 +63,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.9";
+        public const string RecurlyApiVersion = "2.10";
 
         // static, unlikely to change
         public string UserAgent

--- a/Library/CreditPayment.cs
+++ b/Library/CreditPayment.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Xml;
+
+namespace Recurly
+{
+    /// <summary>
+    /// Represents a credit payment
+    /// </summary>
+    public class CreditPayment : RecurlyEntity
+    {
+        public string Uuid { get; set; }
+        public string Action { get; set; }
+        public int UnitAmountInCents { get; set; }
+        public string AppliedToInvoice { get; set; }
+        public string Currency { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
+        public DateTime VoidedAt { get; set; }
+
+        #region Constructors
+
+        internal CreditPayment()
+        {
+        }
+
+        internal CreditPayment(XmlTextReader reader)
+        {
+            ReadXml(reader);
+        }
+
+        #endregion
+
+        #region Read and Write XML documents
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                // End of account element, get out of here
+                if (reader.Name == "credit_payment" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                DateTime dt;
+                switch (reader.Name)
+                { 
+                    case "uuid":
+                        Uuid = reader.ReadElementContentAsString();
+                        break;
+        
+                    case "unit_amount_in_cents":
+                        UnitAmountInCents = reader.ReadElementContentAsInt();
+                        break;
+   
+                    case "currency":
+                        Currency = reader.ReadElementContentAsString();
+                        break;
+
+                    case "action":
+                        Action = reader.ReadElementContentAsString();
+                        break;
+
+                    case "applied_to_invoice":
+                        AppliedToInvoice = reader.ReadElementContentAsString();
+                        break;
+
+                    case "created_at":
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out dt))
+                            CreatedAt = dt;
+                        break;
+
+                    case "updated_at":
+                        if(DateTime.TryParse(reader.ReadElementContentAsString(), out dt))
+                            UpdatedAt = dt;
+                        break;
+
+                    case "voided_at":
+                        if (DateTime.TryParse(reader.ReadElementContentAsString(), out dt))
+                            VoidedAt = dt;
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+
+    public class CreditPayments
+    {
+        internal const string UrlPrefix = "/credit_payments";
+
+        /// <summary>
+        /// Get a credit payment given a UUID
+        /// </summary>
+        /// <param name="uuid">The unique uuid of the credit payment</param>
+        /// <returns>CreditPayment</returns>
+        public static CreditPayment Get(string uuid)
+        {
+            var creditPayment = new CreditPayment();
+            Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
+                "/credit_payment/" + Uri.EscapeDataString(uuid),
+                creditPayment.ReadXml);
+            return creditPayment;
+        }
+
+        /// <summary>   
+        /// Lists credit payments
+        /// </summary>
+        /// <param name="filter">FilterCriteria used to apply server side sorting and filtering</param>
+        /// <returns></returns>
+        public static RecurlyList<CreditPayment> List(FilterCriteria filter)
+        {
+            filter = filter ?? FilterCriteria.Instance;
+            var parameters = filter.ToNamedValueCollection();
+            return new CreditPaymentList(UrlPrefix + "?" + parameters.ToString());
+        }
+    }
+}

--- a/Library/InvoiceCollection.cs
+++ b/Library/InvoiceCollection.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml;
+
+namespace Recurly
+{
+
+    /// <summary>
+    /// Represents a collection of charge and credit invoices
+    /// </summary>
+    public class InvoiceCollection : RecurlyEntity
+    {
+       
+        /// <summary>
+        /// The invoice associated with charges.
+        /// </summary>
+        public Invoice ChargeInvoice { get; private set; }
+
+        /// <summary>
+        /// The invoices associated with credits.
+        /// </summary>
+        public RecurlyList<Invoice> CreditInvoices { get; private set; }
+
+        internal InvoiceCollection()
+        {
+        }
+
+        internal InvoiceCollection(XmlTextReader reader)
+        {
+            ReadXml(reader);
+        }
+
+
+        #region Read and Write XML documents
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "invoice_collection" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                switch (reader.Name)
+                {
+                    case "charge_invoice":
+                        var invoice = new Invoice();
+                        invoice.ReadXml(reader, "charge_invoice");
+                        ChargeInvoice = invoice;
+                        break;                    
+                    case "credit_invoices":
+                        var invoices = new InvoiceList();
+                        invoices.ReadXml(reader);
+                        CreditInvoices = invoices;
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter writer)
+        {
+            throw new NotImplementedException();
+        }
+
+       
+        #endregion
+
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return "Recurly Invoice Collection";
+        }
+
+        public override bool Equals(object obj)
+        {
+            var sub = obj as InvoiceCollection;
+            return sub != null && Equals(sub);
+        }
+
+        public bool Equals(InvoiceCollection collection)
+        {
+            return ChargeInvoice == collection?.ChargeInvoice
+                && CreditInvoices == collection?.CreditInvoices;
+        }
+
+        public override int GetHashCode()
+        {
+            return ChargeInvoice?.GetHashCode() ?? 0;
+        }
+
+        #endregion
+    }
+}

--- a/Library/List/CreditPaymentList.cs
+++ b/Library/List/CreditPaymentList.cs
@@ -1,0 +1,44 @@
+﻿using System.Xml;
+
+namespace Recurly
+{
+    public class CreditPaymentList : RecurlyList<CreditPayment>
+    {
+        public override RecurlyList<CreditPayment> Start
+        {
+            get { return HasStartPage() ? new CreditPaymentList(StartUrl) : RecurlyList.Empty<CreditPayment>(); }
+        }
+
+        public override RecurlyList<CreditPayment> Next
+        {
+            get { return HasNextPage() ? new CreditPaymentList(NextUrl) : RecurlyList.Empty<CreditPayment>(); }
+        }
+
+        public override RecurlyList<CreditPayment> Prev
+        {
+            get { return HasPrevPage() ? new CreditPaymentList(PrevUrl) : RecurlyList.Empty<CreditPayment>(); }
+        }
+
+        public CreditPaymentList()
+        {
+        }
+
+        public CreditPaymentList(string url) : base(Client.HttpRequestMethod.Get, url)
+        {
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if ((reader.Name == "credit_payments") && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "credit_payment")
+                {
+                    Add(new CreditPayment(reader));
+                }
+            }
+        }
+    }
+}

--- a/Library/List/InvoiceList.cs
+++ b/Library/List/InvoiceList.cs
@@ -5,6 +5,11 @@ namespace Recurly
     public class InvoiceList : RecurlyList<Invoice>
     {
 
+        internal InvoiceList()
+        {
+
+        }
+
         internal InvoiceList(string baseUrl)
             : base(Client.HttpRequestMethod.Get, baseUrl)
         {

--- a/Library/List/RefundList.cs
+++ b/Library/List/RefundList.cs
@@ -7,9 +7,9 @@ namespace Recurly
     internal class RefundList : IEnumerable<Refund>
     {
         private List<Refund> Refunds = new List<Refund>();
-        private Invoice.RefundOrderPriority RefundPriority;
+        private Invoice.RefundMethod RefundMethod;
 
-        internal RefundList(IEnumerable<Adjustment> adjustments, bool prorate, int quantity = 0, Invoice.RefundOrderPriority refundPriority = Invoice.RefundOrderPriority.Credit)
+        internal RefundList(IEnumerable<Adjustment> adjustments, bool prorate, int quantity = 0, Invoice.RefundMethod method = Invoice.RefundMethod.CreditFirst)
         {
             foreach (var adjustment in adjustments)
             {
@@ -21,13 +21,13 @@ namespace Recurly
                 Refunds.Add(refund);
             }
 
-            RefundPriority = refundPriority;
+            RefundMethod = method;
         }
 
         internal void WriteXml(XmlTextWriter writer) 
         {
             writer.WriteStartElement("invoice");
-            writer.WriteElementString("refund_apply_order", RefundPriority.ToString().ToLower());
+            writer.WriteElementString("refund_method", RefundMethod.ToString().ToLower());
             writer.WriteStartElement("line_items");
 
             foreach (var refund in Refunds)

--- a/Library/OpenAmountRefund.cs
+++ b/Library/OpenAmountRefund.cs
@@ -5,12 +5,12 @@ namespace Recurly
     class OpenAmountRefund : RecurlyEntity
     {
         public int AmountInCents { get; protected set; }
-        private Invoice.RefundOrderPriority RefundPriority;
+        private Invoice.RefundMethod RefundMethod;
 
-        internal OpenAmountRefund(int amountInCents, Invoice.RefundOrderPriority refundPriority = Invoice.RefundOrderPriority.Credit)
+        internal OpenAmountRefund(int amountInCents, Invoice.RefundMethod method = Invoice.RefundMethod.CreditFirst)
         {
             AmountInCents = amountInCents;
-            RefundPriority = refundPriority;
+            RefundMethod = method;
         }
 
         internal override void ReadXml(XmlTextReader reader)
@@ -21,7 +21,7 @@ namespace Recurly
         internal override void WriteXml(XmlTextWriter writer)
         {
             writer.WriteStartElement("invoice");
-            writer.WriteElementString("refund_apply_order", RefundPriority.ToString().ToLower());
+            writer.WriteElementString("refund_method", RefundMethod.ToString().ToLower());
             writer.WriteElementString("amount_in_cents", AmountInCents.AsString());
             writer.WriteEndElement();
         }

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -134,31 +134,31 @@ namespace Recurly
         /// <summary>
         /// Creates and invoices this purchase.
         /// </summary>
-        public static Invoice Invoice(Purchase purchase)
+        public static InvoiceCollection Invoice(Purchase purchase)
         {
-            var invoice = new Invoice();
+            var collection = new InvoiceCollection();
 
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 UrlPrefix, 
                 purchase.WriteXml,
-                invoice.ReadXml);
+                collection.ReadXml);
 
-            return invoice;
+            return collection;
         }
 
         /// <summary>
         /// Previews the invoice for this purchase. Runs validations but not transactions.
         /// </summary>
-        public static Invoice Preview(Purchase purchase)
+        public static InvoiceCollection Preview(Purchase purchase)
         {
-            var invoice = new Invoice();
+            var collection = new InvoiceCollection();
 
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 UrlPrefix + "preview/",
                 purchase.WriteXml,
-                invoice.ReadXml);
+                collection.ReadXml);
 
-            return invoice;
+            return collection;
         }
 
         /// <summary>
@@ -168,16 +168,16 @@ namespace Recurly
         /// has been completed on an external source (e.g. Adyen's Hosted
         /// Payment Pages).
         /// </summary>
-        public static Invoice Authorize(Purchase purchase)
+        public static InvoiceCollection Authorize(Purchase purchase)
         {
-            var invoice = new Invoice();
+            var collection = new InvoiceCollection();
 
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 UrlPrefix + "authorize/",
                 purchase.WriteXml,
-                invoice.ReadXml);
+                collection.ReadXml);
 
-            return invoice;
+            return collection;
         }
 
         #region Read and Write XML documents

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -65,12 +65,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AccountAcquisition.cs" />
+    <Compile Include="CreditPayment.cs" />
     <Compile Include="Delivery.cs" />
     <Compile Include="GiftCard.cs" />
     <Compile Include="Account.cs" />
     <Compile Include="AccountBalance.cs" />
     <Compile Include="Address.cs" />
     <Compile Include="FilterCriteria.cs" />
+    <Compile Include="InvoiceCollection.cs" />
+    <Compile Include="List\CreditPaymentList.cs" />
     <Compile Include="Purchase.cs" />
     <Compile Include="Errors.cs" />
     <Compile Include="Export.cs" />

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -68,6 +68,8 @@ namespace Recurly
             get { return _invoice ?? (_invoice = Invoices.Get(_invoiceNumber)); }
         }
 
+        public InvoiceCollection InvoiceCollection { get; private set; }
+
         private Plan _plan;
 
         public Plan Plan
@@ -639,6 +641,10 @@ namespace Recurly
                             _invoiceNumber = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
                         else
                             InvoicePreview = new Invoice(reader);
+                        break;
+
+                    case "invoice_collection":
+                        InvoiceCollection = new InvoiceCollection(reader);
                         break;
 
                     case "pending_subscription":

--- a/Test/Fixtures/invoices/create-201.xml
+++ b/Test/Fixtures/invoices/create-201.xml
@@ -6,7 +6,7 @@ Location: https://api.recurly.com/v2/invoices/created-invoice
 <invoice href="https://api.recurly.com/v2/invoices/012345678901234567890123456789ab">
   <account href="https://api.recurly.com/v2/accounts/abcdef1234567890"/>
   <uuid>012345678901234567890123456789ab</uuid>
-  <state>open</state>
+  <state>pending</state>
   <invoice_number type="integer">1000</invoice_number>
   <currency>USD</currency>
   <total_in_cents type="integer">300</total_in_cents>

--- a/Test/Fixtures/invoices/mark_successful-200.xml
+++ b/Test/Fixtures/invoices/mark_successful-200.xml
@@ -5,7 +5,7 @@ Content-Type: application/xml; charset=utf-8
 <invoice href="https://api.recurly.com/v2/invoices/abcdef1234567890">
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <uuid>012345678901234567890123456789aa</uuid>
-  <state>collected</state>
+  <state>paid</state>
   <invoice_number type="integer">abcdef1234567890</invoice_number>
   <po_number nil="nil"></po_number>
   <vat_number nil="nil"></vat_number>

--- a/Test/Fixtures/invoices/show-200.xml
+++ b/Test/Fixtures/invoices/show-200.xml
@@ -6,7 +6,7 @@ Content-Type: application/xml; charset=utf-8
   <account href="https://api.recurly.com/v2/accounts/1"/>
   <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
   <uuid>012345678901234567890123456789aa</uuid>
-  <state>collected</state>
+  <state>paid</state>
   <invoice_number type="integer">abcdef1234567890</invoice_number>
   <po_number></po_number>
   <vat_number></vat_number>

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -13,7 +13,7 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 5000, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var invoice = account.InvoicePendingCharges().ChargeInvoice;
             Assert.Equal("usst", invoice.TaxType);
             Assert.Equal(0.0875M, invoice.TaxRate.Value);
 
@@ -30,7 +30,8 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 5000, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
 
             var pdf = invoice.GetPdf();
 
@@ -51,9 +52,9 @@ namespace Recurly.Test
             adjustment = account.NewAdjustment("USD", -2500, "Test Credit");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var invoice = account.InvoicePendingCharges().ChargeInvoice;
 
-            invoice.State.Should().Be(Invoice.InvoiceState.Open);
+            invoice.State.Should().Be(Invoice.InvoiceState.Pending);
             invoice.TotalInCents.Should().Be(7500);
         }
 
@@ -71,7 +72,7 @@ namespace Recurly.Test
             adjustment = account.NewAdjustment("USD", -2500, "Test Credit");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges(new Invoice
+            var collection = account.InvoicePendingCharges(new Invoice
             {
                 CustomerNotes = "Some customer notes",
                 TermsAndConditions = "Some terms and conditions",
@@ -80,6 +81,8 @@ namespace Recurly.Test
                 NetTerms = 5,
                 PoNumber = "Some po number"
             });
+
+            var invoice = collection.ChargeInvoice;
 
             Assert.NotNull(invoice);
             Assert.Equal(invoice.CustomerNotes, "Some customer notes");
@@ -123,7 +126,7 @@ namespace Recurly.Test
             adjustment = account.NewAdjustment("USD", -2500, "Test Credit");
             adjustment.Create();
 
-            var invoice = account.PreviewInvoicePendingCharges(new Invoice
+            var collection = account.PreviewInvoicePendingCharges(new Invoice
             {
                 CustomerNotes = "Some customer notes",
                 TermsAndConditions = "Some terms and conditions",
@@ -132,6 +135,8 @@ namespace Recurly.Test
                 NetTerms = 5,
                 PoNumber = "Some po number"
             });
+
+            var invoice = collection.ChargeInvoice;
 
             Assert.NotNull(invoice);
             Assert.Equal(invoice.CustomerNotes, "Some customer notes");
@@ -169,13 +174,14 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
 
             invoice.MarkSuccessful();
 
             Assert.Equal(1, invoice.Adjustments.Count);
 
-            invoice.State.Should().Be(Invoice.InvoiceState.Collected);
+            invoice.State.Should().Be(Invoice.InvoiceState.Paid);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
@@ -186,7 +192,9 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
+
             invoice.MarkFailed();
             invoice.State.Should().Be(Invoice.InvoiceState.Failed);
             Assert.NotNull(invoice.ClosedAt);
@@ -200,11 +208,12 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
 
             invoice.MarkSuccessful();
 
-            invoice.State.Should().Be(Invoice.InvoiceState.Collected);
+            invoice.State.Should().Be(Invoice.InvoiceState.Paid);
 
             Assert.Equal(1, invoice.Adjustments.Count);
 
@@ -230,7 +239,8 @@ namespace Recurly.Test
             var adjustment2 = account.NewAdjustment("USD", 2, "Test Charge 2", 2);
             adjustment2.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
             invoice.MarkSuccessful();
 
             System.Threading.Thread.Sleep(2000); // hack
@@ -261,11 +271,12 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
 
             invoice.MarkSuccessful();
 
-            invoice.State.Should().Be(Invoice.InvoiceState.Collected);
+            invoice.State.Should().Be(Invoice.InvoiceState.Paid);
 
             Assert.Equal(1, invoice.Adjustments.Count);
 

--- a/Test/List/InvoiceListTest.cs
+++ b/Test/List/InvoiceListTest.cs
@@ -16,7 +16,8 @@ namespace Recurly.Test
                 var adjustment = acct.NewAdjustment("USD", 500 + x, "Test Charge");
                 adjustment.Create();
 
-                var invoice = acct.InvoicePendingCharges();
+                var collection = acct.InvoicePendingCharges();
+                var invoice = collection.ChargeInvoice;
 
                 if (x < 2)
                 {
@@ -47,7 +48,7 @@ namespace Recurly.Test
                 account.InvoicePendingCharges();
             }
 
-            var list = Invoices.List(Invoice.InvoiceState.Open);
+            var list = Invoices.List(Invoice.InvoiceState.Pending);
             list.Should().NotBeEmpty();
         }
 
@@ -59,11 +60,12 @@ namespace Recurly.Test
                 var acct = CreateNewAccount();
                 var adjustment = acct.NewAdjustment("USD", 500 + x, "Test Charge");
                 adjustment.Create();
-                var invoice = acct.InvoicePendingCharges();
+                var collection = acct.InvoicePendingCharges();
+                var invoice = collection.ChargeInvoice;
                 invoice.MarkSuccessful();
             }
 
-            var list = Invoices.List(Invoice.InvoiceState.Collected);
+            var list = Invoices.List(Invoice.InvoiceState.Paid);
             list.Should().NotBeEmpty();
         }
 
@@ -75,7 +77,8 @@ namespace Recurly.Test
                 var acct = CreateNewAccount();
                 var adjustment = acct.NewAdjustment("USD", 500 + x, "Test Charge");
                 adjustment.Create();
-                var invoice = acct.InvoicePendingCharges();
+                var collection = acct.InvoicePendingCharges();
+                var invoice = collection.ChargeInvoice;
                 invoice.MarkFailed();
             }
 
@@ -124,13 +127,15 @@ namespace Recurly.Test
             var adjustment = account.NewAdjustment("USD", 450, "Test Charge #1");
             adjustment.Create();
 
-            var invoice = account.InvoicePendingCharges();
+            var collection = account.InvoicePendingCharges();
+            var invoice = collection.ChargeInvoice;
             invoice.MarkSuccessful();
 
             adjustment = account.NewAdjustment("USD", 350, "Test Charge #2");
             adjustment.Create();
 
-            invoice = account.InvoicePendingCharges();
+            collection = account.InvoicePendingCharges();
+            invoice = collection.ChargeInvoice;
             invoice.MarkFailed();
 
             var list = Invoices.List(account.AccountCode);


### PR DESCRIPTION
This includes the changes needed for API version 2.10. There are a few breaking changes:

#### 1. InvoiceCollection

When creating or failing invoices, we now return an InvoiceCollection object rather than an Invoice. If you wish to upgrade your application without changing functionality, we recommend that you use the `ChargeInvoice` property on the InvoiceCollection to get the charge Invoice. Example:

```csharp
// Change this:
var invoice = account.InvoicePendingCharges();

// To this
var invoiceCollection = account.InvoicePendingCharges();
var invoice = invoiceCollection.ChargeInvoice;

// Invoice.MarkFailed now returns a new collection
// Change this
invoice.MarkFailed();

// To this
var invoiceCollection = invoice.MarkFailed();
var failedInvoice = invoiceCollection.ChargeInvoice;
```

#### 2. Invoice `Subtotal*` changes

If you want to preserve functionality, change any use of `Invoice#SubtotalAfterDiscountInCents` to `Invoice#SubtotalInCents`. If you were previously using `Invoice#SubtotalInCents`, this has been changed to `Invoice#SubtotalBeforeDiscountInCents`.

#### 3. Invoice Refund -- `refund_apply_order` changed to `refund_method`

The `RefundOrderPriority` enum was changed to `RefundMethod`. Change use of `RefundOrderPriority.Credit` to `RefundMethod.CreditFirst` and `RefundOrderPriority.Transaction` to `RefundMethod.TransactionFirst`.


#### 4. Invoice States

If you are checking `Invoice#State` anywhere, you will want to check that you have the new correct values. `collected` has changed to `paid` and `open` has changed to `pending`. Example:

```csharp
// Change this
if (invoice.State == Invoice.InvoiceState.Collected) {
// To this
if (invoice.State == Invoice.InvoiceState.Paid) {

// Change this
if (invoice.State == Invoice.InvoiceState.Open) {
// To this
if (invoice.State == Invoice.InvoiceState.Pending) {
```

#### 5. Invoices on Subscription Previews

If you are using `Subscription#Invoice` on subscription previews, you will need to change this to use `Subscription#InvoiceCollection`. To keep functionality the same:

```csharp
// Change this
subscription.Preview();
var invoice = subscription.Invoice;

// To this
subscription.Preview();
var invoice = subscription.InvoiceCollection.ChargeInvoice;
```

