### PR TITLE
3.0.0-beta.6 Release

### DIFF
--- a/Recurly/Recurly.csproj
+++ b/Recurly/Recurly.csproj
@@ -4,12 +4,17 @@
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <PackageId>Recurly</PackageId>
     <Version>3.0.0-beta.6</Version>
-    <Authors>ben@recurly.com</Authors>
+    <Authors>dx@recurly.com</Authors>
     <Company>Recurly, Inc.</Company>
+    <Title>Recurly API Client</Title>
+    <PackageDescription>The official .NET client for Recurly's V3 API.</PackageDescription>
+    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSource>true</IncludeSource>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="restsharp" Version="106.6.9" />
-    <PackageReference Include="RestSharp.Newtonsoft.Json" Version="1.5.0" />
+    <PackageReference Include="restsharp" Version="106.6.10" />
+    <PackageReference Include="RestSharp.Newtonsoft.Json" Version="1.5.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
A few notable changes:

* Remove the site-id constraint from Client #440 
*  Implement bump script #443  
* Fix Pager empty page bug #432 [ Fixes #445 ]
* Add CONTRIBUTING.md #430

This PR also makes sure that symbols and the source code are included in the release in the form of a [.snupkg](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) file. This should fix some of the difficulties with debugging as experienced with #445.

## Upgrade Notes

#440 contains a breaking change. `Recurly.Client` now only takes an api key (site id / subdomain is not needed). The type signature was changed from: `Recurly.Client(string siteId, string apiKey)` to `Recurly.Client(string apiKey)`