### PR TITLE
modified Error classes to have at least one public constructor

### DIFF
--- a/Library/Error.cs
+++ b/Library/Error.cs
@@ -36,6 +36,8 @@ namespace Recurly
         /// </summary>
         public string Details { get; internal set; }
 
+        public Error() { }
+
         internal Error(XmlTextReader reader, bool fromList)
         {
             if (fromList)

--- a/Library/Error.cs
+++ b/Library/Error.cs
@@ -14,27 +14,27 @@ namespace Recurly
         /// <summary>
         /// Error message
         /// </summary>
-        public string Message { get; internal set; }
+        public string Message { get; set; }
 
         /// <summary>
         /// Field causing the error, if appropriate.
         /// </summary>
-        public string Field { get; internal set; }
+        public string Field { get; set; }
 
         /// <summary>
         /// Error code set for certain transaction failures.
         /// </summary>
-        public string Code { get; internal set; }
+        public string Code { get; set; }
 
         /// <summary>
         /// Error symbol
         /// </summary>
-        public string Symbol { get; internal set; }
+        public string Symbol { get; set; }
 
         /// <summary>
         /// Error details
         /// </summary>
-        public string Details { get; internal set; }
+        public string Details { get; set; }
 
         public Error() { }
 

--- a/Library/Errors.cs
+++ b/Library/Errors.cs
@@ -6,9 +6,9 @@ using System.Xml;
 namespace Recurly
 {
     /// <summary>
-    /// An internal class for parsing and handling errors
+    /// A class for parsing and handling errors
     /// </summary>
-    internal class Errors
+    public class Errors
     {
         /// <summary>
         /// Error objects message
@@ -20,7 +20,10 @@ namespace Recurly
         /// </summary>
         public TransactionError TransactionError { get; internal set; }
 
-        internal Errors() { }
+        public Errors()
+        {
+            ValidationErrors = new List<Error>().ToArray();
+        }
 
         internal Errors(XmlTextReader xmlReader)
         {

--- a/Library/Exception.cs
+++ b/Library/Exception.cs
@@ -17,6 +17,8 @@ namespace Recurly
         /// </summary>
         public TransactionError TransactionError { get; private set; }
 
+        public RecurlyException() { }
+
         internal RecurlyException(Errors errors)
         {
             Errors = errors.ValidationErrors;
@@ -28,7 +30,7 @@ namespace Recurly
             Errors = errors;
         }
 
-        internal RecurlyException(string message)
+        public RecurlyException(string message)
             : base(message)
         { }
 

--- a/Library/InvalidCredentialsException.cs
+++ b/Library/InvalidCredentialsException.cs
@@ -5,6 +5,10 @@
     /// </summary>
     public class InvalidCredentialsException : RecurlyException
     {
+        public InvalidCredentialsException()
+            : base("The API credentials for Recurly are invalid. Please check the credentials and try again.")
+        { }
+
         internal InvalidCredentialsException(Errors errors)
             : base("The API credentials for Recurly are invalid. Please check the credentials and try again.", errors)
         { }

--- a/Library/NotFoundException.cs
+++ b/Library/NotFoundException.cs
@@ -5,6 +5,8 @@
     /// </summary>
     public class NotFoundException : RecurlyException
     {
+        public NotFoundException() { }
+
         internal NotFoundException(string message, Errors errors)
             : base(message, errors)
         { }

--- a/Library/ServerException.cs
+++ b/Library/ServerException.cs
@@ -5,6 +5,8 @@
     /// </summary>
     public class ServerException : RecurlyException
     {
+        public ServerException() { }
+
         internal ServerException(Errors errors)
             : base("Recurly experienced an internal server error.", errors)
         { }

--- a/Library/TemporarilyUnavailableException.cs
+++ b/Library/TemporarilyUnavailableException.cs
@@ -2,7 +2,7 @@
 {
     public class TemporarilyUnavailableException : ServerException
     {
-        internal TemporarilyUnavailableException()
+        public TemporarilyUnavailableException()
             : base("Recurly is temporarily unavailable. Please try again.")
         { }
     }

--- a/Library/TransactionError.cs
+++ b/Library/TransactionError.cs
@@ -35,6 +35,8 @@ namespace Recurly
         /// </summary>
         public string GatewayErrorCode { get; internal set; }
 
+        public TransactionError() { }
+
         internal TransactionError(XmlTextReader reader)
         {
             while (reader.Read())

--- a/Library/ValidationException.cs
+++ b/Library/ValidationException.cs
@@ -6,6 +6,8 @@
     /// </summary>
     public class ValidationException : RecurlyException
     {
+        public ValidationException() { }
+
         /// <summary>
         /// HTTP Status Code 422 is "Unprocessable Entity"
         /// </summary>


### PR DESCRIPTION
Relates to issue https://github.com/recurly/recurly-client-net/issues/348.

Basically, aim is to be able to mock the Recurly errors from outside of the Recurly namespace. I did not make every constructor public but I made sure that every error exposed by Recurly had a public parameterless constructor. Beyond that, I wasn't sure what needed to actually remain as 'internal only'. 

After this change, the following worked for me:

```c#
namespace Foo.Bar 
{
  public class CustomRecurlyTests
  {
    public void DoAnything()
    {
      var a0 = new Recurly.RecurlyException();
      var a1 = new Recurly.InvalidCredentialsException();
      var a2 = new Recurly.NotFoundException();
      var a3 = new Recurly.ServerException();
      var a4 = new Recurly.TemporarilyUnavailableException();
      var a5 = new Recurly.TransactionError();
      var a6 = new Recurly.ValidationException();
      var a7 = new Recurly.Error();
      var a8 = new Recurly.Errors();
    }
  }
}
```


