### PR TITLE
Upgrade mono to fix TLS issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 dist: trusty
 mono:
-  - 4.6.2
+  - 4.8.1
 solution: Recurly.sln
 install:
   - nuget restore Recurly.sln


### PR DESCRIPTION
Upgrades mono to 4.8 to fix the failing tests.