### PR TITLE
All pagination to continue without state.

### DIFF
--- a/Library/List/AccountList.cs
+++ b/Library/List/AccountList.cs
@@ -23,6 +23,11 @@ namespace Recurly
 
         }
 
+        public static AccountList Continue(string continuationToken)
+        {
+            return new AccountList(continuationToken);
+        }
+
         public override RecurlyList<Account> Start
         {
             get { return HasStartPage() ? new AccountList(StartUrl) : RecurlyList.Empty<Account>(); }

--- a/Library/List/RecurlyList.cs
+++ b/Library/List/RecurlyList.cs
@@ -18,6 +18,7 @@ namespace Recurly
         protected string NextUrl { get; set; }
         protected string PrevUrl { get; set; }
         protected int PerPage { get; set; }
+        public string ContinuationToken { get { return NextUrl; } }
 
         public int Count
         {

--- a/Library/List/SubscriptionList.cs
+++ b/Library/List/SubscriptionList.cs
@@ -8,6 +8,11 @@ namespace Recurly
         {
         }
 
+        public static SubscriptionList Continue(string continuationToken)
+        {
+            return new SubscriptionList(continuationToken);
+        }
+
         public override RecurlyList<Subscription> Start
         {
             get { return HasStartPage() ? new SubscriptionList(StartUrl) : RecurlyList.Empty<Subscription>(); }


### PR DESCRIPTION
Allow stateless servers to return a continuation token and then use the token to continue the iteration.