### PR TITLE
Fix coupon parsing bug

### DIFF
--- a/Recurly.Tests/JsonSerializerTest.cs
+++ b/Recurly.Tests/JsonSerializerTest.cs
@@ -51,16 +51,13 @@ namespace Recurly.UnitTests
         public void DeserializeWithWrongType()
         {
             var json = "{\"my_string\":\"benjamin\",\"my_int\":\"49urj\"}";
-            var resource = _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json));
-            // It should ignore the field that was wrong type but still parse other properties
-            Assert.Null(resource.MyInt);
-            Assert.Equal("benjamin", resource.MyString);
+            Assert.Throws<JsonReaderException>(() => _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json)));
         }
 
         [Fact]
         public void DeserializeWithNewUnrecognizedKey()
         {
-            var json = "{\"my_string\":\"benjamin\",\"unregonized\":\"unknown\"}";
+            var json = "{\"my_string\":\"benjamin\",\"unrecognized\":\"unknown\"}";
             var resource = _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json));
             // It should ignore the the unrecognized new field but still parse other properties
             Assert.Equal("benjamin", resource.MyString);

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -67,7 +67,8 @@ namespace Recurly {
             }
 
             // If we have a body, serialize it and add it to the request
-            if (body != null) {
+            if (body != null)
+            {
                 request.AddJsonBody(body);
             }
 
@@ -76,7 +77,15 @@ namespace Recurly {
             var status = (int)resp.StatusCode;
             Debug.WriteLine($"Status: {status}");
             Debug.WriteLine($"Content: {resp.Content}");
-            if (status < 200 || status >= 300)
+
+            // If the response has an ErrorException,
+            // an error casting the json to a Resource
+            // has likely occurred
+            if (resp.ErrorException != null)
+            {
+                throw new RecurlyError(resp.ErrorMessage);
+            }
+            else if (status < 200 || status >= 300)
             {
                 // Turn web exceptions into Recurly.NetworkErrors
                 if (resp.ErrorException is WebException)

--- a/Recurly/JsonSerializer.cs
+++ b/Recurly/JsonSerializer.cs
@@ -15,15 +15,6 @@ namespace Recurly {
     public class JsonSerializer : ISerializer, IDeserializer
     {
         private Newtonsoft.Json.JsonSerializer serializer;
-        private List<string> _errors;
-        public List<string> Errors {
-            get {
-                if (this._errors == null)
-                    this._errors = new List<string>();
-                return this._errors;
-            }
-        }
-        
         public string RootElement { get; set; }
         public string Namespace { get; set; }
         public string DateFormat { get; set; }
@@ -41,11 +32,6 @@ namespace Recurly {
                 MissingMemberHandling = MissingMemberHandling.Ignore,
                 DateFormatHandling = DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-                Error = delegate(object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
-                {
-                    Errors.Add(args.ErrorContext.Error.Message);
-                    args.ErrorContext.Handled = true;
-                },
                 //Formatting = Formatting.Indented,
             };
             this.serializer = Newtonsoft.Json.JsonSerializer.Create(settings);
@@ -59,14 +45,6 @@ namespace Recurly {
                 using (var jsonTextReader = new JsonTextReader(stringReader))
                 {
                     var obj = serializer.Deserialize<T>(jsonTextReader);
-                    if (Errors.Any())
-                    {
-                        Debug.WriteLine("WARNING: Serialization errors");
-                        foreach (string err in Errors)
-                        {
-                            Debug.WriteLine(err);
-                        }
-                    }
                     return obj;
                 }
             }

--- a/Recurly/Resources/Coupon.cs
+++ b/Recurly/Resources/Coupon.cs
@@ -80,10 +80,6 @@ namespace Recurly.Resources {
     [JsonProperty("name")]
     public string Name { get; set; }
   
-    /// <value>Plans</value>
-    [JsonProperty("plans")]
-    public List<PlanMini> Plans { get; set; }
-  
     /// <value>TODO</value>
     [JsonProperty("plans_names")]
     public List<string> PlansNames { get; set; }


### PR DESCRIPTION
Two changes here:

1. Remove Coupon#Plans. The API is returning both strings and Lists for this property. This won't be fixed until 2018-10-04.
2. No longer display warnings for serialization errors, instead we should throw an exception.