### PR TITLE
Release version 2.14.1 / API version 2.17

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,21 @@
 Unreleased
 ===============
 
+1.14.1 (stable) / 2018-12-11
+===============
+
+This release brings us up to API version 2.17
+
+* Add public constructors to error classes [PR](https://github.com/recurly/recurly-client-net/pull/350)
+* Add missing values to WriteSubscriptionXml() [PR](https://github.com/recurly/recurly-client-net/pull/352)
+* Add `GatewayCode` to Subscription for notes and Invoice [PR](https://github.com/recurly/recurly-client-net/pull/355)
+* Add `ExemptionCertificate` attribute to Account [PR](https://github.com/recurly/recurly-client-net/pull/356)
+* Remove examples.md [PR](https://github.com/recurly/recurly-client-net/pull/357)
+* Add Custom Fields to WriteSubscriptionXml() [PR](https://github.com/recurly/recurly-client-net/pull/358)
+* Add EnterOfflinePayment method to Invoice [PR](https://github.com/recurly/recurly-client-net/pull/359)
+* Add methods for working with Shipping Addresses [PR](https://github.com/recurly/recurly-client-net/pull/360)
+* Make UTC explicit in Subscription.Postpone [PR](https://github.com/recurly/recurly-client-net/pull/362)
+
 1.14.0 (stable) / 2018-10-30
 ===============
 

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -35,6 +35,7 @@ namespace Recurly
         public string CompanyName { get; set; }
         public string VatNumber { get; set; }
         public bool? TaxExempt { get; set; }
+        public string ExemptionCertificate { get; set; }
         public string EntityUseCode { get; set; }
         public string AcceptLanguage { get; set; }
         public string CcEmails { get; set; }
@@ -536,6 +537,10 @@ namespace Recurly
                         TaxExempt = reader.ReadElementContentAsBoolean();
                         break;
 
+                    case "exemption_certificate":
+                        ExemptionCertificate = reader.ReadElementContentAsString();
+                        break;
+
                     case "entity_use_code":
                         EntityUseCode = reader.ReadElementContentAsString();
                         break;
@@ -653,6 +658,8 @@ namespace Recurly
 
             if (TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());
+
+            xmlWriter.WriteStringIfValid("exemption_certificate", ExemptionCertificate);
 
             if(_accountAcquisition != null)
                 _accountAcquisition.WriteXml(xmlWriter);

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -63,7 +63,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.16";
+        public const string RecurlyApiVersion = "2.17";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -123,6 +123,7 @@ namespace Recurly
         public string CustomerNotes { get; set; }
         public string TermsAndConditions { get; set; }
         public string VatReverseChargeNotes { get; set; }
+        public string GatewayCode { get; set; }
         public DateTime? AttemptNextCollectionAt { get; set; }
         public string RecoveryReason { get; set; }
         public string AllLineItemsLink { get; set; }
@@ -553,6 +554,10 @@ namespace Recurly
                         VatReverseChargeNotes = reader.ReadElementContentAsString();
                         break;
 
+                    case "gateway_code":
+                        GatewayCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "line_items":
                         // overrite existing value with the Recurly API response
                         Adjustments = new AdjustmentList();
@@ -650,6 +655,7 @@ namespace Recurly
             xmlWriter.WriteElementString("customer_notes", CustomerNotes);
             xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
             xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
+            xmlWriter.WriteElementString("gateway_code", GatewayCode);
             xmlWriter.WriteElementString("po_number", PoNumber);
 
             if (NetTerms.HasValue && _netTermsChanged)

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.14.0.0")]
-[assembly: AssemblyFileVersion("1.14.0.0")]
+[assembly: AssemblyVersion("1.14.1.0")]
+[assembly: AssemblyFileVersion("1.14.1.0")]

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -307,6 +307,8 @@ namespace Recurly
         public string CustomerNotes { get; set; }
         public string TermsAndConditions { get; set; }
         public string VatReverseChargeNotes { get; set; }
+        public string GatewayCode { get; set; }
+
         /// <summary>
         /// True if the subscription started from a gift card.
         /// </summary>
@@ -571,10 +573,17 @@ namespace Recurly
                 UrlPrefix + Uri.EscapeDataString(Uuid) + "/notes",
                 WriteSubscriptionNotesXml(notes),
                 ReadXml);
+            if (notes.ContainsKey("CustomerNotes"))
+                CustomerNotes = notes["CustomerNotes"];
 
-            CustomerNotes = notes["CustomerNotes"];
-            TermsAndConditions = notes["TermsAndConditions"];
-            VatReverseChargeNotes = notes["VatReverseChargeNotes"];
+            if (notes.ContainsKey("TermsAndConditions"))
+                TermsAndConditions = notes["TermsAndConditions"];
+
+            if (notes.ContainsKey("VatReverseChargeNotes"))
+                VatReverseChargeNotes = notes["VatReverseChargeNotes"];
+
+            if (notes.ContainsKey("GatewayCode"))
+                GatewayCode = notes["GatewayCode"];
 
             return true;
         }
@@ -796,6 +805,10 @@ namespace Recurly
 
                     case "vat_reverse_charge_notes":
                         VatReverseChargeNotes = reader.ReadElementContentAsString();
+                        break;
+
+                    case "gateway_code":
+                        GatewayCode = reader.ReadElementContentAsString();
                         break;
 
                     case "address":
@@ -1076,9 +1089,18 @@ namespace Recurly
             {
                 xmlWriter.WriteStartElement("subscription"); // Start: subscription
 
-                xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
-                xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
-                xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
+                if (notes.ContainsKey("CustomerNotes"))
+                    xmlWriter.WriteElementString("customer_notes", notes["CustomerNotes"]);
+
+                if (notes.ContainsKey("TermsAndConditions"))
+                    xmlWriter.WriteElementString("terms_and_conditions", notes["TermsAndConditions"]);
+
+                if (notes.ContainsKey("VatReverseChargeNotes"))
+                    xmlWriter.WriteElementString("vat_reverse_charge_notes", notes["VatReverseChargeNotes"]);
+
+                if (notes.ContainsKey("GatewayCode"))
+                    xmlWriter.WriteElementString("gateway_code", notes["GatewayCode"]);
+
                 xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 
                 xmlWriter.WriteEndElement(); // End: subscription

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -33,6 +33,7 @@ namespace Recurly.Test
                 AcceptLanguage = "en",
                 VatNumber = "my-vat-number",
                 TaxExempt = true,
+                ExemptionCertificate = "Some Certificate",
                 EntityUseCode = "I",
                 CcEmails = "cc1@test.com,cc2@test.com",
                 Address = new Address(),
@@ -53,6 +54,7 @@ namespace Recurly.Test
             acct.CcEmails.Should().Be("cc1@test.com,cc2@test.com");
             Assert.Equal("my-vat-number", acct.VatNumber);
             Assert.True(acct.TaxExempt.Value);
+            Assert.Equal(acct.ExemptionCertificate, "Some Certificate");
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
             Assert.False(acct.VatLocationValid);

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -252,11 +252,13 @@ namespace Recurly.Test
             invoice.PoNumber = "1234";
             invoice.CustomerNotes = "Some Customer Notes";
             invoice.TermsAndConditions = "Some Terms and Conditions";
+            invoice.GatewayCode = "jhq4mlfe7wtw";
             invoice.Update();
 
             Assert.Equal(invoice.PoNumber, "1234");
             Assert.Equal(invoice.CustomerNotes, "Some Customer Notes");
             Assert.Equal(invoice.TermsAndConditions, "Some Terms and Conditions");
+            Assert.Equal(invoice.GatewayCode, "jhq4mlfe7wtw");
         }
 
         [Fact(Skip = "This feature is deprecated and no longer supported for accounts where line item refunds are turned on.")]

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -400,6 +400,7 @@ namespace Recurly.Test
             notes.Add("CustomerNotes", "New Customer Notes");
             notes.Add("TermsAndConditions", "New T and C");
             notes.Add("VatReverseChargeNotes", "New VAT Notes");
+            notes.Add("GatewayCode", "jhq4mlfe7wtw");
             sub.CustomFields.Add(new CustomField("food", "taco"));
 
             sub.UpdateNotes(notes);
@@ -407,6 +408,7 @@ namespace Recurly.Test
             sub.CustomerNotes.Should().Be(notes["CustomerNotes"]);
             sub.TermsAndConditions.Should().Be(notes["TermsAndConditions"]);
             sub.VatReverseChargeNotes.Should().Be(notes["VatReverseChargeNotes"]);
+            sub.GatewayCode.Should().Be(notes["GatewayCode"]);
             sub.CustomFields.Should().Contain(cf => cf.Name == "food");
             sub.CustomFields.Should().Contain(cf => cf.Value == "taco");
 

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.14.0</version>
+    <version>1.14.1</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.14.1 (stable) / 2018-12-11
===============

This release brings us up to API version 2.17

* Add public constructors to error classes [PR](https://github.com/recurly/recurly-client-net/pull/350)
* Add missing values to WriteChangeSubscriptionXml() [PR](https://github.com/recurly/recurly-client-net/pull/352)
* Add `GatewayCode` to Subscription for notes and Invoice [PR](https://github.com/recurly/recurly-client-net/pull/355)
* Add `ExemptionCertificate` attribute to Account [PR](https://github.com/recurly/recurly-client-net/pull/356)
* Remove examples.md [PR](https://github.com/recurly/recurly-client-net/pull/357)
* Add Custom Fields to WriteChangeSubscriptionXml() [PR](https://github.com/recurly/recurly-client-net/pull/358)
* Add EnterOfflinePayment method to Invoice [PR](https://github.com/recurly/recurly-client-net/pull/359)
* Add methods for working with Shipping Addresses [PR](https://github.com/recurly/recurly-client-net/pull/360)
* Make UTC explicit in Subscription.Postpone [PR](https://github.com/recurly/recurly-client-net/pull/362)