### PR TITLE
Add SubscriptionChange class

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,12 @@
 Unreleased
 ===============
 
+### Upgrade Notes
+This release contains one breaking change:
+
+To update a subscription, a SubscriptionChange object must be passed into the `ChangeSubscription()` method.
+See the C# example in our [dev docs](https://dev.recurly.com/docs/update-subscription).
+
 1.14.1 (stable) / 2018-12-11
 ===============
 

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Subscription.cs" />
     <Compile Include="SubscriptionAddOn.cs" />
+    <Compile Include="SubscriptionChange.cs" />
     <Compile Include="TemporarilyUnavailableException.cs" />
     <Compile Include="Transaction.cs" />
     <Compile Include="List\TransactionList.cs" />

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -10,6 +10,7 @@ namespace Recurly
         public int? UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
+        public float? UsagePercentage { get; set; }
 
         public SubscriptionAddOn(XmlTextReader reader)
         {
@@ -67,6 +68,10 @@ namespace Recurly
                         if (!revenueScheduleType.IsNullOrEmpty())
                             RevenueScheduleType = revenueScheduleType.ParseAsEnum<Adjustment.RevenueSchedule>();
                         break;
+
+                    case "usage_percentage":
+                        UsagePercentage = reader.ReadElementContentAsFloat();
+                        break;
                 }
             }
         }
@@ -83,6 +88,9 @@ namespace Recurly
 
             if (RevenueScheduleType.HasValue)
                 writer.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+
+            if (UsagePercentage.HasValue)
+                writer.WriteElementString("usage_percentage", UsagePercentage.ToString());
 
             writer.WriteEndElement();
         }

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml;
+
+namespace Recurly
+{
+
+    /// <summary>
+    /// Represents subscriptions for accounts
+    /// </summary>
+    public class SubscriptionChange
+    {
+        public enum ChangeTimeframe : short
+        {
+            Now,
+            Renewal
+        }
+
+        public ChangeTimeframe TimeFrame { get; set; }
+
+        public string PlanCode { get; set; }
+
+        /// <summary>
+        /// List of custom fields
+        /// </summary>
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
+        private List<CustomField> _customFields;
+
+        /// <summary>
+        /// Unit amount per quantity.  Leave null to keep as is. Set to override plan's default amount.
+        /// </summary>
+        public int? UnitAmountInCents { get; set; }
+
+        public int? Quantity { get; set; }
+
+        /// <summary>
+        /// List of add ons for this subscription
+        /// </summary>
+        public SubscriptionAddOnList AddOns
+        {
+            get { return _addOns ?? (_addOns = new SubscriptionAddOnList(new Subscription())); }
+            set { _addOns = value; }
+        }
+
+        private SubscriptionAddOnList _addOns;
+        /// <summary>
+        /// The coupon code you want to redeem in the update.
+        /// Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
+        /// </summary>
+        public string CouponCode { get; set; }
+
+        public int? RemainingBillingCycles { get; set; }
+
+        public string CollectionMethod { get; set; }
+
+        public int? NetTerms { get; set; }
+
+        public string PoNumber { get; set; }
+
+        /// <summary>
+        /// Determines whether subscriptions to this plan should auto-renew term at the end of the current term or expire.
+        /// Defaults to true.
+        /// </summary>
+        public bool? AutoRenew { get; set; }
+
+        /// <summary>
+        /// Determines the renewal subscription term.
+        /// Defaults to plans total billing cycles value unless
+        /// overwritten when creating the subscription or editing subscription.
+        /// </summary>
+        public int? RenewalBillingCycles { get; set; }
+
+        public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
+
+        /// <summary>
+        /// Optionally set true to indicate if the subscription is to be treated as an import
+        /// for data analysis or a real trial. This value can only be changed on a trial subscription
+        /// and is persisted for its lifetime.
+        /// </summary>
+        public bool? ImportedTrial { get; set; }
+
+        /// <summary>
+        /// Creates a new subscription change object
+        /// </summary>
+        public SubscriptionChange() { }
+
+        #region Write XML documents
+
+        internal void WriteChangeSubscriptionXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("subscription"); // Start: subscription
+
+            xmlWriter.WriteElementString("timeframe", TimeFrame.ToString().EnumNameToTransportCase());
+
+            if (Quantity.HasValue)
+                xmlWriter.WriteElementString("quantity", Quantity.ToString());
+
+            xmlWriter.WriteStringIfValid("plan_code", PlanCode);
+            xmlWriter.WriteIfCollectionHasAny("subscription_add_ons", AddOns);
+            xmlWriter.WriteStringIfValid("coupon_code", CouponCode);
+
+            if (UnitAmountInCents.HasValue)
+                xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.Value.AsString());
+
+            if (CollectionMethod.Like("manual"))
+            {
+                xmlWriter.WriteElementString("collection_method", "manual");
+                xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
+                xmlWriter.WriteElementString("po_number", PoNumber);
+            }
+            else if (CollectionMethod.Like("automatic"))
+            {
+                xmlWriter.WriteElementString("collection_method", "automatic");
+            }
+
+            if (ImportedTrial.HasValue)
+                xmlWriter.WriteElementString("imported_trial", ImportedTrial.Value.ToString().ToLower());
+
+            if (RevenueScheduleType.HasValue)
+                xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+
+            if (RemainingBillingCycles.HasValue)
+                xmlWriter.WriteElementString("remaining_billing_cycles", RemainingBillingCycles.Value.AsString());
+
+            if (AutoRenew.HasValue)
+                xmlWriter.WriteElementString("auto_renew", AutoRenew.Value.AsString());
+
+            if (RenewalBillingCycles.HasValue)
+                xmlWriter.WriteElementString("renewal_billing_cycles", RenewalBillingCycles.Value.AsString());
+
+            xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
+
+            xmlWriter.WriteEndElement(); // End: subscription
+        }
+
+        #endregion
+
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return "Recurly SubscriptionChange";
+        }
+
+        #endregion
+    }
+}

