### PR TITLE
Add travis file for 3.0.0 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: csharp
+solution: recurly.sln
+dist: xenial
+mono: none
+matrix:
+  include:
+    - dotnet: 2.1.300
+      mono: none
+    - dotnet: 2.2.101
+      mono: none
+script:
+  - dotnet restore
+  - ./scripts/build
+  - ./scripts/test


### PR DESCRIPTION
This adds the travis file for the v3 beta code. Going to try to get a matrix build running the tests.

Dotnet 1.1 is end-of-life in summer of 2019. I think we will stick with 2.1 and 2.2 support until we have a strong reason to add 1.1 support.