### PR TITLE
Bump 1.12.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,17 @@
 Unreleased
 ===============
 
+1.12.0 (stable) / 2018-05-29
+===============
+
+* Fix unit amount in cents for usage add ons
+* Expose subs accountcode to avoid unnecessary api requests
+
+###Upgrade Notes
+
+SubscriptionAddOn#UnitAmountInCents was changed to nullable type. If you do not read this value, no change is needed.
+
+
 1.11.4 (stable) / 2018-05-16
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.11.4.0")]
-[assembly: AssemblyFileVersion("1.11.4.0")]
+[assembly: AssemblyVersion("1.12.0.0")]
+[assembly: AssemblyFileVersion("1.12.0.0")]


### PR DESCRIPTION
* Fix unit amount in cents for usage add ons #298 
* Expose subs accountcode to avoid unnecessary api requests #296 

###Upgrade Notes 

 `SubscriptionAddOn#UnitAmountInCents` was changed to nullable type. If you do not read this value, no change is needed. 