### PR TITLE
Bump 1.12.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,16 @@
 Unreleased
 ===============
 
+1.12.2 (stable) / 2018-06-26
+===============
+
+This release brings us to API version 2.13 but does not have any breaking changes.
+
+* Allow programmer to set gateway code per purchase
+* Add link to all_transactions on Invoice
+* Subscription Terms
+* Subscription.Coupon throws an ArgumentNullException if couponCode is null. Now returns null.
+
 1.12.1 (stable) / 2018-06-22
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.12.1.0")]
-[assembly: AssemblyFileVersion("1.12.1.0")]
+[assembly: AssemblyVersion("1.12.2.0")]
+[assembly: AssemblyFileVersion("1.12.2.0")]


### PR DESCRIPTION
This release brings us to API version 2.13 but does not have any breaking changes.

* Allow programmer to set gateway code per purchase #303 
* Add link to all_transactions on Invoice #302 
* Subscription Terms #311 
* Subscription.Coupon throws an ArgumentNullException, if _couponCode is null. Now returns null. #313 