### PR TITLE
Add missing properties to NewAdjustment method

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -398,44 +398,11 @@ namespace Recurly
         /// <param name="description">Description of the adjustment for the invoice.</param>
         /// <param name="quantity">Quantity, defaults to 1.</param>
         /// <param name="accountingCode">Accounting code. Max of 20 characters.</param>
-        /// <param name="taxExempt">True exempts tax on the charge, false applies tax on the charge.</param>
-        /// <param name="revenueScheduleType">Sets a revenue schedule type.</param>
-        /// <param name="taxCode">For EU VAT merchants and Avalara AvaTax Pro merchants.</param>
-        /// <param name="startDate">A timestamp associated with when the charge began.</param>
-        /// <param name="endDate">A timestamp associated with when the charge ended.</param>
-        /// <param name="productCode">The product code or SKU of the line item. Max of 50 characters.</param>
-        /// <param name="origin">Only allowed if the Gift Cards feature is enabled on your site and unit_amount_in_cents is negative. Can only have a value of external_gift_card.</param>
+        /// <param name="taxExempt"></param>
         /// <returns></returns>
-        public Adjustment NewAdjustment(
-            string currency,
-            int unitAmountInCents,
-            string description = "",
-            int quantity = 1,
-            string accountingCode = "",
-            bool taxExempt = false,
-            Adjustment.RevenueSchedule? revenueScheduleType = null,
-            string taxCode = null,
-            DateTime? startDate = null,
-            DateTime? endDate = null,
-            string productCode = null,
-            string origin = null
-        )
+        public Adjustment NewAdjustment(string currency, int unitAmountInCents, string description = "", int quantity = 1, string accountingCode = "", bool taxExempt = false)
         {
-            return new Adjustment(
-                AccountCode,
-                description,
-                currency,
-                unitAmountInCents,
-                quantity,
-                accountingCode,
-                taxExempt,
-                revenueScheduleType,
-                taxCode,
-                startDate,
-                endDate,
-                productCode,
-                origin
-            );
+            return new Adjustment(AccountCode, description, currency, unitAmountInCents, quantity, accountingCode, taxExempt);
         }
 
         /// <summary>

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -398,12 +398,44 @@ namespace Recurly
         /// <param name="description">Description of the adjustment for the invoice.</param>
         /// <param name="quantity">Quantity, defaults to 1.</param>
         /// <param name="accountingCode">Accounting code. Max of 20 characters.</param>
-        /// <param name="taxExempt"></param>
+        /// <param name="taxExempt">True exempts tax on the charge, false applies tax on the charge.</param>
+        /// <param name="revenueScheduleType">Sets a revenue schedule type.</param>
+        /// <param name="taxCode">For EU VAT merchants and Avalara AvaTax Pro merchants.</param>
+        /// <param name="startDate">A timestamp associated with when the charge began.</param>
+        /// <param name="endDate">A timestamp associated with when the charge ended.</param>
+        /// <param name="productCode">The product code or SKU of the line item. Max of 50 characters.</param>
+        /// <param name="origin">Only allowed if the Gift Cards feature is enabled on your site and unit_amount_in_cents is negative. Can only have a value of external_gift_card.</param>
         /// <returns></returns>
-        public Adjustment NewAdjustment(string currency, int unitAmountInCents, string description = "", int quantity = 1, string accountingCode = "", bool taxExempt = false)
+        public Adjustment NewAdjustment(
+            string currency,
+            int unitAmountInCents,
+            string description = "",
+            int quantity = 1,
+            string accountingCode = "",
+            bool taxExempt = false,
+            Adjustment.RevenueSchedule? revenueScheduleType = null,
+            string taxCode = null,
+            DateTime? startDate = null,
+            DateTime? endDate = null,
+            string productCode = null,
+            string origin = null
+        )
         {
-            // TODO All of the properties should be settable
-            return new Adjustment(AccountCode, description, currency, unitAmountInCents, quantity, accountingCode, taxExempt);
+            return new Adjustment(
+                AccountCode,
+                description,
+                currency,
+                unitAmountInCents,
+                quantity,
+                accountingCode,
+                taxExempt,
+                revenueScheduleType,
+                taxCode,
+                startDate,
+                endDate,
+                productCode,
+                origin
+            );
         }
 
         /// <summary>

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -38,7 +38,7 @@ namespace Recurly
         public string Description { get; set; }
         public string AccountingCode { get; set; }
         public string ProductCode { get; set; }
-        public string Origin { get; protected set; }
+        public string Origin { get; set; }
         public int UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
         public int DiscountInCents { get; protected set; }
@@ -62,8 +62,8 @@ namespace Recurly
 
         public bool? Prorate { internal get; set; }
 
-        public DateTime? StartDate { get; protected set; }
-        public DateTime? EndDate { get; protected set; }
+        public DateTime StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
 
         public DateTime? CreatedAt { get ; protected set; }
         public DateTime UpdatedAt { get; private set; }
