### PR TITLE
Allow more nulls in BillingInfo

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -455,7 +455,7 @@ namespace Recurly
 
                     case "state":
                         // TODO investigate in case of incoming data representing multiple states, as https://dev.recurly.com/docs/get-account says is possible
-                         State = reader.ReadElementContentAsString().ParseAsEnum<AccountState>();
+                        State = reader.ReadElementContentAsString().ParseAsEnum<AccountState>();
                         break;
 
                     case "username":

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -284,17 +284,23 @@ namespace Recurly
                         break;
 
                     case "card_type":
-                        CardType = reader.ReadElementContentAsString().ParseAsEnum<CreditCardType>();
+                        var type = reader.ReadElementContentAsString();
+                        if (!type.IsNullOrEmpty())
+                            CardType = type.ParseAsEnum<CreditCardType>();
                         break;
 
                     case "year":
-                        ExpirationYear = reader.ReadElementContentAsInt();
+                        int y;
+                        if (int.TryParse(reader.ReadElementContentAsString(), out y))
+                            ExpirationYear = y;
                         break;
 
                     case "month":
-                        ExpirationMonth = reader.ReadElementContentAsInt();
+                        int m;
+                        if (int.TryParse(reader.ReadElementContentAsString(), out m))
+                            ExpirationMonth = m;
                         break;
-
+                        
                     case "first_six":
                         FirstSix = reader.ReadElementContentAsString();
                         break;


### PR DESCRIPTION
This PR allows `CardType`, `Month`, and `Year` to be null. It prevents exceptions when parsing.