### PR TITLE
Release version 1.15.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,15 @@
 Unreleased
 ===============
 
+1.15.6 (stable) / 2019-05-21
+===============
+
+This release brings us up to API version 2.20. There are no breaking changes.
+
+* Add Default Request Timeout Setting [PR](https://github.com/recurly/recurly-client-net/pull/395)
+* Add Shipping Fees [PR](https://github.com/recurly/recurly-client-net/pull/396)
+* Allow updating a subscription at next bill date [PR](https://github.com/recurly/recurly-client-net/pull/397)
+
 1.15.5 (stable) / 2019-04-30
 ===============
 

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.19";
+        public const string RecurlyApiVersion = "2.20";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/List/ShippingMethodList.cs
+++ b/Library/List/ShippingMethodList.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Net;
+using System.Web;
+using System.Xml;
+
+namespace Recurly
+{
+    public class ShippingMethodList : RecurlyList<ShippingMethod>
+    {
+        internal ShippingMethodList()
+        {
+        }
+
+        internal ShippingMethodList(string baseUrl) : base(Client.HttpRequestMethod.Get, baseUrl)
+        {
+        }
+
+        public override RecurlyList<ShippingMethod> Start
+        {
+            get { return HasStartPage() ? new ShippingMethodList(StartUrl) : RecurlyList.Empty<ShippingMethod>(); }
+        }
+
+        public override RecurlyList<ShippingMethod> Next
+        {
+            get { return HasNextPage() ? new ShippingMethodList(NextUrl) : RecurlyList.Empty<ShippingMethod>(); }
+        }
+
+        public override RecurlyList<ShippingMethod> Prev
+        {
+            get { return HasPrevPage() ? new ShippingMethodList(PrevUrl) : RecurlyList.Empty<ShippingMethod>(); }
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if ((reader.Name == "shipping_methods") && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "shipping_method")
+                {
+                    Add(new ShippingMethod(reader));
+                }
+            }
+        }
+
+        public void ReadFromLocation(HttpWebResponse response)
+        {
+            var url = new Uri(response.Headers["Location"]);
+            NameValueCollection qscoll = HttpUtility.ParseQueryString(url.Query);
+            PerPage = int.Parse(qscoll.Get("per_page"));
+
+            BaseUrl = url.Scheme + "://" + url.Host + ":" + url.Port + url.AbsolutePath + "?cursor=" + qscoll.Get("cursor");
+
+            GetItems();
+        }
+    }
+}

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.5.0")]
-[assembly: AssemblyFileVersion("1.15.5.0")]
+[assembly: AssemblyVersion("1.15.6.0")]
+[assembly: AssemblyFileVersion("1.15.6.0")]

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -58,6 +58,17 @@ namespace Recurly
         private List<Adjustment> _adjustments;
 
         /// <summary>
+        /// List of shipping fees to apply to this purchase
+        /// </summary>
+        public List<ShippingFee> ShippingFees
+        {
+            get { return _shippingFees ?? (_shippingFees = new List<ShippingFee>()); }
+            set { _shippingFees = value; }
+        }
+
+        private List<ShippingFee> _shippingFees;
+
+        /// <summary>
         /// List of coupon codes to apply to this purchase
         /// </summary>
         public List<string> CouponCodes
@@ -247,6 +258,16 @@ namespace Recurly
                     subscription.WriteEmbeddedSubscriptionXml(xmlWriter);
                 }
                 xmlWriter.WriteEndElement(); // End: subscriptions
+            }
+
+            if (ShippingFees.HasAny())
+            {
+                xmlWriter.WriteStartElement("shipping_fees"); // Start: shipping_fees
+                foreach (var shippingFee in ShippingFees)
+                {
+                    shippingFee.WriteEmbeddedXml(xmlWriter);
+                }
+                xmlWriter.WriteEndElement(); // End: shipping_fees
             }
 
             if (CouponCodes.HasAny())

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -84,6 +84,9 @@
     <Compile Include="List\UsageList.cs" />
     <Compile Include="List\ShippingAddressList.cs" />
     <Compile Include="ShippingAddress.cs" />
+    <Compile Include="List\ShippingMethodList.cs" />
+    <Compile Include="ShippingMethod.cs" />
+    <Compile Include="ShippingFee.cs" />
     <Compile Include="Configuration\SettingsManager.cs" />
     <Compile Include="List\MeasuredUnitList.cs" />
     <Compile Include="Usage.cs" />

