### PR TITLE
Update pagination doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ var accounts = client.ListAccounts();
 while(accounts.HasMore)
 {
     Console.WriteLine("Fetching next page...");
-    accounts = accounts.FetchNextPage();
+    accounts.FetchNextPage();
     foreach(Account a in accounts.Data)
     {
       Console.WriteLine($"Account: {a.CreatedAt}");
@@ -104,7 +104,7 @@ var accounts = client.ListAccounts();
 while(accounts.HasMore)
 {
     Console.WriteLine("Fetching next page...");
-    accounts = await accounts.FetchNextPageAsync();
+    await accounts.FetchNextPageAsync();
     foreach(Account a in accounts.Data)
     {
       Console.WriteLine($"Account: {a.CreatedAt}");

--- a/Recurly.Tests/PagerTest.cs
+++ b/Recurly.Tests/PagerTest.cs
@@ -51,6 +51,42 @@ namespace Recurly.Tests
             pager.Dispose();
         }
 
+        [Fact]
+        public void EnumerablePagesTest()
+        {
+            var pager = Pager<MyResource>.Build("/next", new Dictionary<string, object> { }, GetPagerSuccessClient());
+
+            var total = 0;
+            var page = 0;
+            while (pager.HasMore)
+            {
+                pager.FetchNextPage();
+                var count = 0;
+                page++;
+                foreach (MyResource r in pager.Data)
+                {
+                    count++;
+                    total++;
+                }
+                if (page == 1)
+                {
+                    Assert.Equal(count, 3);
+                }
+                else if (page == 2)
+                {
+                    Assert.Equal(count, 2);
+                }
+                else
+                {
+                    Assert.True(false, $"Should not have reached this page: {page}");
+                }
+            }
+
+            // There should be 5 resources since
+            // there is a second page
+            Assert.Equal(5, total);
+        }
+
         private Recurly.Client GetPagerSuccessClient()
         {
             var page1 = new Pager<MyResource>()


### PR DESCRIPTION
* Update paginate by page examples. Don't need to reassign the pager object since it returns this. This interface was not implemented.
* Add test for this example just for assurances.

