### PR TITLE
Fix usages Id parsing bug

### DIFF
--- a/Library/List/UsageList.cs
+++ b/Library/List/UsageList.cs
@@ -50,7 +50,8 @@ namespace Recurly
 
                 if (reader.NodeType == XmlNodeType.Element && reader.Name == "usage")
                 {
-                    Add(new Usage(reader));
+                    var href = reader.GetAttribute("href");
+                    Add(new Usage(reader, href));
                 }
             }
         }


### PR DESCRIPTION
Resolves #304 

I've adapted the code initially reported to test this:

```csharp
var subUuid = "4568de9b86ec93f7a875e446aca2f694";
var addonCode = "usage-code";
var quantity = 1;
var usage = new Recurly.Usage(subUuid, addonCode);
usage.Amount = quantity;
usage.Create();

var usages = Recurly.Usages.List(subUuid, addonCode);

usage = usages.FirstOrDefault();
usage.Amount = quantity;
usage.Update();