### PR TITLE
Bump to version 1.15.7

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Unreleased
 ===============
 
+1.15.7 (stable) / 2019-06-18
+===============
+
+* Allow programmer to change the PlanCode [PR](https://github.com/recurly/recurly-client-net/pull/414)
+
 1.15.6 (stable) / 2019-05-21
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.6.0")]
-[assembly: AssemblyFileVersion("1.15.6.0")]
+[assembly: AssemblyVersion("1.15.7.0")]
+[assembly: AssemblyFileVersion("1.15.7.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.15.6</version>
+    <version>1.15.7</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.15.7 (stable) / 2019-06-18
===============

* Allow programmer to change the PlanCode [PR](https://github.com/recurly/recurly-client-net/pull/414)