### PR TITLE
Ensure that net47 folder exists

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -3,6 +3,7 @@ set -e
 
 ./scripts/clean
 ./scripts/build Release
+mkdir -p ./dist/lib/net47
 cp ./Library/bin/Release/* ./dist/lib/net47/
 cd dist
 nuget pack recurly.nuspec


### PR DESCRIPTION
Adds a line to ensure the net47 folder exists in the release script