### PR TITLE
Release version 1.15.2 / API version 2.18

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 Unreleased
 ===============
 
+1.15.2 (stable) / 2019-02-19
+===============
+
+This release brings us up to API version 2.18
+
+* Add support for Amazon Region [PR](https://github.com/recurly/recurly-client-net/pull/369)
+
 1.15.1 (stable) / 2019-02-07
 ===============
 

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -102,6 +102,11 @@ namespace Recurly
         /// </summary>
         public string AmazonBillingAgreementId { get; set; }
 
+        /// <summary>
+        /// Amazon Region
+        /// </summary>
+        public string AmazonRegion { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -326,6 +331,10 @@ namespace Recurly
                         AmazonBillingAgreementId = reader.ReadElementContentAsString();
                         break;
 
+                    case "amazon_region":
+                        AmazonRegion = reader.ReadElementContentAsString();
+                        break;
+
                     case "routing_number":
                         RoutingNumber = reader.ReadElementContentAsString();
                         break;
@@ -403,6 +412,11 @@ namespace Recurly
                 if (!AmazonBillingAgreementId.IsNullOrEmpty())
                 {
                     xmlWriter.WriteElementString("amazon_billing_agreement_id", AmazonBillingAgreementId);
+                }
+
+                if (!AmazonRegion.IsNullOrEmpty())
+                {
+                    xmlWriter.WriteElementString("amazon_region", AmazonRegion);
                 }
 
                 if (ExternalHppType.HasValue)

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -65,7 +65,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.17";
+        public const string RecurlyApiVersion = "2.18";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.1.0")]
-[assembly: AssemblyFileVersion("1.15.1.0")]
+[assembly: AssemblyVersion("1.15.2.0")]
+[assembly: AssemblyFileVersion("1.15.2.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.15.1</version>
+    <version>1.15.2</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.15.2 (stable) / 2019-02-19
===============

This release brings us up to API version 2.18

* Add support for Amazon Region [PR](https://github.com/recurly/recurly-client-net/pull/369)