--- a/Test/EnumTest.cs
+++ b/Test/EnumTest.cs
@@ -45,7 +45,7 @@ namespace Recurly.Test
             private static readonly Action CouponState = () => EnumOperations<CouponState>();
             private static readonly Action InvoiceState = () => EnumOperations<InvoiceState>();
             private static readonly Action SubscriptionState = () => EnumOperations<SubscriptionState>();
-            private static readonly Action SubscriptionChangeTimeframe = () => EnumOperations<Subscription.ChangeTimeframe>();
+            private static readonly Action SubscriptionChangeTimeframe = () => EnumOperations<SubscriptionChange.ChangeTimeframe>();
             private static readonly Action SubscriptionRefundType = () => EnumOperations<Subscription.RefundType>();
 
             private readonly List<object[]> _data = new List<object[]>


### PR DESCRIPTION
Fixes #157 

The pattern here is different from the patterns of this library, but I believe it will be an improvement because it makes all the changes you want to make explicit, rather than implicit. 

The developer must make a SubscriptionChange object, then any value that ought to be changed should be explicitly set on that object. This object can then be passed into the new static methods `PreviewChange()` and `ChangeSubscription()`, which will return the changed subscription in a new Subscription object.

Script:
```c#
using System;
using Recurly;

namespace TestRig
{
    class PreviewSubscriptionChange
    {
        public static void Run(string[] args)
        {
            var change = new SubscriptionChange()
            {
                PlanCode = "gold"
            };
            var newSub = Subscription.PreviewChange("48e99881b3726425bf49e64b45af7fe4", change);
        }
    }
}
```
Another Script:
```c#
using System;
using System.Linq;
using Recurly;
using System.Collections.Generic;

namespace TestRig
{
    class UpdateSubscription
    {
        public static void Run(string[] args)
        {
            var sub = Subscriptions.Get("47852d1aefe69b0e9c69504d93ab46f9");
            var subChange = new SubscriptionChange()
            {
                CustomFields = sub.CustomFields
            };

            foreach (var field in subChange.CustomFields)
            {
                if (field.Name == "internal-code")
                    field.Value = null;
            }
            Subscription.ChangeSubscription(sub.Uuid, subChange);
        }
    }
}
```