### PR TITLE
Add tokenization support for billing info

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -16,7 +16,7 @@ namespace Recurly
             AmericanExpress,
             Discover,
             JCB,
-            Danokrt,
+            Dankort,
             Maestro,
             Forbrugsforeningen,
             Laser,
@@ -132,6 +132,10 @@ namespace Recurly
         public string VerificationValue { get; set; }
 
         public string TokenId { get; set; }
+
+        public string GatewayToken { get; set; }
+
+        public string GatewayCode { get; set; }
 
         /// <summary>
         /// Timestamp representing the last update of this billing info
@@ -400,6 +404,20 @@ namespace Recurly
                 {
                     xmlWriter.WriteElementString("external_hpp_type", ExternalHppType.Value.ToString().EnumNameToTransportCase());
 
+                }
+
+                if (!GatewayCode.IsNullOrEmpty())
+                {
+                    xmlWriter.WriteElementString("gateway_code", GatewayCode);
+                    xmlWriter.WriteElementString("gateway_token", GatewayToken);
+
+                    // EnumNameToTransportCase() turns MasterCard into "master_card",
+                    // but it needs to be "master" for the server to accept it.
+                    // Check for this edge case before writing the card_type tag.
+                    var card = CardType.ToString().EnumNameToTransportCase();
+                    if (card == "master_card") card = "master";
+
+                    xmlWriter.WriteElementString("card_type", card);
                 }
             }
 


### PR DESCRIPTION
Adds gateway_code, gateway_token, and card_type in billing info xml.

Playground script:

```C#
// Assumes account "x" exists on this site
// Assumes gateway_code "jhpqd551excn" is the code for vantiv on this site
using System;
using Recurly;

namespace TestRig
{
    class CreateBillingInfo
    {
        public static void Run(string[] args)
        {
            var account = Accounts.Get("x");
            var info = new BillingInfo(account);
            info.FirstName = "John";
            info.LastName = "Smith";
            info.Address1 = "123 Main St";
            info.City = "San Fransisco";
            info.State = "CA";
            info.Country = "US";
            info.PostalCode = "90212";
            info.GatewayToken = "4111115851581111";
            info.GatewayCode = "jhpqd551excn";
            info.CardType = BillingInfo.CreditCardType.Visa;
            info.ExpirationMonth = 10;
            info.ExpirationYear = 2020;

            try
            {
                info.Create();
            }
            catch(RecurlyException e)
            {
                Console.WriteLine(e.Errors[0]);
            }
        }
    }
}
```