### PR TITLE
fix typo in Subscription#pause

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -569,6 +569,7 @@ namespace Recurly
 
                 DateTime dateVal;
                 Int32 billingCycles;
+                Int32 pauseCycles;
 
                 switch (reader.Name)
                 {
@@ -694,7 +695,7 @@ namespace Recurly
                         break;
 
                     case "remaining_pause_cycles":
-                        if (Int32.TryParse(reader.ReadElementContentAsString(), out int pauseCycles))
+                        if (Int32.TryParse(reader.ReadElementContentAsString(), out pauseCycles))
                             RemainingPauseCycles = pauseCycles;
                         break;
 

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -253,6 +253,7 @@ namespace Recurly
         public Invoice InvoicePreview { get; private set; }
         public int? TotalBillingCycles { get; set; }
         public int? RemainingBillingCycles { get; private set; }
+        public int? RemainingPauseCycles { get; private set; }
         public DateTime? FirstRenewalDate { get; set; }
 
         internal const string UrlPrefix = "/subscriptions/";
@@ -487,9 +488,9 @@ namespace Recurly
                 ReadXml);
         }
 
-        public void Pause(int remainingBillingCycles)
+        public void Pause(int remainingPauseCycles)
         {
-            RemainingBillingCycles = remainingBillingCycles;
+            RemainingPauseCycles = remainingPauseCycles;
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                 UrlPrefix + Uri.EscapeDataString(Uuid) + "/pause",
                 WritePauseXml,
@@ -692,6 +693,11 @@ namespace Recurly
                             RemainingBillingCycles = billingCycles;
                         break;
 
+                    case "remaining_pause_cycles":
+                        if (Int32.TryParse(reader.ReadElementContentAsString(), out int pauseCycles))
+                            RemainingPauseCycles = pauseCycles;
+                        break;
+
                     case "tax_in_cents":
                         TaxInCents = reader.ReadElementContentAsInt();
                         break;
@@ -784,7 +790,7 @@ namespace Recurly
         internal void WritePauseXml(XmlTextWriter xmlWriter)
         {
             xmlWriter.WriteStartElement("subscription"); // Start: subscription
-            xmlWriter.WriteElementString("remaining_billing_cycles", RemainingBillingCycles.Value.AsString());
+            xmlWriter.WriteElementString("remaining_pause_cycles", RemainingPauseCycles.Value.AsString());
             xmlWriter.WriteEndElement();
         }
 


### PR DESCRIPTION
Hi, when I try to pause a subscription, I get an error from the server that the field 'remaining_pause_cycles' is required. After these changes, the pause is working.