### PR TITLE
Remove broken test for ExemptionCertificate

### DIFF
--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -33,7 +33,6 @@ namespace Recurly.Test
                 AcceptLanguage = "en",
                 VatNumber = "my-vat-number",
                 TaxExempt = true,
-                ExemptionCertificate = "Some Certificate",
                 EntityUseCode = "I",
                 CcEmails = "cc1@test.com,cc2@test.com",
                 Address = new Address(),
@@ -54,7 +53,6 @@ namespace Recurly.Test
             acct.CcEmails.Should().Be("cc1@test.com,cc2@test.com");
             Assert.Equal("my-vat-number", acct.VatNumber);
             Assert.True(acct.TaxExempt.Value);
-            Assert.Equal(acct.ExemptionCertificate, "Some Certificate");
             Assert.Equal("I", acct.EntityUseCode);
             Assert.Equal(address, acct.Address.Address1);
             Assert.False(acct.VatLocationValid);


### PR DESCRIPTION
This test will always fail because it only works when Vertex is integrated on the account. This would be better as a unit test, but we don't have an XML mocking framework set up for tests like these in this library.

Honestly, I trust this works without a test.