### PR TITLE
Fix issue when usage_percentage is null

### DIFF
--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Xml;
+using System.Globalization;
 
 namespace Recurly
 {
@@ -70,7 +71,10 @@ namespace Recurly
                         break;
 
                     case "usage_percentage":
-                        UsagePercentage = reader.ReadElementContentAsFloat();
+                        var usagePercentage = reader.ReadElementContentAsString();
+                        if (Single.TryParse(usagePercentage, NumberStyles.Number,
+                                CultureInfo.InvariantCulture.NumberFormat, out float percentage))
+                            UsagePercentage = percentage;
                         break;
                 }
             }


### PR DESCRIPTION
Fixes #375 

This change reads the tag for `usage_percentage` as a string and then converts it to a float with Invariant culture format so it will be represented the same way regardless of locale settings.