### PR TITLE
Add amazon_region to Billing Info

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -102,6 +102,11 @@ namespace Recurly
         /// </summary>
         public string AmazonBillingAgreementId { get; set; }
 
+        /// <summary>
+        /// Amazon Region
+        /// </summary>
+        public string AmazonRegion { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -326,6 +331,10 @@ namespace Recurly
                         AmazonBillingAgreementId = reader.ReadElementContentAsString();
                         break;
 
+                    case "amazon_region":
+                        AmazonRegion = reader.ReadElementContentAsString();
+                        break;
+
                     case "routing_number":
                         RoutingNumber = reader.ReadElementContentAsString();
                         break;
@@ -403,6 +412,11 @@ namespace Recurly
                 if (!AmazonBillingAgreementId.IsNullOrEmpty())
                 {
                     xmlWriter.WriteElementString("amazon_billing_agreement_id", AmazonBillingAgreementId);
+                }
+
+                if (!AmazonRegion.IsNullOrEmpty())
+                {
+                    xmlWriter.WriteElementString("amazon_region", AmazonRegion);
                 }
 
                 if (ExternalHppType.HasValue)


### PR DESCRIPTION
This adds the new amazon_region attribute to the Billing Info class.

```C#
namespace TestRig
{
    class CreateBillingInfo
    {
        public static void Run(string[] args)
        {
            var account = Accounts.Get("x");
            var info = new BillingInfo(account);
            info.FirstName = "Aaron";
            info.LastName = "Du Monde";
            info.Address1 = "123 Main St";
            info.City = "New Orleans";
            info.State = "LA";
            info.Country = "US";
            info.PostalCode = "70212";
            info.AmazonBillingAgreementId = "C01-1234567-8901234";
            info.AmazonRegion = "eu";

            try
            {
                info.Create();
            }
            catch(RecurlyException e)
            {
                Console.WriteLine(e.Errors[0]);
            }
        }
    }
}
```