### PR TITLE
Only send Address object if Address properties were changed

### DIFF
--- a/Library/Address.cs
+++ b/Library/Address.cs
@@ -110,5 +110,36 @@ namespace Recurly
 
             xmlWriter.WriteEndElement();
         }
+
+        public bool Equals(object that)
+        {
+            if (null == that)
+                return false;
+            if (object.ReferenceEquals(this, that))
+                return true;
+            if (this.GetType() != that.GetType())
+                return false;
+            return this.CompareMembers(that as Address);
+        }
+
+        private bool CompareMembers(Address that)
+        {
+            if (this.FirstName != that.FirstName) return false;
+            if (this.LastName != that.LastName) return false;
+            if (this.NameOnAccount != that.NameOnAccount) return false;
+            if (this.Company != that.Company) return false;
+            if (this.Address1 != that.Address1) return false;
+            if (this.Address2 != that.Address2) return false;
+            if (this.City != that.City) return false;
+            if (this.State != that.State) return false;
+            if (this.Zip != that.Zip) return false;
+            if (this.Country != that.Country) return false;
+            if (this.Phone != that.Phone) return false;
+            return true;
+        }
+
+        public virtual object Clone() {
+            return this.MemberwiseClone();
+        }
     }
 }

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -108,6 +108,9 @@ namespace Recurly
         }
         private Address _address;
 
+        // Preserve original address in case the user wants to change a field in the address
+        private Address _referenceAddress;
+
         public ShippingAddress ShippingAddress { get; private set; }
 
         /// <summary>
@@ -586,6 +589,7 @@ namespace Recurly
 
                     case "address":
                         Address = new Address(reader);
+                        _referenceAddress = (Address) Address.Clone();
                         break;
 
                     case "shipping_address":
@@ -665,12 +669,18 @@ namespace Recurly
         {
             xmlWriter.WriteStartElement("invoice"); // Start: invoice
 
-            Address.WriteXml(xmlWriter);
-            xmlWriter.WriteElementString("customer_notes", CustomerNotes);
-            xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
-            xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
-            xmlWriter.WriteElementString("gateway_code", GatewayCode);
-            xmlWriter.WriteElementString("po_number", PoNumber);
+            if (!Address.Equals(_referenceAddress)) Address.WriteXml(xmlWriter);
+
+            if (CustomerNotes != null)
+                xmlWriter.WriteElementString("customer_notes", CustomerNotes);
+            if (TermsAndConditions != null)
+                xmlWriter.WriteElementString("terms_and_conditions", TermsAndConditions);
+            if (VatReverseChargeNotes != null)
+                xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
+            if (GatewayCode != null)
+                xmlWriter.WriteElementString("gateway_code", GatewayCode);
+            if (PoNumber != null)
+                xmlWriter.WriteElementString("po_number", PoNumber);
 
             if (NetTerms.HasValue && _netTermsChanged)
             {


### PR DESCRIPTION
When updating an invoice, more XML elements are written than what was actually changed. This can cause problems if, for example, a site has taxes enabled and an invoice is previously taxed (meaning that the address cannot be updated).

Suppose you want to update the invoice PO number. The XML should look like this:
```xml
<?xml version="1.0" encoding="utf-8"?>
<invoice>
  <po_number>1-I1</po_number>
</invoice> 
```

Currently, an Address object is also sent with the invoice update, like so:
```xml
<?xml version="1.0" encoding="utf-8"?>
<invoice>
  <address>
    <first_name>Aaron</first_name>
    <last_name>Du Monde</last_name>
    <name_on_account />
    <company />
    <address1>900 Camp St.</address1>
    <address2 />
    <city>New Orleans</city>
    <state>LA</state>
    <zip>70115</zip>
    <country>US</country>
    <phone />
  </address>
  <customer_notes />
  <terms_and_conditions />
  <vat_reverse_charge_notes />
  <gateway_code />
  <po_number>1-I1</po_number>
</invoice>
```

This PR also removes the `customer_notes`, `terms_and_conditions`, `vat_reverse_charge_notes`, `gateway_code` and `po_number` from the request unless they are explicitly set as empty strings. The API will sometimes return empty strings for these values when they aren't explicitly set, but now if you would like the request to avoid including those empty strings, you can set them to null.

Script:
```c#
// Assumes invoice 3256 exists on the site
var invoice = Invoices.Get(3256);
invoice.PoNumber= "1-I1";
invoice.CustomerNotes = null;
try
{
    invoice.Update();
}
catch(ValidationException e)
{
    Console.WriteLine(e);
    foreach (var err in e.Errors) {
        Console.WriteLine(err);
    }
}
```
