### PR TITLE
Fix unit amount in cents for usage add ons

### DIFF
--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -70,7 +70,9 @@ namespace Recurly
                     "The given AddOn does not have UnitAmountInCents for the currency of the subscription (" + _subscription.Currency + ")."
                     , new Errors());
             }
-            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, planAddOn.AddOnType, amount, quantity);
+            int? unitAmountInCents = planAddOn.AddOnType.HasValue && (planAddOn.AddOnType.Value == AddOn.Type.Usage) ? (int?)null : amount;
+
+            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, planAddOn.AddOnType, unitAmountInCents, quantity);
             base.Add(sub);
         }
 

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -7,7 +7,7 @@ namespace Recurly
     {
         public string AddOnCode { get; set; }
         public AddOn.Type? AddOnType { get; set; }
-        public int UnitAmountInCents { get; set; }
+        public int? UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
 
@@ -17,7 +17,7 @@ namespace Recurly
         }
 
         // keep old constructor
-        public SubscriptionAddOn(string addOnCode, int unitAmountInCents, int quantity = 1)
+        public SubscriptionAddOn(string addOnCode, int? unitAmountInCents, int quantity = 1)
         {
             AddOnCode = addOnCode;
             UnitAmountInCents = unitAmountInCents;
@@ -25,7 +25,7 @@ namespace Recurly
         }
 
         // new constructor including addOnType (recommended)
-        public SubscriptionAddOn(string addOnCode, AddOn.Type? addOnType, int unitAmountInCents, int quantity = 1)
+        public SubscriptionAddOn(string addOnCode, AddOn.Type? addOnType, int? unitAmountInCents, int quantity = 1)
         {
             AddOnCode = addOnCode;
             AddOnType = addOnType;
@@ -75,7 +75,9 @@ namespace Recurly
 
             writer.WriteElementString("add_on_code", AddOnCode);
             writer.WriteElementString("quantity", Quantity.AsString());			
-            writer.WriteElementString("unit_amount_in_cents", UnitAmountInCents.AsString());
+
+            if(UnitAmountInCents.HasValue)
+                writer.WriteElementString("unit_amount_in_cents", UnitAmountInCents.Value.AsString());
 
             if (RevenueScheduleType.HasValue)
                 writer.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());


### PR DESCRIPTION
We are getting the following error when we try to create a new subscription with a Usage addon type:

Message: {usagePriceInDecimalUnits is not allowed when PricingType is USAGE. | Field: "subscription.base" Code: "" Symbol: "field_mismatch_not_allowed" Details: ""} 

The problem is that the field unitamountincents was being provided with 0 automatically. With this pull request fix this error.

Regards,