### PR TITLE
Allow updating custom fields through /notes endpoint

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -329,13 +329,13 @@ namespace Recurly
 
         /// <summary>
         /// Determines the renewal subscription term.
-        /// Defaults to plan’s total billing cycles value unless
+        /// Defaults to plans total billing cycles value unless
         /// overwritten when creating the subscription or editing subscription. 
         /// </summary>
         public int? RenewalBillingCycles { get; set; }
 
         /// <summary>
-        /// Previously named first_renewal_date. Forces the subscription’s next billing period start date.
+        /// Previously named first_renewal_date. Forces the subscriptions next billing period start date.
         /// Subsequent billing period start dates will be offset from this date.
         /// The first invoice will be prorated appropriately so that the customer pays
         /// for the portion of the first billing period for which the subscription applies. 
@@ -344,18 +344,18 @@ namespace Recurly
 
         /// <summary>
         /// Previously named next_renewal_date. Specifies a future date that 
-        /// the subscription’s next billing period should be billed.
+        /// the subscriptions next billing period should be billed.
         /// </summary>
         public DateTime NextBillDate { get; private set; }
 
         /// <summary>
-        /// Start date of the subscription’s current term. Will equal the future start
+        /// Start date of the subscriptions current term. Will equal the future start
         /// date if subscription was created in the future state.
         /// </summary>
         public DateTime CurrentTermStartedAt { get; private set; }
 
         /// <summary>
-        /// End date of the subscription’s current term. Will be nil
+        /// End date of the subscriptions current term. Will be nil
         /// if subscription has future start date.
         /// </summary>
         public DateTime CurrentTermEndsAt { get; private set; }
@@ -1058,6 +1058,7 @@ namespace Recurly
                 xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
                 xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
                 xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
+                xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
                 xmlWriter.WriteEndElement(); // End: subscription
             };

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -400,12 +400,15 @@ namespace Recurly.Test
             notes.Add("CustomerNotes", "New Customer Notes");
             notes.Add("TermsAndConditions", "New T and C");
             notes.Add("VatReverseChargeNotes", "New VAT Notes");
+            sub.CustomFields.Add(new CustomField("food", "taco"));
 
             sub.UpdateNotes(notes);
 
             sub.CustomerNotes.Should().Be(notes["CustomerNotes"]);
             sub.TermsAndConditions.Should().Be(notes["TermsAndConditions"]);
             sub.VatReverseChargeNotes.Should().Be(notes["VatReverseChargeNotes"]);
+            sub.CustomFields.Should().Contain(cf => cf.Name == "food");
+            sub.CustomFields.Should().Contain(cf => cf.Value == "taco");
 
         }
 


### PR DESCRIPTION
The changes at lines 332, 338, 347, 352 and 358 remove an invisible character that is unrecognized by OSX. Since it's all in the comments, I figured it's not a problem to remove that character.