### PR TITLE
Terms timeframe enum change

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -434,10 +434,16 @@ namespace Recurly
         /// Cancel an active subscription.  The subscription will not renew, but will continue to be active
         /// through the remainder of the current term.
         /// </summary>
-        public void Cancel()
+        public void Cancel(SubscriptionChange.ChangeTimeframe? timeframe = null)
         {
+            var url = UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel";
+            if (timeframe != null)
+            {
+                url += "?timeframe=" + timeframe.ToString().EnumNameToTransportCase();
+            }
+
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
-                UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel",
+                url,
                 ReadXml);
         }
 

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -15,7 +15,8 @@ namespace Recurly
         {
             Now,
             Renewal,
-            BillDate
+            BillDate,
+            TermEnd
         }
 
         public ChangeTimeframe TimeFrame { get; set; }


### PR DESCRIPTION
Adds term_end to the Timeframe values. This affects
Subscription#ChangeSubscription, Subscription#PreviewChange
and Subscription#Cancel.

Subscription#ChangeSubscription and Subscription#PreviewChange have been updated to no longer accept the Renewal timeframe.
Instead, merchants will be able to send timeframes of BillDate or TermEnd.
These timeframes are aligned to "current_period_ends_at" and "current_term_ends_at", respectively.

Subscription#Cancel has been updated to accept the "timeframe" parameter. It accepts values of BillDate or TermEnd.