### PR TITLE
2.13 Custom Fields Support

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -135,6 +135,16 @@ namespace Recurly
         }
         private List<ShippingAddress> _shippingAddresses;
 
+        /// <summary>
+        /// List of custom fields
+        /// </summary>
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
+        private List<CustomField> _customFields;
+
         internal const string UrlPrefix = "/accounts/";
 
         public Account(string accountCode)
@@ -559,6 +569,20 @@ namespace Recurly
                     case "preferred_locale":
                         PreferredLocale = reader.ReadElementContentAsString();
                         break;
+
+                    case "custom_fields":
+                        CustomFields = new List<CustomField>();
+                        while (reader.Read())
+                        {
+                            if (reader.Name == "custom_fields" && reader.NodeType == XmlNodeType.EndElement)
+                                break;
+
+                            if (reader.NodeType == XmlNodeType.Element && reader.Name == "custom_field")
+                            {
+                                CustomFields.Add(new CustomField(reader));
+                            }
+                        }
+                        break;
                 }
             }
         }
@@ -585,6 +609,7 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("preferred_locale", PreferredLocale);
 
             xmlWriter.WriteIfCollectionHasAny("shipping_addresses", ShippingAddresses);
+            xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
             if (TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());

--- a/Library/CustomField.cs
+++ b/Library/CustomField.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Recurly
+{
+    public class CustomField : RecurlyEntity
+    {
+        public string Name;
+        public string Value;
+
+        public CustomField() { }
+
+        public CustomField(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
+
+        internal CustomField(XmlTextReader reader) : this()
+        {
+            ReadXml(reader);
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                // End of custom_field element, get out of here
+                if (reader.Name == "custom_field" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                switch (reader.Name)
+                {
+                    case "name":
+                        Name = reader.ReadElementContentAsString();
+                        break;
+                    case "value":
+                        Value = reader.ReadElementContentAsString();
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("custom_field");
+
+            xmlWriter.WriteElementString("name", Name);
+            xmlWriter.WriteElementString("value", Value);
+
+            xmlWriter.WriteEndElement();
+        }
+    }
+}

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="AccountAcquisition.cs" />
     <Compile Include="CreditPayment.cs" />
+    <Compile Include="CustomField.cs" />
     <Compile Include="Delivery.cs" />
     <Compile Include="GiftCard.cs" />
     <Compile Include="Account.cs" />

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -104,6 +104,16 @@ namespace Recurly
 
         public long? ShippingAddressId { get; set; }
 
+        /// <summary>
+        /// List of custom fields
+        /// </summary>
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
+        private List<CustomField> _customFields;
+
         public string Uuid { get; private set; }
 
         public SubscriptionState State { get; private set; }
@@ -703,6 +713,20 @@ namespace Recurly
                         AddOns.ReadXml(reader);
                         break;
 
+                    case "custom_fields":
+                        CustomFields = new List<CustomField>();
+                        while (reader.Read())
+                        {
+                            if (reader.Name == "custom_fields" && reader.NodeType == XmlNodeType.EndElement)
+                                break;
+
+                            if (reader.NodeType == XmlNodeType.Element && reader.Name == "custom_field")
+                            {
+                                CustomFields.Add(new CustomField(reader));
+                            }
+                        }
+                        break;
+
                     case "invoice":
                         href = reader.GetAttribute("href");
                         if (!href.IsNullOrEmpty())
@@ -974,6 +998,8 @@ namespace Recurly
 
             if (RenewalBillingCycles.HasValue)
                 xmlWriter.WriteElementString("renewal_billing_cycles", RenewalBillingCycles.Value.AsString());
+
+            xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
             xmlWriter.WriteEndElement(); // End: subscription
         }

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FluentAssertions;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Recurly.Test
 {
@@ -19,6 +20,9 @@ namespace Recurly.Test
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void CreateAccountWithParameters()
         {
+            var customFields = new List<CustomField>();
+            customFields.Add(new CustomField("food", "taco"));
+
             var acct = new Account(GetUniqueAccountCode())
             {
                 Username = "testuser1",
@@ -31,7 +35,8 @@ namespace Recurly.Test
                 TaxExempt = true,
                 EntityUseCode = "I",
                 CcEmails = "cc1@test.com,cc2@test.com",
-                Address = new Address()
+                Address = new Address(),
+                CustomFields = customFields
             };
 
             string address = "123 Faux Street";
@@ -51,6 +56,8 @@ namespace Recurly.Test
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
             Assert.False(acct.VatLocationValid);
+            Assert.Equal(acct.CustomFields.First().Name, "food");
+            Assert.Equal(acct.CustomFields.First().Value, "taco");
         }
 
         [Fact]

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -72,10 +72,10 @@ namespace Recurly.Test
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
 
-            var account = CreateNewAccountWithBillingInfo();
-
+            var account = CreateNewAccountWithBillingInfo();            
             var coup = CreateNewCoupon(3);
             var sub = new Subscription(account, plan, "USD");
+            sub.CustomFields.Add(new CustomField("food", "taco"));
             sub.TotalBillingCycles = 5;
             sub.Coupon = coup;
             Assert.Null(sub.TaxInCents);
@@ -93,7 +93,8 @@ namespace Recurly.Test
 
             var sub1 = Subscriptions.Get(sub.Uuid);
             Assert.Equal(5, sub1.TotalBillingCycles);
-
+            Assert.Equal(sub1.CustomFields.First().Name, "food");
+            Assert.Equal(sub1.CustomFields.First().Value, "taco");
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]


### PR DESCRIPTION
Adds custom fields support to Account and Subscription. This also works when embedding them in a Purchase.

```csharp
var account = Accounts.Get("c4ac4481");
foreach (var f in account.CustomFields)
{
  Console.WriteLine(f.Name);
  Console.WriteLine(f.Value);
}
// Setting the value to null will clear the field
//account.CustomFields[0].Value = null;
account.CustomFields[0].Value = "new-value";
// Add a new custom field
account.CustomFields.Add(new CustomField("topping", "lettuce"));
account.Update();  
```