### PR TITLE
Add EnterOfflinePayment method to Invoice

### DIFF
--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -290,12 +290,12 @@ namespace Recurly
             var refunds = new RefundList(adjustments, options);
             var invoice = new Invoice();
 
-            var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 memberUrl() + "/refund",
                 refunds.WriteXml,
                 invoice.ReadXml);
 
-            if (HttpStatusCode.Created == response || HttpStatusCode.OK == response)
+            if (HttpStatusCode.Created == statusCode || HttpStatusCode.OK == statusCode)
                 return invoice;
             else
                 return null;
@@ -345,12 +345,12 @@ namespace Recurly
             var refunds = new RefundList(adjustments, prorate, quantity, method);
             var invoice = new Invoice();
 
-            var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 memberUrl() + "/refund",
                 refunds.WriteXml,
                 invoice.ReadXml);
 
-            if (HttpStatusCode.Created == response || HttpStatusCode.OK == response)
+            if (HttpStatusCode.Created == statusCode || HttpStatusCode.OK == statusCode)
                 return invoice;
             else
                 return null;
@@ -367,12 +367,12 @@ namespace Recurly
             var refundInvoice = new Invoice();
             var refund = new OpenAmountRefund(amountInCents, options);
 
-            var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 memberUrl() + "/refund",
                 refund.WriteXml,
                 refundInvoice.ReadXml);
 
-            if (HttpStatusCode.Created == response || HttpStatusCode.OK == response)
+            if (HttpStatusCode.Created == statusCode || HttpStatusCode.OK == statusCode)
                 return refundInvoice;
             else
                 return null;
@@ -384,13 +384,33 @@ namespace Recurly
             var refundInvoice = new Invoice();
             var refund = new OpenAmountRefund(amountInCents, method);
 
-            var response = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
                 memberUrl() + "/refund",
                 refund.WriteXml,
                 refundInvoice.ReadXml);
 
-            if (HttpStatusCode.Created == response || HttpStatusCode.OK == response)
+            if (HttpStatusCode.Created == statusCode || HttpStatusCode.OK == statusCode)
                 return refundInvoice;
+            else
+                return null;
+        }
+
+        /// <summary>
+        /// Enter an offline payment for a manual invoice
+        /// </summary>
+        /// <param name="transaction">The transaction to be entered.</param>
+        /// <returns>new Transaction object</returns>
+        public Transaction EnterOfflinePayment(Transaction transaction)
+        {
+            var successfulTransaction = new Transaction();
+
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                memberUrl() + "/transactions",
+                transaction.WriteOfflinePaymentXml,
+                successfulTransaction.ReadXml);
+
+            if (HttpStatusCode.Created == statusCode || HttpStatusCode.OK == statusCode)
+                return successfulTransaction;
             else
                 return null;
         }

--- a/Library/Transaction.cs
+++ b/Library/Transaction.cs
@@ -332,6 +332,18 @@ namespace Recurly
             xmlWriter.WriteEndElement();
         }
 
+        internal void WriteOfflinePaymentXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("transaction");
+
+            xmlWriter.WriteStringIfValid("payment_method", PaymentMethod);
+            xmlWriter.WriteElementString("collected_at", CollectedAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"));
+            xmlWriter.WriteElementString("amount_in_cents", AmountInCents.AsString());
+            xmlWriter.WriteStringIfValid("description", Description);
+
+            xmlWriter.WriteEndElement();
+        }
+
         #endregion
 
         #region Object Overrides


### PR DESCRIPTION
This adds a method to handle this API endpoint https://dev.recurly.com/docs/enter-an-offline-payment-for-a-manual-invoice

The test pretty much shows example usage, but here's a script just in case:
```C#
using System;
using Recurly;

namespace TestRig
{
    class EnterOfflinePayment
    {
        public static void Run(string[] args)
        {
            var account = new Account(System.Guid.NewGuid().ToString());
            account.Create();

            var adjustment = account.NewAdjustment("USD", 5000, "Test Charge");
            adjustment.Create();

            var newInvoice = new Invoice();
            newInvoice.CollectionMethod = Invoice.Collection.Manual;

            var invoice = account.InvoicePendingCharges(newInvoice).ChargeInvoice;

            var offlineTransaction = new Transaction(account, 5000, "");
            offlineTransaction.PaymentMethod = "credit_card";
            offlineTransaction.CollectedAt = new DateTime(2018, 12, 3, 2, 30, 20, DateTimeKind.Local);
            offlineTransaction.Description = "Paid the test charge. Gooood customer *pats customer head*";

            try
            {
                var recordedTransaction = invoice.EnterOfflinePayment(offlineTransaction);
                Console.WriteLine(recordedTransaction.Status);
            }
            catch(ValidationException e)
            {
                Console.WriteLine(e);
                foreach (var err in e.Errors) {
                  Console.WriteLine(err);
                }
            }
        }
    }
}
```