--- a/Library/ShippingFee.cs
+++ b/Library/ShippingFee.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml;
+
+namespace Recurly
+{
+    public class ShippingFee : RecurlyEntity
+    {
+        public string ShippingMethodCode { get; set; }
+        public int? ShippingAmountInCents { get; set; }
+        private ShippingAddress _shippingAddress;
+
+        public ShippingAddress ShippingAddress
+        {
+            get { return _shippingAddress; }
+            set
+            {
+                if (value.Id.HasValue)
+                {
+                    ShippingAddressId = value.Id.Value;
+                }
+                _shippingAddress = value;
+            }
+        }
+
+        public long? ShippingAddressId { get; set; }
+
+        #region Constructors
+
+        public ShippingFee()
+        {
+        }
+
+        internal ShippingFee(XmlTextReader xmlReader)
+        {
+            ReadXml(xmlReader);
+        }
+
+        #endregion
+
+        #region Read and Write XML documents
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("shipping_fee"); // Start: shipping_fee
+
+            xmlWriter.WriteElementString("shipping_method_code", ShippingMethodCode);
+
+            if (ShippingAmountInCents.HasValue)
+                xmlWriter.WriteElementString("shipping_amount_in_cents", ShippingAmountInCents.Value.AsString());
+
+            if (ShippingAddressId.HasValue)
+            {
+                xmlWriter.WriteElementString("shipping_address_id", ShippingAddressId.Value.ToString());
+            } else if(_shippingAddress != null)
+            {
+                _shippingAddress.WriteXml(xmlWriter);
+            }
+
+            xmlWriter.WriteEndElement(); // End: shipping_fee
+        }
+
+        internal void WriteEmbeddedXml(XmlTextWriter xmlWriter)
+        {
+            WriteXml(xmlWriter);
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return "Recurly Shipping Fee: " + ShippingMethodCode + " " + ShippingAmountInCents;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var shippingFee = obj as ShippingFee;
+            return shippingFee != null && Equals(shippingFee);
+        }
+
+        public bool Equals(ShippingFee shippingFee)
+        {
+            return ShippingMethodCode == shippingFee.ShippingMethodCode &&
+                ShippingAmountInCents == shippingFee.ShippingAmountInCents;
+        }
+
+        public override int GetHashCode()
+        {
+            int? shippingMethodHashCode = ShippingMethodCode?.GetHashCode();
+            int? shippingAmountHashCode = ShippingAmountInCents?.GetHashCode();
+
+            if (shippingMethodHashCode != null && shippingAmountHashCode != null)
+            {
+                return (int) shippingMethodHashCode ^ (int) shippingAmountHashCode;
+            }
+
+            return 0;
+        }
+
+        #endregion
+    }
+}

