### PR TITLE
Release 1.17.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,15 @@
 Unreleased
 ===============
 
+1.17.0 (stable) / 2019-11-21
+===============
+
+- Add Item class [PR] (https://github.com/recurly/recurly-client-net/pull/461)
+
+### Upgrade Notes
+This brings us up to API version 2.24. There is one breaking change.
+- Adjustment#TaxExempt has been converted to nullable.
+
 1.16.3 (stable) / 2019-10-22
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.16.3.0")]
-[assembly: AssemblyFileVersion("1.16.3.0")]
+[assembly: AssemblyVersion("1.16.4.0")]
+[assembly: AssemblyFileVersion("1.16.4.0")]

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.16.4.0")]
-[assembly: AssemblyFileVersion("1.16.4.0")]
+[assembly: AssemblyVersion("1.17.0.0")]
+[assembly: AssemblyFileVersion("1.17.0.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.16.4</version>
+    <version>1.17.0</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.16.3</version>
+    <version>1.16.4</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
Release 1.17.0
- Add Item class (https://github.com/recurly/recurly-client-net/pull/461)

### Upgrade Notes
This brings us up to API version 2.24. There is one breaking change.
- Adjustment#TaxExempt has been converted to nullable.