### PR TITLE
Fix missing `company` field when updating `BillingInfo` instances

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -213,6 +213,10 @@ namespace Recurly
 
                 switch (reader.Name)
                 {
+                    case "billing_info":
+                        // The element's opening tag - nothing to do
+                        break;
+
                     case "account":
                         var href = reader.GetAttribute("href");
                         AccountCode = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
@@ -321,6 +325,10 @@ namespace Recurly
                             UpdatedAt = d;
                         }
                         break;
+
+                    default:
+                        Debug.WriteLine("Recurly Client Library: Unexpected XML field in response - " + reader.Name);
+                        break;
                 }
             }
         }
@@ -334,6 +342,7 @@ namespace Recurly
             {
                 xmlWriter.WriteStringIfValid("first_name", FirstName);
                 xmlWriter.WriteStringIfValid("last_name", LastName);
+                xmlWriter.WriteStringIfValid("company", Company);
                 xmlWriter.WriteStringIfValid("name_on_account", NameOnAccount);
                 xmlWriter.WriteStringIfValid("address1", Address1);
                 xmlWriter.WriteStringIfValid("address2", Address2);

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Recurly.Test
@@ -109,15 +109,21 @@ namespace Recurly.Test
             {
                 FirstName = account.FirstName,
                 LastName = account.LastName,
+                Company = "Acme Software",
+                PhoneNumber = "916-555-0101",
+                VatNumber = "12345",
                 Address1 = "123 Test St",
+                Address2 = "The Test Cut",
                 City = "San Francisco",
+                PostalCode = "94105",
                 State = "CA",
                 Country = "US",
-                PostalCode = "94105",
-                ExpirationMonth = DateTime.Now.Month,
-                ExpirationYear = DateTime.Now.Year + 1,
+                Currency = "USD",   // Should really be a different currency for testing but test environment doesn't seem set up for multi-currency
+                IpAddress = "93.184.216.34",    // Address currently hosting example.com domain
                 CreditCardNumber = TestCreditCardNumbers.Visa1,
-                VerificationValue = "123"
+                VerificationValue = "123",
+                ExpirationMonth = DateTime.Now.Month,
+                ExpirationYear = DateTime.Now.Year + 1
             };
             return billingInfo;
         }
@@ -128,15 +134,21 @@ namespace Recurly.Test
             {
                 FirstName = "John",
                 LastName = "Smith",
+                Company = "Acme Software",
+                PhoneNumber = "916-555-0101",
+                VatNumber = "12345",
                 Address1 = "123 Test St",
+                Address2 = "The Test Cut",
                 City = "San Francisco",
+                PostalCode = "94105",
                 State = "CA",
                 Country = "US",
-                PostalCode = "94105",
-                ExpirationMonth = DateTime.Now.Month,
-                ExpirationYear = DateTime.Now.Year + 1,
+                Currency = "USD",   // Should really be a different currency for testing but test environment doesn't seem set up for multi-currency
+                IpAddress = "93.184.216.34",    // Address currently hosting example.com domain
                 CreditCardNumber = TestCreditCardNumbers.Visa1,
-                VerificationValue = "123"
+                VerificationValue = "123",
+                ExpirationMonth = DateTime.Now.Month,
+                ExpirationYear = DateTime.Now.Year + 1
             };
         }
 

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Xunit;
 using Xunit.Extensions;
@@ -15,7 +15,20 @@ namespace Recurly.Test
 
             var info = NewBillingInfo(account);
             info.FirstName = "Jane";
-            info.LastName = "Smith";
+            info.LastName = "Jones";
+            info.Company = "St Agatha's Home for the Bewildered";
+            info.PhoneNumber = "020	7946 0001";
+            info.VatNumber = "GB123456789";
+            info.Address1 = "Parliament Square";
+            info.Address2 = "Testminster";
+            info.City = "London";
+            info.PostalCode = "SW1A 0PW";
+            info.State = "";
+            info.Country = "GB";
+            info.Currency = "USD";   // Should really be a different currency for testing but test environment doesn't seem set up for multi-currency
+            info.IpAddress = "192.0.2.1";    // Reserved address for "TEST-NET-1" (so no country)
+            info.CreditCardNumber = TestCreditCardNumbers.MasterCard1;
+            info.VerificationValue = "321";
             info.ExpirationMonth = DateTime.Now.AddMonths(3).Month;
             info.ExpirationYear = DateTime.Now.AddYears(3).Year;
             info.Update();
