### PR TITLE
Add a Timeout Configuration.

### DIFF
--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -130,6 +130,7 @@ namespace Recurly
         protected virtual HttpStatusCode PerformRequest(HttpRequestMethod method, string urlPath,
             WriteXmlDelegate writeXmlDelegate, ReadXmlDelegate readXmlDelegate, ReadXmlListDelegate readXmlListDelegate, ReadResponseDelegate reseponseDelegate)
         {
+            const int sixtySeconds = 60000;
             var url = Settings.GetServerUri(urlPath);
 #if (DEBUG)
             Console.WriteLine("Requesting " + method + " " + url);
@@ -154,7 +155,7 @@ namespace Recurly
             if ((method == HttpRequestMethod.Post || method == HttpRequestMethod.Put) && (writeXmlDelegate != null))
             {
                 // 60 second timeout -- some payment gateways (e.g. PayPal) can take a while to respond
-                request.Timeout = 60000;
+                request.Timeout = Settings.RequestTimeoutMilliseconds.HasValue ? request.Timeout : sixtySeconds;
 
                 // Write POST/PUT body
                 using (var requestStream = request.GetRequestStream())

--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -147,6 +147,7 @@ namespace Recurly
             request.Headers.Add(HttpRequestHeader.Authorization, Settings.AuthorizationHeaderValue);
             request.Headers.Add("X-Api-Version", Settings.RecurlyApiVersion);
             request.Method = method.ToString().ToUpper();
+            request.Timeout = Settings.RequestTimeoutMilliseconds ?? request.Timeout;
 
             Console.WriteLine(String.Format("Recurly: Requesting {0} {1}", request.Method, request.RequestUri));
 

--- a/Library/Configuration/Section.cs
+++ b/Library/Configuration/Section.cs
@@ -59,7 +59,8 @@ namespace Recurly.Configuration
         /// <summary>
         /// Default request timeout
         /// </summary>
-        public int TimeoutMilliseconds
+        [ConfigurationProperty("timeoutMilliseconds", IsRequired = false, DefaultValue=null)]
+        public int? TimeoutMilliseconds
         {
             get { return (int)base["requestTimeoutMilliseconds"]; }
             set { base["requestTimeoutMilliseconds"] = value; }

--- a/Library/Configuration/Section.cs
+++ b/Library/Configuration/Section.cs
@@ -55,6 +55,15 @@ namespace Recurly.Configuration
             get { return (int)base["pageSize"]; }
             set { base["pageSize"] = value; }
         }
+
+        /// <summary>
+        /// Default request timeout
+        /// </summary>
+        public int TimeoutMilliseconds
+        {
+            get { return (int)base["requestTimeoutMilliseconds"]; }
+            set { base["requestTimeoutMilliseconds"] = value; }
+        }
       
         #endregion
     }

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -64,6 +64,19 @@ namespace Recurly.Configuration
             private set { _pageSize = value; }
         }
 
+        public int? RequestTimeoutMilliseconds
+        {
+            get
+            {
+                if (_hasLoaded == false)
+                {
+                    throw new Exception("The Recurly client has has no configuration initialized, please add your settings to web/app.config or call Recurly.Configuration.SettingsManager.Initialize(args)");
+                }
+                return _requestTimeoutMilliseconds;
+            }
+            private set { _requestTimeoutMilliseconds = value; }
+        }
+
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
         public const string RecurlyApiVersion = "2.19";
         public const string ValidDomain = ".recurly.com";
@@ -101,6 +114,7 @@ namespace Recurly.Configuration
         private int _pageSize;
         private bool _hasLoaded;
         private string _subdomain;
+        private int? _requestTimeoutMilliseconds;
 
         public static Settings Instance
         {
@@ -114,15 +128,17 @@ namespace Recurly.Configuration
             Subdomain = Section.Current.Subdomain;
             PrivateKey = Section.Current.PrivateKey;
             PageSize = Section.Current.PageSize;
+            RequestTimeoutMilliseconds = Section.Current.TimeoutMilliseconds;
             _hasLoaded = true;
         }
 
-        public void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 50)
+        public void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 50, int? requestTimeoutMilliseconds = null)
         {
             ApiKey = apiKey;
             Subdomain = subdomain;
             PrivateKey = privateKey;
             PageSize = pageSize;
+            RequestTimeoutMilliseconds = requestTimeoutMilliseconds;
             _hasLoaded = true;
         }
 

--- a/Library/Configuration/SettingsManager.cs
+++ b/Library/Configuration/SettingsManager.cs
@@ -7,9 +7,10 @@
             Settings.Instance.InitializeFromConfig();
         }
 
-        public static void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 200)
+        public static void Initialize(string apiKey, string subdomain, string privateKey = "", int pageSize = 200,
+            int? requestTimeoutMilliseconds = null)
         {
-            Settings.Instance.Initialize(apiKey, subdomain, privateKey, pageSize);
+            Settings.Instance.Initialize(apiKey, subdomain, privateKey, pageSize, requestTimeoutMilliseconds);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The recommended way to configure the library is to statically initialize it:
 
 ```csharp
 // pageSize is optional and defaults to 200
-Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize);
+Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, privateKey, pageSize);
 ```
 
 ```csharp
 // requestTimeoutMilliseconds is optional and defaults to null
-Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize, requestTimeoutMilliseconds);
+Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, privateKey, pageSize, requestTimeoutMilliseconds);
 ```
 
 We recommend doing this for compatibility with newer .NET frameworks as well as security. We also recommend you encrypt

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize);
 ```
 
 ```csharp
-// requestTimeoutMilliseconds is potional and defaults to null
+// requestTimeoutMilliseconds is optional and defaults to null
 Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize, requestTimeoutMilliseconds);
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ The recommended way to configure the library is to statically initialize it:
 Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize);
 ```
 
+```csharp
+// requestTimeoutMilliseconds is potional and defaults to null
+Recurly.Configuration.SettingsManager.Initialize(apiKey, subdomain, pageSize, requestTimeoutMilliseconds);
+```
+
 We recommend doing this for compatibility with newer .NET frameworks as well as security. We also recommend you encrypt
 your api key at rest or use a secrets service. *You should not store your api key in plain text on your system.*
 

--- a/Test/SettingsManagerTest.cs
+++ b/Test/SettingsManagerTest.cs
@@ -8,12 +8,13 @@ namespace Recurly.Test
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void SetApidKey()
         {
-            SettingsManager.Initialize("api", "subdomain", "private", 100);
+            SettingsManager.Initialize("api", "subdomain", "private", 100, 600);
 
             Assert.True("api" == Settings.Instance.ApiKey);
             Assert.True("subdomain" == Settings.Instance.Subdomain);
             Assert.True("private" == Settings.Instance.PrivateKey);
             Assert.True(100 == Settings.Instance.PageSize);
+            Assert.True(600 == Settings.Instance.RequestTimeoutMilliseconds);
         }
     }
 }


### PR DESCRIPTION
Add a timeout configuration to allow the user to overwrite the default timeout for an httpWebRequest.
