### PR TITLE
Add 3DS tokens to transaction error and billing info

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -107,6 +107,11 @@ namespace Recurly
         /// </summary>
         public string AmazonRegion { get; set; }
 
+        /// <summary>
+        /// 3DSecure Action Result Token ID
+        /// </summary>
+        public string ThreeDSecureActionResultTokenId { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -441,6 +446,7 @@ namespace Recurly
             }
 
             xmlWriter.WriteStringIfValid("token_id", TokenId);
+            xmlWriter.WriteStringIfValid("three_d_secure_action_result_token_id", ThreeDSecureActionResultTokenId);
 
             xmlWriter.WriteEndElement(); // End: billing_info
         }

--- a/Library/TransactionError.cs
+++ b/Library/TransactionError.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Xml;
+using System.Linq;
 
 namespace Recurly
 {
@@ -49,6 +50,11 @@ namespace Recurly
         /// </summary>
         public string GatewayErrorCode { get; internal set; }
 
+        /// <summary>
+        /// The 3DS Action token to pass into RecurlyJS
+        /// </summary>
+        public string ThreeDSecureActionTokenId { get; internal set; }
+
         public TransactionError() { }
 
         internal TransactionError(XmlTextReader reader)
@@ -77,14 +83,16 @@ namespace Recurly
                     case "gateway_error_code":
                         GatewayErrorCode = reader.ReadElementContentAsString();
                         break;
+                    case "three_d_secure_action_token_id":
+                        ThreeDSecureActionTokenId = reader.ReadElementContentAsString();
+                        break;
                 }
             }
         }
 
         public override string ToString()
         {
-            return string.Format("Code: \"{0}\" Category: \"{1}\" CustomerMessage: \"{2}\" MerchantAdvice: \"{3}\" GatewayCode: \"{4}\""
-                , ErrorCode, ErrorCategory, CustomerMessage, MerchantAdvice, GatewayErrorCode);
+            return String.Concat(this.GetType().GetProperties().Select(i=>$"{i.Name}: \"{i.GetValue(this, null)}\" "));
         }
 
         internal static TransactionError ReadResponseAndParseError(HttpWebResponse response)

--- a/Library/TransactionErrorEnum.cs
+++ b/Library/TransactionErrorEnum.cs
@@ -90,6 +90,11 @@
         recurly_failed_to_get_token,
         recurly_token_not_found,
 
-        not_recognized
+        // NOTE: not_recognized is used as a default and does not reflect a
+        // valid value from the Recurly API. To preserve backwards compatibility,
+        // order of this enum should be preserved and new values must be appended.
+        not_recognized,
+
+        three_d_secure_action_required
     }
 }


### PR DESCRIPTION
This allows the client to use the new 3DSecure features of the API. This involves a 2 step flow with RecurlyJS, see https://github.com/recurly/recurly-js/pull/527 for technical details on that side of this process.

Script 1: Attempt to update a billing info with a credit card that requires 3DS authentication:
```C#
var account = Accounts.Get("x");
var info = new BillingInfo(account);
info.FirstName = "Aaron";
info.LastName = "Du Monde";
info.Address1 = "123 Main St";
info.City = "New Orleans";
info.State = "LA";
info.Country = "US";
info.PostalCode = "70212";
info.CreditCardNumber = "4000000000003220";
info.ExpirationMonth = 10;
info.ExpirationYear = 2020;

try
{
    info.Create();
}
catch(RecurlyException e)
{
    if (e.TransactionError.ErrorCodeEnum == TransactionErrorCodeEnum.three_d_secure_action_required)
    {
        // Get the 3DS Action Token ID and pass it into RJS to authenticate
        Console.WriteLine(e.TransactionError.ThreeDSecureActionTokenId);
    }
    else
    {
        // Something else went wrong
        Console.WriteLine(e);
    }
}
```

The `RecurlyException`'s `TransactionError` will contain a `TransactionErrorCodeEnum.three_d_secure_action_required` in its `TransactionErrorCodeEnum` property. This value needs to be passed to RJS for authentication. Upon successful authentication, RJS will return a result token, which can then be passed with the billing info.

Script 2: Update the billing info using 3DS:
```C#
var account = Accounts.Get("x");
var info = new BillingInfo(account);
info.FirstName = "Aaron";
info.LastName = "Du Monde";
info.Address1 = "123 Main St";
info.City = "New Orleans";
info.State = "LA";
info.Country = "US";
info.PostalCode = "70212";
info.CreditCardNumber = "4000000000003220";
info.ExpirationMonth = 10;
info.ExpirationYear = 2020;
info.ThreeDSecureActionResultTokenId = "LASEUHaurq3Wep9VM4V3rg";

try
{
    info.Create();
    Console.WriteLine("Success!");
}
catch(RecurlyException e)
{
     Console.WriteLine(e);
}
```

This flow still applies when passing a `billing_info` object to the `/accounts`, `/subscriptions`, and `/purchases` endpoints.