@@ -89,21 +89,7 @@ namespace Recurly
             
         }
 
-        internal Adjustment(
-            string accountCode,
-            string description,
-            string currency,
-            int unitAmountInCents,
-            int quantity,
-            string accountingCode = "",
-            bool taxExempt = false,
-            RevenueSchedule? revenueScheduleType = null,
-            string taxCode = null,
-            DateTime? startDate = null,
-            DateTime? endDate = null,
-            string productCode = null,
-            string origin = null
-        )
+        internal Adjustment(string accountCode, string description, string currency, int unitAmountInCents, int quantity, string accountingCode = "", bool taxExempt = false)
         {
             AccountCode = accountCode;
             Description = description;
@@ -112,12 +98,6 @@ namespace Recurly
             Quantity = quantity;
             AccountingCode = accountingCode;
             TaxExempt = taxExempt;
-            RevenueScheduleType = revenueScheduleType;
-            TaxCode = taxCode;
-            StartDate = startDate;
-            EndDate = endDate;
-            ProductCode = productCode;
-            Origin = origin;
             State = AdjustmentState.Pending;
 
             if (!AccountingCode.IsNullOrEmpty() && AccountingCode.Length > AccountingCodeMaxLength)
@@ -319,8 +299,8 @@ namespace Recurly
                 xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
             if (TaxCode != null)
                 xmlWriter.WriteElementString("tax_code", TaxCode);
-            if (StartDate.HasValue)
-                xmlWriter.WriteElementString("start_date", StartDate.Value.ToString("s"));
+            if (StartDate != DateTime.MinValue)
+                xmlWriter.WriteElementString("start_date", StartDate.ToString("s"));
             if (EndDate.HasValue)
                 xmlWriter.WriteElementString("end_date", EndDate.Value.ToString("s"));
             if (Origin != null)

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -62,7 +62,7 @@ namespace Recurly
 
         public bool? Prorate { internal get; set; }
 
-        public DateTime StartDate { get; protected set; }
+        public DateTime? StartDate { get; protected set; }
         public DateTime? EndDate { get; protected set; }
 
         public DateTime? CreatedAt { get ; protected set; }
@@ -89,7 +89,21 @@ namespace Recurly
             
         }
 
-        internal Adjustment(string accountCode, string description, string currency, int unitAmountInCents, int quantity, string accountingCode = "", bool taxExempt = false)
+        internal Adjustment(
+            string accountCode,
+            string description,
+            string currency,
+            int unitAmountInCents,
+            int quantity,
+            string accountingCode = "",
+            bool taxExempt = false,
+            RevenueSchedule? revenueScheduleType = null,
+            string taxCode = null,
+            DateTime? startDate = null,
+            DateTime? endDate = null,
+            string productCode = null,
+            string origin = null
+        )
         {
             AccountCode = accountCode;
             Description = description;
@@ -98,6 +112,12 @@ namespace Recurly
             Quantity = quantity;
             AccountingCode = accountingCode;
             TaxExempt = taxExempt;
+            RevenueScheduleType = revenueScheduleType;
+            TaxCode = taxCode;
+            StartDate = startDate;
+            EndDate = endDate;
+            ProductCode = productCode;
+            Origin = origin;
             State = AdjustmentState.Pending;
 
             if (!AccountingCode.IsNullOrEmpty() && AccountingCode.Length > AccountingCodeMaxLength)
@@ -297,6 +317,14 @@ namespace Recurly
                 xmlWriter.WriteElementString("currency", Currency);
             if (RevenueScheduleType.HasValue)
                 xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+            if (TaxCode != null)
+                xmlWriter.WriteElementString("tax_code", TaxCode);
+            if (StartDate.HasValue)
+                xmlWriter.WriteElementString("start_date", StartDate.Value.ToString("s"));
+            if (EndDate.HasValue)
+                xmlWriter.WriteElementString("end_date", EndDate.Value.ToString("s"));
+            if (Origin != null)
+                xmlWriter.WriteElementString("origin", Origin);
             xmlWriter.WriteEndElement(); // End: adjustment
         }
 


### PR DESCRIPTION
This adds missing properties to the XML serializer of the `Adjustment` class.

Script:
```C#
var account = Accounts.Get("x");
var adjustment = account.NewAdjustment(
    "USD",                        // currency
    5000,                         // unit_amount_in_cents
    "Charge for extra bandwidth", // description
    1,                            // quantity
    "bandwidth",                  // accounting_code
    false                         // tax_exempt
);                       
adjustment.RevenueScheduleType = Adjustment.RevenueSchedule.AtInvoice;
adjustment.StartDate = new DateTime(2019, 6, 11);
adjustment.EndDate = new DateTime(2019, 7, 11);
adjustment.Create();
```