### PR TITLE
MOTO transactions

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -52,6 +52,7 @@ namespace Recurly
         public bool HasPastDueInvoice { get; private set; }
         public string PreferredLocale { get; set; }
         public string ParentAccountCode { get; set; }
+        public string TransactionType { get; set; }
 
         private AccountAcquisition _accountAcquisition;
 
@@ -675,6 +676,9 @@ namespace Recurly
 
             xmlWriter.WriteIfCollectionHasAny("shipping_addresses", ShippingAddresses);
             xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             // Clear the parent account by writing empty string. Null should not clear parent.
             if (ParentAccountCode != null)

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -112,6 +112,8 @@ namespace Recurly
         /// </summary>
         public string ThreeDSecureActionResultTokenId { get; set; }
 
+        public string TransactionType { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -447,6 +449,9 @@ namespace Recurly
                     xmlWriter.WriteElementString("card_type", card);
                 }
             }
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             xmlWriter.WriteStringIfValid("token_id", TokenId);
             xmlWriter.WriteStringIfValid("three_d_secure_action_result_token_id", ThreeDSecureActionResultTokenId);

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -117,6 +117,11 @@ namespace Recurly
         /// </summary>
         public string GatewayCode { get; set; }
 
+        /// <summary>
+        /// Optional type flag for the gateway transaction. Currently accepts only "moto".
+        /// </summary>
+        public string TransactionType { get; set; }
+
         #region Constructors
 
         internal Purchase()
@@ -226,6 +231,9 @@ namespace Recurly
             xmlWriter.WriteStartElement("purchase"); // Start: purchase
 
             xmlWriter.WriteElementString("collection_method", CollectionMethod.ToString().EnumNameToTransportCase());
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.ToString());

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -370,6 +370,8 @@ namespace Recurly
         /// </summary>
         public int? ShippingAmountInCents { get; set; }
 
+        public string TransactionType { get; set; }
+
         internal Subscription()
         {
             IsPendingSubscription = false;
@@ -1022,6 +1024,9 @@ namespace Recurly
 
             if (ShippingAmountInCents.HasValue)
                 xmlWriter.WriteElementString("shipping_amount_in_cents", ShippingAmountInCents.Value.AsString());
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             xmlWriter.WriteEndElement(); // End: subscription
         }


### PR DESCRIPTION
As a part of PSD2, there is an exemption to exclude MOTO transactions from SCA scope.
In order to pass this indicator to the gateways, merchants need a mechanism via API
to inform Recurly of these transactions. These transactions will be initiated from
within a merchants customer service / support admin portal UI, where the customer
is not authenticated to be able to complete an SCA flow.

This is exposed to the programmer as `transaction_type` on many of the resources. Set the value to `moto` to mark the transaction as MOTO. Ex use with purchases:

```csharp
var purchase = new Purchase("benjamin-du-monde", "USD";);
purchase.TransactionType = "moto";
purchase.Subscriptions.Add(new Subscription("gold"));
var collection = Purchase.Invoice(purchase);
```