### PR TITLE
Transaction should parse embedded account

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -444,9 +444,13 @@ namespace Recurly
                         AccountCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "billing_info":
+                        BillingInfo = new BillingInfo(reader);
+                        break;
+
                     case "state":
                         // TODO investigate in case of incoming data representing multiple states, as https://dev.recurly.com/docs/get-account says is possible
-                        State = reader.ReadElementContentAsString().ParseAsEnum<AccountState>();
+                         State = reader.ReadElementContentAsString().ParseAsEnum<AccountState>();
                         break;
 
                     case "username":

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -157,6 +157,11 @@ namespace Recurly
             AccountCode = account.AccountCode;
         }
 
+        internal BillingInfo(XmlTextReader reader)
+        {
+            ReadXml(reader);
+        }
+
         private BillingInfo()
         {
         }

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -176,7 +176,13 @@ namespace Recurly
                     case "account":
                         href = reader.GetAttribute("href");
                         if (null != href)
+                        {
                             AccountCode = Uri.UnescapeDataString(href.Substring(href.LastIndexOf("/") + 1));
+                        } 
+                        else
+                        {
+                            Account = new Account(reader);
+                        }
                         break;
 
                     case "invoice":


### PR DESCRIPTION
The Transaction class was only parsing links to accounts. We want to parse the embedded Account if it's embedded (since it may contain a snapshot of information). We also want to parse the embedded BillingInfo in Account if it exists for similar reasons.

Testing:

```csharp
var transaction = Transactions.Get("4573206f388c4eb391da9d42109329437");
Console.WriteLine(transaction.Account.AccountCode);
Console.WriteLine(transaction.Account.BillingInfo.CardType);
```
