### PR TITLE
Add GatewayCode to subscription for notes and invoice

### DIFF
--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -123,6 +123,7 @@ namespace Recurly
         public string CustomerNotes { get; set; }
         public string TermsAndConditions { get; set; }
         public string VatReverseChargeNotes { get; set; }
+        public string GatewayCode { get; set; }
         public DateTime? AttemptNextCollectionAt { get; set; }
         public string RecoveryReason { get; set; }
         public string AllLineItemsLink { get; set; }
@@ -533,6 +534,10 @@ namespace Recurly
                         VatReverseChargeNotes = reader.ReadElementContentAsString();
                         break;
 
+                    case "gateway_code":
+                        GatewayCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "line_items":
                         // overrite existing value with the Recurly API response
                         Adjustments = new AdjustmentList();
@@ -630,6 +635,7 @@ namespace Recurly
             xmlWriter.WriteElementString("customer_notes", CustomerNotes);
             xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
             xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
+            xmlWriter.WriteElementString("gateway_code", GatewayCode);
             xmlWriter.WriteElementString("po_number", PoNumber);
 
             if (NetTerms.HasValue && _netTermsChanged)

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -307,6 +307,8 @@ namespace Recurly
         public string CustomerNotes { get; set; }
         public string TermsAndConditions { get; set; }
         public string VatReverseChargeNotes { get; set; }
+        public string GatewayCode { get; set; }
+
         /// <summary>
         /// True if the subscription started from a gift card.
         /// </summary>
@@ -569,10 +571,17 @@ namespace Recurly
                 UrlPrefix + Uri.EscapeDataString(Uuid) + "/notes",
                 WriteSubscriptionNotesXml(notes),
                 ReadXml);
+            if (notes.ContainsKey("CustomerNotes"))
+                CustomerNotes = notes["CustomerNotes"];
 
-            CustomerNotes = notes["CustomerNotes"];
-            TermsAndConditions = notes["TermsAndConditions"];
-            VatReverseChargeNotes = notes["VatReverseChargeNotes"];
+            if (notes.ContainsKey("TermsAndConditions"))
+                TermsAndConditions = notes["TermsAndConditions"];
+
+            if (notes.ContainsKey("VatReverseChargeNotes"))
+                VatReverseChargeNotes = notes["VatReverseChargeNotes"];
+
+            if (notes.ContainsKey("GatewayCode"))
+                GatewayCode = notes["GatewayCode"];
 
             return true;
         }
@@ -794,6 +803,10 @@ namespace Recurly
 
                     case "vat_reverse_charge_notes":
                         VatReverseChargeNotes = reader.ReadElementContentAsString();
+                        break;
+
+                    case "gateway_code":
+                        GatewayCode = reader.ReadElementContentAsString();
                         break;
 
                     case "address":
@@ -1072,9 +1085,18 @@ namespace Recurly
             {
                 xmlWriter.WriteStartElement("subscription"); // Start: subscription
 
-                xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
-                xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
-                xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
+                if (notes.ContainsKey("CustomerNotes"))
+                    xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
+
+                if (notes.ContainsKey("TermsAndConditions"))
+                    xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
+
+                if (notes.ContainsKey("VatReverseChargeNotes"))
+                    xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
+
+                if (notes.ContainsKey("GatewayCode"))
+                    xmlWriter.WriteElementString("gateway_code", notes["GatewayCode"]);
+
                 xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
                 xmlWriter.WriteEndElement(); // End: subscription

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -252,11 +252,13 @@ namespace Recurly.Test
             invoice.PoNumber = "1234";
             invoice.CustomerNotes = "Some Customer Notes";
             invoice.TermsAndConditions = "Some Terms and Conditions";
+            invoice.GatewayCode = "jhq4mlfe7wtw";
             invoice.Update();
 
             Assert.Equal(invoice.PoNumber, "1234");
             Assert.Equal(invoice.CustomerNotes, "Some Customer Notes");
             Assert.Equal(invoice.TermsAndConditions, "Some Terms and Conditions");
+            Assert.Equal(invoice.GatewayCode, "jhq4mlfe7wtw");
         }
 
         [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -400,6 +400,7 @@ namespace Recurly.Test
             notes.Add("CustomerNotes", "New Customer Notes");
             notes.Add("TermsAndConditions", "New T and C");
             notes.Add("VatReverseChargeNotes", "New VAT Notes");
+            notes.Add("GatewayCode", "jhq4mlfe7wtw");
             sub.CustomFields.Add(new CustomField("food", "taco"));
 
             sub.UpdateNotes(notes);
@@ -407,6 +408,7 @@ namespace Recurly.Test
             sub.CustomerNotes.Should().Be(notes["CustomerNotes"]);
             sub.TermsAndConditions.Should().Be(notes["TermsAndConditions"]);
             sub.VatReverseChargeNotes.Should().Be(notes["VatReverseChargeNotes"]);
+            sub.GatewayCode.Should().Be(notes["GatewayCode"]);
             sub.CustomFields.Should().Contain(cf => cf.Name == "food");
             sub.CustomFields.Should().Contain(cf => cf.Value == "taco");
 


### PR DESCRIPTION
Adds GatewayCode to the Subscription object for the `/notes` endpoint. Also adds GatewayCode to the Invoice object for `PUT invoices`.

Scripts:
```c#
using System;
using System.Linq;
using Recurly;
using System.Collections.Generic;

namespace TestRig
{
    class UpdateSubNotes
    {
        public static void Run(string[] args)
        {
            var subscription = Subscriptions.Get("4810fde9f3f29b244474e445d795cc78");
            var dict = new Dictionary<string, string>();
            dict.Add("GatewayCode", "jotgbnxnecn0");
            subscription.UpdateNotes(dict);
        }
    }
}
```
```c#
using System;
using System.Linq;
using Recurly;
using System.Collections.Generic;

namespace TestRig
{
    class UpdateInvoice
    {
        public static void Run(string[] args)
        {
            var invoice = Invoices.Get(1001);
            invoice.GatewayCode = "jhpqd551evcn";
            try
            {
                invoice.Update();
                Console.WriteLine(invoice.GatewayCode);
            }
            catch(ValidationException e)
            {
                Console.WriteLine(e);
                foreach (var err in e.Errors) {
                  Console.WriteLine(err);
                }
            }
        }
    }
}
```