### PR TITLE
Release 1.16.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,11 @@
 Unreleased
 ===============
 
+1.16.2 (stable) / 2019-09-13
+===============
+
+- PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-net/pull/441)
+
 1.16.1 (stable) / 2019-08-21
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.16.1.0")]
-[assembly: AssemblyFileVersion("1.16.1.0")]
+[assembly: AssemblyVersion("1.16.2.0")]
+[assembly: AssemblyFileVersion("1.16.2.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.16.1</version>
+    <version>1.16.2</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
1.16.2 (stable) / 2019-09-13
===============

- PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-net/pull/441)