### PR TITLE
Fix timeoutMilliseconds when using config file

### DIFF
--- a/Library/Configuration/Section.cs
+++ b/Library/Configuration/Section.cs
@@ -59,11 +59,11 @@ namespace Recurly.Configuration
         /// <summary>
         /// Default request timeout
         /// </summary>
-        [ConfigurationProperty("timeoutMilliseconds", IsRequired = false, DefaultValue=null)]
+        [ConfigurationProperty("timeoutMilliseconds", IsRequired = false, DefaultValue=60000)]
         public int? TimeoutMilliseconds
         {
-            get { return (int)base["requestTimeoutMilliseconds"]; }
-            set { base["requestTimeoutMilliseconds"] = value; }
+            get { return (int)base["timeoutMilliseconds"]; }
+            set { base["timeoutMilliseconds"] = value; }
         }
       
         #endregion

--- a/Test/SettingsManagerTest.cs
+++ b/Test/SettingsManagerTest.cs
@@ -3,10 +3,10 @@ using Xunit;
 
 namespace Recurly.Test
 {
-    public class SettingsManagerTest
+    public class SettingsManagerTest : BaseTest
     {
         [RecurlyFact(TestEnvironment.Type.Integration)]
-        public void SetApidKey()
+        public void SetApiKey()
         {
             SettingsManager.Initialize("api", "subdomain", "private", 100, 600);
 
@@ -15,6 +15,18 @@ namespace Recurly.Test
             Assert.True("private" == Settings.Instance.PrivateKey);
             Assert.True(100 == Settings.Instance.PageSize);
             Assert.True(600 == Settings.Instance.RequestTimeoutMilliseconds);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void SetFromConfigFile()
+        {
+            SettingsManager.InitializeFromConfig();
+
+            Assert.NotNull(Settings.Instance.ApiKey);
+            Assert.NotNull(Settings.Instance.Subdomain);
+            Assert.NotNull(Settings.Instance.PrivateKey);
+            Assert.NotNull(Settings.Instance.PageSize);
+            Assert.NotNull(Settings.Instance.RequestTimeoutMilliseconds);
         }
     }
 }


### PR DESCRIPTION
Fixes #417 

The problem was both that the property needed to be changed to `timeoutMilliseconds` and that defaulting to `null` would result in another NullReferenceException. This fixes both of those problems, and adds a test around the configuration file so we'll hopefully catch this if something changes again.