### PR TITLE
Fixing error factory bug

### DIFF
--- a/Recurly.Tests/Errors/ApiErrorTest.cs
+++ b/Recurly.Tests/Errors/ApiErrorTest.cs
@@ -12,8 +12,7 @@ namespace Recurly.Tests
         {
             var err = new Recurly.Resources.ErrorMayHaveTransaction()
             {
-                Message = "Something bad happened",
-                Type = "my_api_error"
+                Message = "Something bad happened"
             };
             var ex = new MyApiError(err.Message) { Error = err };
             Assert.Equal(err.Message, ex.Message);


### PR DESCRIPTION
This was missed because the spec that was used to originally develop the enum support did not include the error types.
