### PR TITLE
Implement pagination params

### DIFF
--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -84,22 +84,7 @@ namespace Recurly {
             // If we have any query params, add them to the request
             if (queryParams != null)
             {
-              foreach(KeyValuePair<string, object> entry in queryParams)
-              {
-                  if (entry.Value != null)
-                  {
-                    string stringRepr;
-                    if (entry.Value.GetType() == typeof(DateTime))
-                    {
-                        stringRepr = ((DateTime)entry.Value).ToString("o");
-                    }
-                    else
-                    {
-                        stringRepr = entry.Value.ToString();
-                    }
-                    request.AddQueryParameter(entry.Key.ToString(), stringRepr);
-                  }
-              }
+                url += Utils.QueryString(queryParams);
             }
 
             // If we have a body, serialize it and add it to the request

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -27,7 +27,11 @@ namespace Recurly {
 
         internal static Pager<T> Build(string url, Dictionary<string, object> queryParams, Client client)
         {
-            // TODO - need to properly build URL from queryParams
+            if (queryParams != null)
+            {
+                url += Utils.QueryString(queryParams);
+            }
+
             return new Pager<T>()
             {
                 HasMore = true,

--- a/Recurly/Utils.cs
+++ b/Recurly/Utils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Recurly {
@@ -16,6 +17,34 @@ namespace Recurly {
 
             return newString.ToString();
         }
+
+        public static string QueryString(Dictionary<string, object> queryParams) {
+            var qString = new List<string>();
+
+            foreach (var param in queryParams)
+            {
+                if (param.Value != null)
+                {
+                    string stringRepr;
+                    if (param.Value.GetType() == typeof(DateTime))
+                    {
+                        stringRepr = ((DateTime)param.Value).ToString("o");
+                    }
+                    else
+                    {
+                        stringRepr = param.Value.ToString();
+                    }
+                    qString.Add($"{param.Key}={Uri.EscapeUriString(stringRepr)}");
+                }
+            }
+
+            if (qString.Count > 0) {
+                return "?" + String.Join("&", qString);
+            } else {
+                return String.Empty;
+            }
+        }
+
     }
     
 }


### PR DESCRIPTION
This ensures the query params that were passed to the pager builder are used. Even though RestSharp handles some of this for the BaseClient, I decided to share the implementation in Utils.QueryString so there weren't 2 places where we have to do the casting and encoding.

We might change this interface in the future to support a `PaginationOptions` object or something similar instead of all of these arguments. For now, let's make this work.

Example use:

```csharp
// set page size to 200 and begin time to 2019/04/01 
var accounts = client.ListAccounts(null, 200, null, null, new DateTime(2019, 4, 1));
foreach(var account in accounts)
{
    Console.WriteLine(account.Code);
}
```

