### PR TITLE
Bump 1.13.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,21 @@
 Unreleased
 ===============
 
+1.13.0 (stable) / 2018-09-11
+===============
+
+* Allow updating custom fields through /notes endpoint
+* Add ability to update an invoice
+* Remove reference to unused ruleset
+* Upgrade .NET 4.7 and scripts folder
+* Allow test script to run a single method
+* Fix integration tests so they all pass
+
+### Upgrade Notes
+
+This release brings us up to API version 2.14. The build now targets .NET v4.7.
+Please make sure that you update your application appropriately.
+
 1.12.5 (stable) / 2018-07-30
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.12.5.0")]
-[assembly: AssemblyFileVersion("1.12.5.0")]
+[assembly: AssemblyVersion("1.13.0.0")]
+[assembly: AssemblyFileVersion("1.13.0.0")]


### PR DESCRIPTION
* Allow updating custom fields through /notes endpoint #328 
* Add ability to update an invoice #329 
* Remove reference to unused ruleset #326 
* Upgrade .NET 4.7 and scripts folder #327 
* Allow test script to run a single method #330 
* Fix integration tests so they all pass #332 

### Upgrade Notes

This release brings us up to API version 2.14. The build now targets .NET v4.7.
Please make sure that you update your application appropriately.
