### PR TITLE
Bump to version 1.14.0 / API version 2.16

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,20 @@
 Unreleased
 ===============
 
+1.14.0 (stable) / 2018-10-30
+===============
+
+* Made Gift Card RedeemedAt, DeliveredAt and CanceledAt nullable [PR](https://github.com/recurly/recurly-client-net/pull/343)
+* Change Usage dates to UTC [PR](https://github.com/recurly/recurly-client-net/pull/345)
+* Standardize line endings [PR](https://github.com/recurly/recurly-client-net/pull/346)
+* Changed Invoice Refunds for Credit Memo API changes [PR](https://github.com/recurly/recurly-client-net/pull/347)
+* Fixed tests based on credit memo changes [PR](https://github.com/recurly/recurly-client-net/pull/349)
+
+### Upgrade Notes
+
+This release brings us up to API version 2.16.
+Refunding multiple adjustments requires use of the new Invoice#RefundOptions class.
+
 1.13.1 (stable) / 2018-09-25
 ===============
 

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -63,7 +63,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.15";
+        public const string RecurlyApiVersion = "2.16";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.13.1.0")]
-[assembly: AssemblyFileVersion("1.13.1.0")]
+[assembly: AssemblyVersion("1.14.0.0")]
+[assembly: AssemblyFileVersion("1.14.0.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.13.1</version>
+    <version>1.14.0</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.14.0 (stable) / 2018-10-30
===============

* Made Gift Card RedeemedAt, DeliveredAt and CanceledAt nullable [PR](https://github.com/recurly/recurly-client-net/pull/343)
* Change Usage dates to UTC [PR](https://github.com/recurly/recurly-client-net/pull/345)
* Standardize line endings [PR](https://github.com/recurly/recurly-client-net/pull/346)
* Changed Invoice Refunds for Credit Memo API changes [PR](https://github.com/recurly/recurly-client-net/pull/347)
* Fixed tests based on credit memo changes [PR](https://github.com/recurly/recurly-client-net/pull/349)

### Upgrade Notes

This release brings us up to API version 2.16.
Refunding multiple adjustments requires use of the new Invoice#RefundOptions class.