### PR TITLE
#312 - Subscription.Coupon throws an ArgumentNullException, if _couponCode is null

### DIFF
--- a/Library/Coupon.cs
+++ b/Library/Coupon.cs
@@ -532,6 +532,11 @@ namespace Recurly
         /// <returns></returns>
         public static Coupon Get(string couponCode)
         {
+            if (string.IsNullOrWhiteSpace(couponCode))
+            {
+                return null;
+            }
+
             var coupon = new Coupon();
 
             var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -199,7 +199,15 @@ namespace Recurly
         /// </summary>
         public Coupon Coupon
         {
-            get { return _coupon ?? (_coupon = Recurly.Coupons.Get(_couponCode)); }
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_couponCode))
+                {
+                    return null;
+                }
+
+                return _coupon ?? (_coupon = Recurly.Coupons.Get(_couponCode));
+            }
             set
             {
                 _coupon = value;

--- a/Test/CouponTest.cs
+++ b/Test/CouponTest.cs
@@ -173,5 +173,26 @@ namespace Recurly.Test
             coupon.Should().NotBeNull();
             coupon.State.Should().Be(Coupon.CouponState.Inactive);
         }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void GetCouponWithNullCouponCodeIsNull()
+        {
+            var nullCoupon = Coupons.Get(null);
+            Assert.Equal(null, nullCoupon);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void GetCouponWithEmptyCouponCodeIsNull()
+        {
+            var emptyCoupon = Coupons.Get("");
+            Assert.Equal(null, emptyCoupon);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void GetCouponWithWhitespaceCouponCodeIsNull()
+        {
+            var whitespaceCoupon = Coupons.Get("  ");
+            Assert.Equal(null, whitespaceCoupon);
+        }
     }
 }

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -30,6 +30,29 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void LookupSubscriptionWithNullCouponCode()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Lookup Subscription Test" };
+            plan.UnitAmountInCents.Add("USD", 1500);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.Create();
+
+            sub.ActivatedAt.Should().HaveValue().And.NotBe(default(DateTime));
+            sub.State.Should().Be(Subscription.SubscriptionState.Active);
+
+            Assert.Equal(null, sub.Coupon);
+
+            var fromService = Subscriptions.Get(sub.Uuid);
+
+            fromService.Should().Be(sub);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void LookupSubscriptionPendingChanges()
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName())

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -9,7 +9,7 @@ namespace Recurly.Test
     public class SubscriptionTest : BaseTest
     {
         [RecurlyFact(TestEnvironment.Type.Integration)]
-        public void LookupSubscription()
+        public Subscription LookupSubscription()
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Lookup Subscription Test" };
             plan.UnitAmountInCents.Add("USD", 1500);
@@ -27,29 +27,14 @@ namespace Recurly.Test
             var fromService = Subscriptions.Get(sub.Uuid);
 
             fromService.Should().Be(sub);
+            return sub;
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void LookupSubscriptionWithNullCouponCode()
         {
-            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Lookup Subscription Test" };
-            plan.UnitAmountInCents.Add("USD", 1500);
-            plan.Create();
-            PlansToDeactivateOnDispose.Add(plan);
-
-            var account = CreateNewAccountWithBillingInfo();
-
-            var sub = new Subscription(account, plan, "USD");
-            sub.Create();
-
-            sub.ActivatedAt.Should().HaveValue().And.NotBe(default(DateTime));
-            sub.State.Should().Be(Subscription.SubscriptionState.Active);
-
+            var sub = LookupSubscription();
             Assert.Equal(null, sub.Coupon);
-
-            var fromService = Subscriptions.Get(sub.Uuid);
-
-            fromService.Should().Be(sub);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]

--- a/Test/TestEnvironment.cs
+++ b/Test/TestEnvironment.cs
@@ -17,7 +17,8 @@ namespace Recurly.Test
         public Type[] Supports;
         public enum Type
         {
-            Integration
+            Integration,
+            Unit
         };
 
         private bool IsTravis;


### PR DESCRIPTION
Addresses https://github.com/recurly/recurly-client-net/issues/312 where Subscription.Coupon would fail if the underlying coupon code was null.

* Updates `Coupons.Get(couponCode)` to return null when the provided couponCode is null or whitespace, preventing a call to Recurly. 
* Updates `Subscription.Coupon` to return null if `_couponCode` is null or whitespace.  However, this does not set the underlying `_coupon` object in the event `_couponCode` is updated elsewhere.
* Adds `TestEnvironment.Type.Unit` for tests, since the tests added do not rely on a web call out.
* Adds tests to `CouponTest` that verifies null is returned for the three scenarios provided, and that the functionality remains consistent.
* Adds tests to `SubscriptionTest` to verify that `Subscription` will receive null, rather than an error when the `_couponCode` is not set.