### PR TITLE
Fix extra written elements and add error details to RecurlyException

### DIFF
--- a/Library/Address.cs
+++ b/Library/Address.cs
@@ -85,17 +85,28 @@ namespace Recurly
         {
             xmlWriter.WriteStartElement("address");
 
-            xmlWriter.WriteElementString("first_name", FirstName);
-            xmlWriter.WriteElementString("last_name", LastName);
-            xmlWriter.WriteElementString("name_on_account", NameOnAccount);
-            xmlWriter.WriteElementString("company", Company);
-            xmlWriter.WriteElementString("address1", Address1);
-            xmlWriter.WriteElementString("address2", Address2);
-            xmlWriter.WriteElementString("city", City);
-            xmlWriter.WriteElementString("state", State);
-            xmlWriter.WriteElementString("zip", Zip);
-            xmlWriter.WriteElementString("country", Country);
-            xmlWriter.WriteElementString("phone", Phone);
+            if (FirstName != null)
+                xmlWriter.WriteElementString("first_name", FirstName);
+            if (LastName != null)
+                xmlWriter.WriteElementString("last_name", LastName);
+            if (NameOnAccount != null)
+                xmlWriter.WriteElementString("name_on_account", NameOnAccount);
+            if (Company != null)
+                xmlWriter.WriteElementString("company", Company);
+            if (Address1 != null)
+                xmlWriter.WriteElementString("address1", Address1);
+            if (Address2 != null)
+                xmlWriter.WriteElementString("address2", Address2);
+            if (City != null)
+                xmlWriter.WriteElementString("city", City);
+            if (State != null)
+                xmlWriter.WriteElementString("state", State);
+            if (Zip != null)
+                xmlWriter.WriteElementString("zip", Zip);
+            if (Country != null)
+                xmlWriter.WriteElementString("country", Country);
+            if (Phone != null)
+                xmlWriter.WriteElementString("phone", Phone);
 
             xmlWriter.WriteEndElement();
         }

--- a/Library/Error.cs
+++ b/Library/Error.cs
@@ -60,7 +60,8 @@ namespace Recurly
             // single error returned
             // <error>
             //    <symbol>asdf</symbol>
-            //    <description>asdfasdf </symbol>
+            //    <description>asdfasdf</description>
+            //    <details>asdfasdfasdfasdf</details>
             // </error>
             while (reader.Read())
             {

--- a/Library/Exception.cs
+++ b/Library/Exception.cs
@@ -50,5 +50,15 @@ namespace Recurly
         {
             Errors = errors;
         }
+
+        public override string ToString()
+        {
+            var details = "";
+            foreach (Error e in Errors)
+                details += e.ToString() + "\n";
+            if (TransactionError != null)
+                details += TransactionError.ToString() + "\n";
+            return string.Format("{0} {1}", details, base.ToString());
+        }
     }
 }

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -215,10 +215,13 @@ namespace Recurly
             xmlWriter.WriteStartElement("purchase"); // Start: purchase
 
             xmlWriter.WriteElementString("collection_method", CollectionMethod.ToString().EnumNameToTransportCase());
+
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.ToString());
 
-            xmlWriter.WriteElementString("po_number", PoNumber);
+            if (PoNumber != null)
+                xmlWriter.WriteElementString("po_number", PoNumber);
+
             xmlWriter.WriteElementString("currency", Currency);
 
             if (ShippingAddressId.HasValue)


### PR DESCRIPTION
While working on #367, I encountered several errors regarding the WriteXML of a few functions. This made me realize two things:

1) We're writing extra elements in the XML that are unnecessary, and we should really be checking for null before writing these elements.
2) The details of the errors are not written when logging the error in the following manner:
```c#
try
{
    // something that will fail validation or transaction
}
catch(RecurlyException e)
{
    Console.WriteLine(e);
}
```
It would be nice if when you log the error somewhere, you could go ahead and see what the details of the error are.

In debug mode, this was logged to my console BEFORE:
```
Recurly Library Received: 400 - BadRequest
Recurly.ValidationException: The information being saved is not valid.
   at Recurly.Client.PerformRequest(HttpRequestMethod method, String urlPath, WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate, ReadXmlListDelegate readXmlListDelegate, ReadResponseDelegate reseponseDelegate) in /Users/asuarez/code/v2/clients/dotnet/Library/Client.cs:line 216
   at Recurly.Client.PerformRequest(HttpRequestMethod method, String urlPath, WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate) in /Users/asuarez/code/v2/clients/dotnet/Library/Client.cs:line 115
   at Recurly.Purchase.Invoice(Purchase purchase) in /Users/asuarez/code/v2/clients/dotnet/Library/Purchase.cs:line 153
   at TestRig.CreatePurchase.Run(String[] args) in /Users/asuarez/code/v2/scripts/dotnet/CreatePurchase.cs:line 20
```
This was written to my console AFTER:
```
Recurly Library Received: 400 - BadRequest
The provided XML was invalid. | Field: "" Code: "" Symbol: "invalid_xml" Details: "13:0: ERROR: Element 'name_on_account': This element is not expected."
 Recurly.ValidationException: The information being saved is not valid.
   at Recurly.Client.PerformRequest(HttpRequestMethod method, String urlPath, WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate, ReadXmlListDelegate readXmlListDelegate, ReadResponseDelegate reseponseDelegate) in /Users/asuarez/code/v2/clients/dotnet/Library/Client.cs:line 216
   at Recurly.Client.PerformRequest(HttpRequestMethod method, String urlPath, WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate) in /Users/asuarez/code/v2/clients/dotnet/Library/Client.cs:line 115
   at Recurly.Purchase.Invoice(Purchase purchase) in /Users/asuarez/code/v2/clients/dotnet/Library/Purchase.cs:line 153
   at TestRig.CreatePurchase.Run(String[] args) in /Users/asuarez/code/v2/scripts/dotnet/CreatePurchase.cs:line 20
```
It took me much longer than necessary to track down the fact that the `name_on_account` element is not expected by the Purchases endpoint. This PR addresses the fact that this element was being sent unnecessarily, as well as the logging issue shown above.