### PR TITLE
Release version 1.15.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,8 +1,15 @@
 Unreleased
 ===============
 
+1.15.1 (stable) / 2019-02-07
+===============
+
+* Fix bug when SubscriptionAddOn.UsagePercentage is null [PR](https://github.com/recurly/recurly-client-net/pull/376)
+
 1.15.0 (stable) / 2019-02-05
 ===============
+
+Note: this release contains a bug in SubscriptionAddoOn. Please use version 1.15.1 or higher instead.
 
 * Bug fixes [PR](https://github.com/recurly/recurly-client-net/pull/368)
 * Remove broken test [PR](https://github.com/recurly/recurly-client-net/pull/365)

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.0.0")]
-[assembly: AssemblyFileVersion("1.15.0.0")]
+[assembly: AssemblyVersion("1.15.1.0")]
+[assembly: AssemblyFileVersion("1.15.1.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.15.0</version>
+    <version>1.15.1</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.15.1 (stable) / 2019-02-07
===============

* Fix bug when SubscriptionAddOn.UsagePercentage is null [PR](https://github.com/recurly/recurly-client-net/pull/376)