### PR TITLE
Accommodate null value in Bank Account Type

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -340,7 +340,10 @@ namespace Recurly
                         break;
 
                     case "account_type":
-                        AccountType = reader.ReadElementContentAsString().ParseAsEnum<BankAccountType>();
+
+                        var accountType = reader.ReadElementContentAsString();
+                        if (!accountType.IsNullOrEmpty())
+                            AccountType = accountType.ParseAsEnum<BankAccountType>();
                         break;
 
                     case "external_hpp_type":


### PR DESCRIPTION
Hi,

I have experienced an issue when retrieving invoices for a particular account. I have submitted to support (see ticket 447037). 

It seems that the XML returned by the api has 'account_type' field as a null value. The SDK then fails with 'Cannot convert a null or empty string to an Enumeration'. 

The submitted patch will only try to parse the account_type field as an enum if the account_type field has a value.

Thanks