### PR TITLE
Change formatting of Usage dates in WriteXML to match Recurly format

### DIFF
--- a/Library/Usage.cs
+++ b/Library/Usage.cs
@@ -189,13 +189,13 @@ namespace Recurly
             xmlWriter.WriteElementString("merchant_tag", MerchantTag);
             
             if (RecordingTimestamp.HasValue)
-                xmlWriter.WriteElementString("recording_timestamp", RecordingTimestamp.Value.ToString("s"));
+                xmlWriter.WriteElementString("recording_timestamp", RecordingTimestamp.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
 
             if (UsageTimestamp.HasValue)
-                xmlWriter.WriteElementString("usage_timestamp", UsageTimestamp.Value.ToString("s"));
+                xmlWriter.WriteElementString("usage_timestamp", UsageTimestamp.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
 
             if (BilledAt.HasValue)
-                xmlWriter.WriteElementString("billed_at", BilledAt.Value.ToString("s"));
+                xmlWriter.WriteElementString("billed_at", BilledAt.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
 
             xmlWriter.WriteEndElement();
         }


### PR DESCRIPTION
Fixes #338 

Playground script for testing. Be sure to change the sub UUID and Addon code to whatever your sandbox site uses. Tested with no updates to the recording time, using DateTimeKind.Utc as well as Local and Unspecified.

```C#
using System;
using Recurly;
using System.Linq;

namespace TestRig
{
    class UpdateUsage 
    {
        public static void Run(string[] args)
        {
            var subscriptionUuid = "47c92b1ea14c0a67ed60fd4f01bded5f";
            var subscriptionAddOnCode= "usage_based";
            var quantity = 2;
            var recTime = new DateTime(2018, 10, 10, 2, 30, 20, DateTimeKind.Local);

            var usage = Recurly.Usages.List(subscriptionUuid, subscriptionAddOnCode).FirstOrDefault();
            if(usage!=null)
            {
                    usage.Amount = quantity;
                    usage.RecordingTimestamp = recTime;
                    usage.Update();
            }
        }
    }
}
```