### PR TITLE
Fix upgrade notes for version 1.14.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -34,7 +34,7 @@ This release brings us up to API version 2.17
 ### Upgrade Notes
 
 This release brings us up to API version 2.16.
-Refunding multiple adjustments requires use of the new Invoice#RefundOptions class.
+The properties RedeemedAt and DeliveredAt of the GiftCard class are now nullable.
 
 1.13.1 (stable) / 2018-09-25
 ===============


### PR DESCRIPTION
The original upgrade notes for version 1.14.0 were incorrect. When this PR is merged, we will also update the [Release tag](https://github.com/recurly/recurly-client-net/releases/tag/1.14.0) as well as the [.Net upgrade guide](https://dev.recurly.com/page/net-upgrade-guide)