### PR TITLE
Fix Subscription Change issues regarding AddOns

### DIFF
--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -6,6 +6,8 @@ namespace Recurly
     {
         private Subscription _subscription;
 
+        public SubscriptionAddOnList() {}
+
         public SubscriptionAddOnList(Subscription subscription)
         {
             _subscription = subscription;
@@ -64,6 +66,14 @@ namespace Recurly
         public void Add(AddOn planAddOn, int quantity = 1)
         {
             int amount = 0;
+
+            if (_subscription == null)
+            {
+                throw new ValidationException(
+                    "SubscriptionAddOnList must be initialized with a Subscription in order to use this method. Try Add(AddOn planAddOn, int quantity, int unitAmountInCents) instead."
+                    , new Errors());
+            }
+
             if (planAddOn.UnitAmountInCents.Count > 0 && !planAddOn.UnitAmountInCents.TryGetValue(_subscription.Currency, out amount))
             {
                 throw new ValidationException(
@@ -100,6 +110,12 @@ namespace Recurly
         // sub.AddOns.Add(code); 1, unitInCents=this.Plan.UnitAmountInCents[this.Currency]
         public void Add(string planAddOnCode, int quantity=1)
         {
+            if (_subscription == null)
+            {
+                throw new ValidationException(
+                    "SubscriptionAddOnList must be initialized with a Subscription in order to use this method. Try Add(string planAddOnCode, int quantity, int unitAmountInCents) instead."
+                    , new Errors());
+            }
             var unitAmount = _subscription.Plan.AddOns.Find(ao => ao.AddOnCode == planAddOnCode).UnitAmountInCents[_subscription.Currency];
             var sub = new SubscriptionAddOn(planAddOnCode, unitAmount, quantity);
             base.Add(sub);
@@ -107,6 +123,12 @@ namespace Recurly
 
         public void Add(string planAddOnCode, AddOn.Type addOnType, int quantity = 1)
         {
+            if (_subscription == null)
+            {
+                throw new ValidationException(
+                    "SubscriptionAddOnList must be initialized with a Subscription in order to use this method. Try Add(string planAddOnCode, AddOn.Type addOnType, int quantity, int unitAmountInCents) instead."
+                    , new Errors());
+            }
             var unitAmount = _subscription.Plan.AddOns.Find(ao => ao.AddOnCode == planAddOnCode).UnitAmountInCents[_subscription.Currency];
             var sub = new SubscriptionAddOn(planAddOnCode, addOnType, unitAmount, quantity);
             base.Add(sub);

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -41,13 +41,8 @@ namespace Recurly
         /// <summary>
         /// List of add ons for this subscription
         /// </summary>
-        public SubscriptionAddOnList AddOns
-        {
-            get { return _addOns ?? (_addOns = new SubscriptionAddOnList(new Subscription())); }
-            set { _addOns = value; }
-        }
+        public SubscriptionAddOnList AddOns { get; set; }
 
-        private SubscriptionAddOnList _addOns;
         /// <summary>
         /// The coupon code you want to redeem in the update.
         /// Only allowed if timeframe is now and you change something about the subscription that creates an invoice.
@@ -101,22 +96,22 @@ namespace Recurly
                 xmlWriter.WriteElementString("quantity", Quantity.ToString());
 
             xmlWriter.WriteStringIfValid("plan_code", PlanCode);
-            xmlWriter.WriteIfCollectionHasAny("subscription_add_ons", AddOns);
+
+            if (AddOns != null)
+                xmlWriter.WriteIfCollectionHasAny("subscription_add_ons", AddOns);
+
             xmlWriter.WriteStringIfValid("coupon_code", CouponCode);
 
             if (UnitAmountInCents.HasValue)
                 xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.Value.AsString());
 
-            if (CollectionMethod.Like("manual"))
-            {
-                xmlWriter.WriteElementString("collection_method", "manual");
+            xmlWriter.WriteStringIfValid("collection_method", CollectionMethod);
+
+            if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
+
+            if (PoNumber != null)
                 xmlWriter.WriteElementString("po_number", PoNumber);
-            }
-            else if (CollectionMethod.Like("automatic"))
-            {
-                xmlWriter.WriteElementString("collection_method", "automatic");
-            }
 
             if (ImportedTrial.HasValue)
                 xmlWriter.WriteElementString("imported_trial", ImportedTrial.Value.ToString().ToLower());


### PR DESCRIPTION
Fixes #379

There were some issues with how SubscriptionAddOns work in this library, and this attempts to fix those issues.

Example script:
```C#
            // Assumes a subscription with uuid "4ac9897d06e86fddcbb62c4a02b54753" 
            // exists on the account
            var subscriptionUuid = "4ac9897d06e86fddcbb62c4a02b54753";

            var change = new SubscriptionChange 
            { 
                TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
                NetTerms = 30,
                PoNumber = "12345",
                AddOns = new SubscriptionAddOnList()
            };

            // Assumes an add on with code "ipaddresses" exists on the account
            var addOnCode = "ipaddresses";
            var quantity = 1;
            var amountInCents = 200;
            change.AddOns.Add(addOnCode, quantity, amountInCents);

            Subscription.ChangeSubscription(subscriptionUuid, change);
```