--- a/Library/ShippingMethod.cs
+++ b/Library/ShippingMethod.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml;
+
+namespace Recurly
+{
+    public class ShippingMethod : RecurlyEntity
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+        public string AccountingCode { get; set; }
+        public string TaxCode { get; set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+
+        internal const string UrlPrefix = "/shipping_methods/";
+
+        private string memberUrl()
+        {
+            return UrlPrefix + Code;
+        }
+
+        #region Constructors
+
+        internal ShippingMethod()
+        {
+        }
+
+        internal ShippingMethod(XmlTextReader xmlReader)
+        {
+            ReadXml(xmlReader);
+        }
+
+        #endregion
+
+        #region Read and Write XML documents
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                // End of shipping_method element, get out of here
+                if (reader.Name == "shipping_method" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                switch (reader.Name)
+                {
+                    case "code":
+                        Code = reader.ReadElementContentAsString();
+                        break;
+
+                    case "name":
+                        Name = reader.ReadElementContentAsString();
+                        break;
+
+                    case "accounting_code":
+                        AccountingCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "tax_code":
+                        TaxCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "created_at":
+                        CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("shipping_method"); // Start: shipping_method
+
+            xmlWriter.WriteElementString("code", Code);
+            xmlWriter.WriteElementString("name", Name);
+            xmlWriter.WriteElementString("accounting_code", AccountingCode);
+            xmlWriter.WriteElementString("tax_code", TaxCode);
+
+            xmlWriter.WriteEndElement(); // End: shipping_method
+        }
+
+        #endregion
+
+        #region Object Overrides
+
+        public override string ToString()
+        {
+            return "Recurly Shipping Method: " + Code;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var shippingMethod = obj as ShippingMethod;
+            return shippingMethod != null && Equals(shippingMethod);
+        }
+
+        public bool Equals(ShippingMethod shippingMethod)
+        {
+            return Code == shippingMethod.Code;
+        }
+
+        public override int GetHashCode()
+        {
+            return Code?.GetHashCode() ?? 0;
+        }
+
+        #endregion
+    }
+
+    public sealed class ShippingMethods
+    {
+        /// <summary>
+        /// Look up a shipping method
+        /// </summary>
+        /// <param name="shippingMethod">Shipping method code</param>
+        /// <returns></returns>
+        public static ShippingMethod Get(string Code)
+        {
+            if (string.IsNullOrWhiteSpace(Code))
+            {
+                return null;
+            }
+
+            var shippingMethod = new ShippingMethod();
+
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
+                ShippingMethod.UrlPrefix + Uri.EscapeDataString(Code),
+                shippingMethod.ReadXml);
+
+            return statusCode == HttpStatusCode.NotFound ? null : shippingMethod;
+        }
+
+        /// <summary>
+        /// Lists shipping methods
+        /// </summary>
+        /// <returns></returns>
+        public static RecurlyList<ShippingMethod> List()
+        {
+            return new ShippingMethodList(ShippingMethod.UrlPrefix);
+        }
+
+        /// <summary>
+        /// Lists shipping methods
+        /// </summary>
+        /// <param name="filter">FilterCriteria used to apply server side sorting and filtering</param>
+        /// <returns></returns>
+        public static RecurlyList<ShippingMethod> List(FilterCriteria filter)
+        {
+            filter = filter ?? FilterCriteria.Instance;
+            var parameters = filter.ToNamedValueCollection();
+
+            return new ShippingMethodList(ShippingMethod.UrlPrefix + "?" + parameters.ToString());
+        }
+    }
+}

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -358,6 +358,18 @@ namespace Recurly
 
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
 
+        /// <summary>
+        /// Unique code associated with the recurring shipping fees for this subscription.
+        /// Required if ShippingAmountInCents is specified.
+        /// </summary>
+        public string ShippingMethodCode { get; set; }
+
+        /// <summary>
+        /// Specifies the amount of recurring shipping fees for this subscription.
+        /// Required if ShippingMethodCode is specified.
+        /// </summary>
+        public int? ShippingAmountInCents { get; set; }
+
         internal Subscription()
         {
             IsPendingSubscription = false;
@@ -853,6 +865,14 @@ namespace Recurly
                         if (DateTime.TryParse(reader.ReadElementContentAsString(), out dateVal))
                             NextBillDate = dateVal;
                         break;
+
+                    case "shipping_method_code":
+                        ShippingMethodCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "shipping_amount_in_cents":
+                        ShippingAmountInCents = reader.ReadElementContentAsInt();
+                        break;
                 }
             }
         }
@@ -996,6 +1016,12 @@ namespace Recurly
                 xmlWriter.WriteElementString("renewal_billing_cycles", RenewalBillingCycles.Value.AsString());
 
             xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
+
+            if (!ShippingMethodCode.IsNullOrEmpty())
+                xmlWriter.WriteElementString("shipping_method_code", ShippingMethodCode);
+
+            if (ShippingAmountInCents.HasValue)
+                xmlWriter.WriteElementString("shipping_amount_in_cents", ShippingAmountInCents.Value.AsString());
 
             xmlWriter.WriteEndElement(); // End: subscription
         }

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -14,7 +14,8 @@ namespace Recurly
         public enum ChangeTimeframe : short
         {
             Now,
-            Renewal
+            Renewal,
+            BillDate
         }
 
         public ChangeTimeframe TimeFrame { get; set; }

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.15.5</version>
+    <version>1.15.6</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.15.6 (stable) / 2019-05-21
===============

This release brings us up to API version 2.20. There are no breaking changes.

* Add Default Request Timeout Setting [PR](https://github.com/recurly/recurly-client-net/pull/395)
* Add Shipping Fees [PR](https://github.com/recurly/recurly-client-net/pull/396)
* Allow updating a subscription at next bill date [PR](https://github.com/recurly/recurly-client-net/pull/397)