### PR TITLE
Add custom fields to WriteChangeSubscriptionXml

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -1062,6 +1062,8 @@ namespace Recurly
 
             if (RenewalBillingCycles.HasValue)
                 xmlWriter.WriteElementString("renewal_billing_cycles", RenewalBillingCycles.Value.AsString());
+            
+            xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
             xmlWriter.WriteEndElement(); // End: subscription
         }


### PR DESCRIPTION
There are two different `WriteXml` type functions on the Subscription object. The one for the `/notes` endpoint includes custom fields, but the one for the regular `/subscriptions` endpoint does not. This PR fixes that.

Script:
```C#
    // Assumes "47852d1aefe69b0e9c69504d93ab46f9" is a valid subscription on the account
    // Assumes "device_id" is a configured custom field on the account
    class UpdateSubscription
    {
        public static void Run(string[] args)
        {
            var sub = Subscriptions.Get("47852d1aefe69b0e9c69504d93ab46f9");
            sub.CustomFields.Add(new CustomField("device_id", "KIWTL-WER-ZXMRD"));
            sub.ChangeSubscription();
        }
    }
}