@@ -26,6 +39,29 @@ namespace Recurly.Test
             get.BillingInfo.LastName.Should().Be("Smith");
             get.BillingInfo.ExpirationMonth.Should().Be(DateTime.Now.AddMonths(3).Month);
             get.BillingInfo.ExpirationYear.Should().Be(DateTime.Now.AddYears(3).Year);
+            get.BillingInfo.AccountCode.Should().Be(info.AccountCode);
+            get.BillingInfo.FirstName.Should().Be(info.FirstName);
+            get.BillingInfo.LastName.Should().Be(info.LastName);
+            get.BillingInfo.Company.Should().Be(info.Company);
+            get.BillingInfo.PhoneNumber.Should().Be(info.PhoneNumber);
+            get.BillingInfo.VatNumber.Should().Be(info.VatNumber);
+            get.BillingInfo.Address1.Should().Be(info.Address1);
+            get.BillingInfo.Address2.Should().Be(info.Address2);
+            get.BillingInfo.City.Should().Be(info.City);
+            get.BillingInfo.PostalCode.Should().Be(info.PostalCode);
+            get.BillingInfo.State.Should().Be(info.State);
+            get.BillingInfo.Country.Should().Be(info.Country);
+            get.BillingInfo.Currency.Should().BeNull();   // Currency not returned unless not set to the default (and test environment doesn't seem set up for multi-currency)
+            (DateTime.Now - get.BillingInfo.UpdatedAt).TotalMinutes.Should().BeLessThan(1.0);
+            get.BillingInfo.IpAddress.Should().Be(info.IpAddress);
+            get.BillingInfo.IpAddressCountry.Should().Be(string.Empty);
+            get.BillingInfo.CreditCardNumber.Should().BeNull();
+            get.BillingInfo.VerificationValue.Should().BeNull();
+            get.BillingInfo.ExpirationMonth.Should().Be(info.ExpirationMonth);
+            get.BillingInfo.ExpirationYear.Should().Be(info.ExpirationYear);
+            get.BillingInfo.CardType.Should().Be(info.CardType);
+            get.BillingInfo.FirstSix.Should().Be(info.CreditCardNumber.Substring(0, 6));
+            get.BillingInfo.LastFour.Should().Be(info.CreditCardNumber.Last(4));
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
@@ -61,10 +97,29 @@ namespace Recurly.Test
 
             var get = Accounts.Get(accountCode);
 
+            get.BillingInfo.AccountCode.Should().Be(info.AccountCode);
             get.BillingInfo.FirstName.Should().Be(info.FirstName);
             get.BillingInfo.LastName.Should().Be(info.LastName);
+            get.BillingInfo.Company.Should().Be(info.Company);
+            get.BillingInfo.PhoneNumber.Should().Be(info.PhoneNumber);
+            get.BillingInfo.VatNumber.Should().Be(info.VatNumber);
+            get.BillingInfo.Address1.Should().Be(info.Address1);
+            get.BillingInfo.Address2.Should().Be(info.Address2);
+            get.BillingInfo.City.Should().Be(info.City);
+            get.BillingInfo.PostalCode.Should().Be(info.PostalCode);
+            get.BillingInfo.State.Should().Be(info.State);
+            get.BillingInfo.Country.Should().Be(info.Country);
+            get.BillingInfo.Currency.Should().BeNull();   // Currency not returned unless not set to the default (and test environment doesn't seem set up for multi-currency)
+            (DateTime.Now - get.BillingInfo.UpdatedAt).TotalMinutes.Should().BeLessThan(1.0);
+            get.BillingInfo.IpAddress.Should().Be(info.IpAddress);
+            get.BillingInfo.IpAddressCountry.Should().Be("US");
+            get.BillingInfo.CreditCardNumber.Should().BeNull();
+            get.BillingInfo.VerificationValue.Should().BeNull();
             get.BillingInfo.ExpirationMonth.Should().Be(info.ExpirationMonth);
             get.BillingInfo.ExpirationYear.Should().Be(info.ExpirationYear);
+            get.BillingInfo.CardType.Should().Be(info.CardType);
+            get.BillingInfo.FirstSix.Should().Be(info.CreditCardNumber.Substring(0, 6));
+            get.BillingInfo.LastFour.Should().Be(info.CreditCardNumber.Last(4));
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]


### PR DESCRIPTION
Resolves #292

Now includes the `company` field when writing the XML for updating a `BillingInfo` instance.

Also added a `Debug` statement to identify any unhandled fields during reading of XML (noticed that `currency` field isn't currently included but don't think that can be tested unless the environment is configured for multi-currency).

Related tests expanded to include all relevant `BillingInfo` properties.
 