### PR TITLE
Bump to version 1.16.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,26 @@
 Unreleased
 ===============
 
+1.16.0 (stable) / 2019-07-16
+===============
+
+* Fix timeoutMilliseconds when using config file [PR](https://github.com/recurly/recurly-client-net/pull/420)
+* Only send Address object if Address properties were changed [PR](https://github.com/recurly/recurly-client-net/pull/426)
+* Add missing properties to XML serializer for Adjustment class  [PR](https://github.com/recurly/recurly-client-net/pull/427)
+
+### Upgrade Notes
+This release contains one breaking change:
+
+When updating an Invoice, the embedded Address object is only sent to the API if explicitly set on the object, and the following fields require an empty string to clear values:
+- CustomerNotes
+- TermsAndConditions
+- VatReverseChargeNotes
+- GatewayCode
+- PoNumber
+
+In the past, if you were to leave a value such as `CustomerNotes` null, it would nullify it via the API.
+Now, you must explicitly nullify it by setting it to empty string `""`. See [this conversation](https://github.com/recurly/recurly-client-net/pull/368#discussion_r246890848) for an example.
+
 1.15.8 (stable) / 2019-06-27
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.8.0")]
-[assembly: AssemblyFileVersion("1.15.8.0")]
+[assembly: AssemblyVersion("1.16.0.0")]
+[assembly: AssemblyFileVersion("1.16.0.0")]

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -78,7 +78,7 @@ namespace Recurly.Test
             {
                 billingInfo.Update();
             }
-            catch (NotFoundException exception)
+            catch (ValidationException exception)
             {
                 threw = true;
                 exception.Errors[0].Symbol.Should().Be("token_invalid");

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.15.8</version>
+    <version>1.16.0</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.16.0 (stable) / 2019-07-16
===============

* Fix timeoutMilliseconds when using config file [PR](https://github.com/recurly/recurly-client-net/pull/420)
* Only send Address object if Address properties were changed [PR](https://github.com/recurly/recurly-client-net/pull/426)
* Add missing properties to XML serializer for Adjustment class  [PR](https://github.com/recurly/recurly-client-net/pull/427)

### Upgrade Notes
This release contains one breaking change:

When updating an Invoice, the embedded Address object is only sent to the API if explicitly set on the object, and the following fields require an empty string to clear values:
- CustomerNotes
- TermsAndConditions
- VatReverseChargeNotes
- GatewayCode
- PoNumber

In the past, if you were to leave a value such as `CustomerNotes` null, it would nullify it via the API.
Now, you must explicitly nullify it by setting it to empty string `""`. See [this conversation](https://github.com/recurly/recurly-client-net/pull/368#discussion_r246890848) for an example.