### PR TITLE
Release 1.16.1 / API version 2.22

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 Unreleased
 ===============
 
+1.16.1 (stable) / 2019-08-21
+===============
+
+This brings us up to API version 2.22. There are no breaking changes.
+
+- MOTO transactions [PR](https://github.com/recurly/recurly-client-net/pull/437)
+
 1.16.0 (stable) / 2019-07-16
 ===============
 

--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -52,6 +52,7 @@ namespace Recurly
         public bool HasPastDueInvoice { get; private set; }
         public string PreferredLocale { get; set; }
         public string ParentAccountCode { get; set; }
+        public string TransactionType { get; set; }
 
         private AccountAcquisition _accountAcquisition;
 
@@ -675,6 +676,9 @@ namespace Recurly
 
             xmlWriter.WriteIfCollectionHasAny("shipping_addresses", ShippingAddresses);
             xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             // Clear the parent account by writing empty string. Null should not clear parent.
             if (ParentAccountCode != null)

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -112,6 +112,8 @@ namespace Recurly
         /// </summary>
         public string ThreeDSecureActionResultTokenId { get; set; }
 
+        public string TransactionType { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -447,6 +449,9 @@ namespace Recurly
                     xmlWriter.WriteElementString("card_type", card);
                 }
             }
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             xmlWriter.WriteStringIfValid("token_id", TokenId);
             xmlWriter.WriteStringIfValid("three_d_secure_action_result_token_id", ThreeDSecureActionResultTokenId);

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.21";
+        public const string RecurlyApiVersion = "2.22";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.16.0.0")]
-[assembly: AssemblyFileVersion("1.16.0.0")]
+[assembly: AssemblyVersion("1.16.1.0")]
+[assembly: AssemblyFileVersion("1.16.1.0")]

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -117,6 +117,11 @@ namespace Recurly
         /// </summary>
         public string GatewayCode { get; set; }
 
+        /// <summary>
+        /// Optional type flag for the gateway transaction. Currently accepts only "moto".
+        /// </summary>
+        public string TransactionType { get; set; }
+
         #region Constructors
 
         internal Purchase()
@@ -226,6 +231,9 @@ namespace Recurly
             xmlWriter.WriteStartElement("purchase"); // Start: purchase
 
             xmlWriter.WriteElementString("collection_method", CollectionMethod.ToString().EnumNameToTransportCase());
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.ToString());

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -370,6 +370,8 @@ namespace Recurly
         /// </summary>
         public int? ShippingAmountInCents { get; set; }
 
+        public string TransactionType { get; set; }
+
         internal Subscription()
         {
             IsPendingSubscription = false;
@@ -1022,6 +1024,9 @@ namespace Recurly
 
             if (ShippingAmountInCents.HasValue)
                 xmlWriter.WriteElementString("shipping_amount_in_cents", ShippingAmountInCents.Value.AsString());
+
+            if (TransactionType != null)
+                xmlWriter.WriteElementString("transaction_type", TransactionType);
 
             xmlWriter.WriteEndElement(); // End: subscription
         }

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.16.0</version>
+    <version>1.16.1</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.16.1 (stable) / 2019-08-21
===============

This brings us up to API version 2.22. There are no breaking changes.

- MOTO transactions [PR](https://github.com/recurly/recurly-client-net/pull/437)