### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -217,19 +217,27 @@ namespace Recurly
 
         public override string ToString()
         {
-            return "Recurly Plan: " + PlanCode;
+            return "Recurly Plan AddOn: " + AddOnCode;
         }
 
         public override bool Equals(object obj)
         {
-            var plan = obj as Plan;
-            return plan != null && Equals(plan);
+            var addon = obj as AddOn;
+            return addon != null && Equals(addon);
         }
 
-        public bool Equals(Plan plan)
+        public bool Equals(AddOn addon)
         {
-            return PlanCode == plan.PlanCode;
+            return PlanCode == addon.PlanCode && AddOnCode == addon.AddOnCode;
         }
+
+        public override int GetHashCode()
+        {
+            var planCodeHash = PlanCode?.GetHashCode() ?? 0;
+            var addOnCodeHash = AddOnCode?.GetHashCode() ?? 0;
+            return planCodeHash + addOnCodeHash;
+        }
+
         #endregion
     }
 }

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -38,10 +38,7 @@ namespace Recurly
         internal static XmlTextReader BuildXmlTextReader(Stream stream)
         {
             var reader = new XmlTextReader(stream);
-            // TODO: ProhibitDtd is for backwards compatibility
-            // but is deprecated. Use DtdProcessing property in next release:
-            // reader.DtdProcessing = DtdProcessing.Prohibit;
-            reader.ProhibitDtd = true;
+            reader.DtdProcessing = DtdProcessing.Prohibit;
             return reader;
         }
 

--- a/Library/List/ShippingAddressList.cs
+++ b/Library/List/ShippingAddressList.cs
@@ -49,7 +49,7 @@ namespace Recurly
             }
         }
 
-        public void Add(ShippingAddress address)
+        public new void Add(ShippingAddress address)
         {
             base.Add(address);
         }

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -604,7 +604,7 @@ namespace Recurly.Test
                     if (plan != null) plan.Deactivate();
                     if (account != null) account.Close();
                 }
-                catch (RecurlyException e) { }
+                catch (RecurlyException) { }
             }
         }
 


### PR DESCRIPTION
These commits fix 4 warnings the compiler complains about when building the project:

1. `List/ShippingAddressList.cs(52,21): warning CS0114: 'ShippingAddressList.Add(ShippingAddress)' hides inherited member 'RecurlyList<ShippingAddress>.Add(ShippingAddress)'.`
2. `AddOn.cs(7,18): warning CS0659: 'AddOn' overrides Object.Equals(object o) but does not override Object.GetHashCode()`
3. `Client.cs(44,13): warning CS0618: 'XmlTextReader.ProhibitDtd' is obsolete: 'Use DtdProcessing property instead.'`
4. `SubscriptionTest.cs(607,41): warning CS0168: The variable 'e' is declared but never used`