### PR TITLE
Add ExemptionCertificate attribute to Account

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -35,6 +35,7 @@ namespace Recurly
         public string CompanyName { get; set; }
         public string VatNumber { get; set; }
         public bool? TaxExempt { get; set; }
+        public string ExemptionCertificate { get; set; }
         public string EntityUseCode { get; set; }
         public string AcceptLanguage { get; set; }
         public string CcEmails { get; set; }
@@ -496,6 +497,10 @@ namespace Recurly
                         TaxExempt = reader.ReadElementContentAsBoolean();
                         break;
 
+                    case "exemption_certificate":
+                        ExemptionCertificate = reader.ReadElementContentAsString();
+                        break;
+
                     case "entity_use_code":
                         EntityUseCode = reader.ReadElementContentAsString();
                         break;
@@ -613,6 +618,8 @@ namespace Recurly
 
             if (TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());
+
+            xmlWriter.WriteStringIfValid("exemption_certificate", ExemptionCertificate);
 
             if(_accountAcquisition != null)
                 _accountAcquisition.WriteXml(xmlWriter);

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -33,6 +33,7 @@ namespace Recurly.Test
                 AcceptLanguage = "en",
                 VatNumber = "my-vat-number",
                 TaxExempt = true,
+                ExemptionCertificate = "Some Certificate",
                 EntityUseCode = "I",
                 CcEmails = "cc1@test.com,cc2@test.com",
                 Address = new Address(),
@@ -53,6 +54,7 @@ namespace Recurly.Test
             acct.CcEmails.Should().Be("cc1@test.com,cc2@test.com");
             Assert.Equal("my-vat-number", acct.VatNumber);
             Assert.True(acct.TaxExempt.Value);
+            Assert.Equal(acct.ExemptionCertificate, "Some Certificate");
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
             Assert.False(acct.VatLocationValid);


### PR DESCRIPTION
Adds exemption_certificate attribute to the account object.

Script:
```c#
using System;
using Recurly;

namespace TestRig
{
    class CreateAccount
    {
        public static void Run(string[] args)
        {
            var account = new Account("new-account");
            account.TaxExempt = true;
            account.ExemptionCertificate = "Some Certificate";
            account.Create();
        }
    }
}
```