### PR TITLE
Add methods for working with Shipping Addresses

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -430,6 +430,46 @@ namespace Recurly
             return activeRedemptions.ToArray()[0];
         }
 
+        /// <summary>
+        /// Creates a shipping address
+        /// </summary>
+        /// <param name="shippingAddress"></param>
+        /// <returns>ShippingAddress object</returns>
+        public ShippingAddress CreateShippingAddress(ShippingAddress shippingAddress)
+        {
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/shipping_addresses",
+                shippingAddress.WriteXml,
+                shippingAddress.ReadXml);
+
+            return statusCode == HttpStatusCode.Created ? shippingAddress : null;
+        }
+
+        /// <summary>
+        /// Gets all shipping addresses
+        /// </summary>
+        /// <param name="shippingAddress"></param>
+        /// <returns>ShippingAddress object</returns>
+        public ShippingAddress UpdateShippingAddress(ShippingAddress shippingAddress)
+        {
+            var shippingAddressId = shippingAddress.Id;
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/shipping_addresses/" + shippingAddressId,
+                shippingAddress.WriteXml,
+                shippingAddress.ReadXml);
+
+            return statusCode == HttpStatusCode.OK ? shippingAddress : null;
+        }
+
+        /// <summary>
+        /// Deletes a shipping address
+        /// </summary>
+        public void DeleteShippingAddress(long shippingAddressId)
+        {
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Delete,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/shipping_addresses/" + shippingAddressId);
+        }
+
         #region Read and Write XML documents
 
         internal override void ReadXml(XmlTextReader reader)

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -173,5 +173,39 @@ namespace Recurly.Test
             balance.Should().NotBeNull();
             balance.BalanceInCents.First().Value.Should().BeGreaterThan(0);
         }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void ShippingAddresses()
+        {
+            var account = new Account(GetUniqueAccountCode());
+            account.Create();
+
+            var newAddress = new ShippingAddress();
+            newAddress.FirstName = "P.";
+            newAddress.LastName = "Sherman";
+            newAddress.Address1 = "42 Wallaby Way";
+            newAddress.Address2 = "Suite 200";
+            newAddress.City = "Sydney";
+            newAddress.State = "New South Wales";
+            newAddress.Country = "Australia";
+            newAddress.Zip = "2060";
+
+            var shippingAddress = account.CreateShippingAddress(newAddress);
+            shippingAddress.Id.Should().NotBeNull();
+
+            var shippingAddresses = account.GetShippingAddresses();
+            shippingAddresses.Should().NotBeEmpty();
+
+            shippingAddress.Address2 = "Suite 100";
+
+            var updatedShippingAddress = account.UpdateShippingAddress(shippingAddress);
+            updatedShippingAddress.Address2.ShouldBeEquivalentTo("Suite 100");
+            var id = updatedShippingAddress.Id;
+
+            account.DeleteShippingAddress((long) id);
+
+            shippingAddresses = account.GetShippingAddresses();
+            shippingAddresses.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
This PR adds methods for working with shipping addresses, which for whatever reason were missing from this library. There was a `GetShippingAddresses` method already, but there was no way to create, update or delete a shipping address.

No script because example usage is in the test.