### PR TITLE
Bump to version 1.13.1 / API version 2.15

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,16 @@
 Unreleased
 ===============
 
+1.13.1 (stable) / 2018-09-25
+===============
+
+* Added clean and release scripts [PR](https://github.com/recurly/recurly-client-net/pull/336)
+* Updated README with config and .Net target instructions [PR](https://github.com/recurly/recurly-client-net/pull/337)
+* Fixed release script [PR](https://github.com/recurly/recurly-client-net/pull/339)
+* Escape user supplied input [commit](https://github.com/recurly/recurly-client-net/commit/7a516e77c43f6993bc8b4d62a21336eed6e6bd6c)
+* Check for empty and null strings [commit](https://github.com/recurly/recurly-client-net/commit/3823d7a0b0d68e6f7877eaca7bc87f784fc105ce)
+* Fix compiler warnings [PR](https://github.com/recurly/recurly-client-net/pull/341)
+
 1.13.0 (stable) / 2018-09-11
 ===============
 

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -63,7 +63,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.14";
+        public const string RecurlyApiVersion = "2.15";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
+[assembly: AssemblyVersion("1.13.1.0")]
+[assembly: AssemblyFileVersion("1.13.1.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.13.0</version>
+    <version>1.13.1</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.13.1 (stable) / 2018-09-25
===============

* Added clean and release scripts [PR](https://github.com/recurly/recurly-client-net/pull/336)
* Updated README with config and .Net target instructions [PR](https://github.com/recurly/recurly-client-net/pull/337)
* Fixed release script [PR](https://github.com/recurly/recurly-client-net/pull/339)
* Escape user supplied input [commit](https://github.com/recurly/recurly-client-net/commit/7a516e77c43f6993bc8b4d62a21336eed6e6bd6c)
* Check for empty and null strings [commit](https://github.com/recurly/recurly-client-net/commit/3823d7a0b0d68e6f7877eaca7bc87f784fc105ce)
* Fix compiler warnings [PR](https://github.com/recurly/recurly-client-net/pull/341)