### PR TITLE
API version 2.18

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,11 +1,27 @@
 Unreleased
 ===============
 
-### Upgrade Notes
-This release contains one breaking change:
+1.15.0 (stable) / 2019-01-29
+===============
 
+This release brings us up to API version 2.18
+
+* Bug fixes [PR](https://github.com/recurly/recurly-client-net/pull/368)
+* Add support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-net/pull/367)
+* Remove broken test [PR](https://github.com/recurly/recurly-client-net/pull/365)
+* Add SubscriptionChange class [PR](https://github.com/recurly/recurly-client-net/pull/363)
+* Update the User Agent [PR](https://github.com/recurly/recurly-client-net/pull/361)
+
+### Upgrade Notes
+This release contains two breaking changes:
+
+#### 1. Subscription Change Objects
 To update a subscription, a SubscriptionChange object must be passed into the `ChangeSubscription()` method.
 See the C# example in our [dev docs](https://dev.recurly.com/docs/update-subscription).
+
+#### 2. Address requires empty string to clear values
+In the past, if you were to leave a value such as `FirstName` null, it would nullify it via the API.
+Now, you must explicitly nullify it by setting it to empty string `""`. See [this conversation](https://github.com/recurly/recurly-client-net/pull/368#discussion_r246890848) for an example.
 
 1.14.1 (stable) / 2018-12-11
 ===============

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -65,7 +65,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.17";
+        public const string RecurlyApiVersion = "2.18";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.14.1.0")]
-[assembly: AssemblyFileVersion("1.14.1.0")]
+[assembly: AssemblyVersion("1.15.0.0")]
+[assembly: AssemblyFileVersion("1.15.0.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.14.1</version>
+    <version>1.15.0</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.15.0 (stable) / 2019-01-29
===============

This release brings us up to API version 2.18

* Bug fixes [PR](https://github.com/recurly/recurly-client-net/pull/368)
* Add support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-net/pull/367)
* Remove broken test [PR](https://github.com/recurly/recurly-client-net/pull/365)
* Add SubscriptionChange class [PR](https://github.com/recurly/recurly-client-net/pull/363)
* Update the User Agent [PR](https://github.com/recurly/recurly-client-net/pull/361)

### Upgrade Notes
This release contains two breaking changes:

#### 1. Subscription Change Objects
To update a subscription, a SubscriptionChange object must be passed into the `ChangeSubscription()` method.
See the C# example in our [dev docs](https://dev.recurly.com/docs/update-subscription).

#### 2. Address requires empty string to clear values
In the past, if you were to leave a value such as `FirstName` null, it would nullify it via the API.
Now, you must explicitly nullify it by setting it to empty string `""`. See [this conversation](https://github.com/recurly/recurly-client-net/pull/368#discussion_r246890848) for an example.