### PR TITLE
Add 'capture' and 'cancel' to Purchase

### DIFF
--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -229,6 +229,36 @@ namespace Recurly
             return collection;
         }
 
+        /// <summary>
+        /// Allows the merchant to cancel an authorization.
+        /// </summary>
+        public static InvoiceCollection Cancel(String uuid)
+        {
+            var collection = new InvoiceCollection();
+
+            Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                UrlPrefix + "transaction-uuid-" + uuid + "/cancel",
+                null,
+                collection.ReadXml);
+
+            return collection;
+        }
+
+        /// <summary>
+        /// Allows the merchants to initiate a capture transaction tied to the original authorization.
+        /// </summary>
+        public static InvoiceCollection Capture(String uuid)
+        {
+            var collection = new InvoiceCollection();
+
+            Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                UrlPrefix + "transaction-uuid-" + uuid + "/capture",
+                null,
+                collection.ReadXml);
+
+            return collection;
+        }
+
         #region Read and Write XML documents
 
         internal override void WriteXml(XmlTextWriter xmlWriter)

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -73,6 +73,22 @@ namespace Recurly.Test
             return coupon;
         }
 
+        protected InvoiceCollection CreateNewCollection()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+            var currency = "USD";
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Plan for Purchase Test" };
+            plan.UnitAmountInCents.Add("USD", 580);
+            plan.Create();
+
+            var purchase = new Purchase(account.AccountCode, currency);
+
+            var sub = new Subscription(plan.PlanCode);
+            purchase.Subscriptions.Add(sub);
+            var collection = Purchase.Authorize(purchase);
+            return collection;
+        }
+
         public string GetUniqueAccountCode()
         {
             return Guid.NewGuid().ToString();

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -1,0 +1,53 @@
+using System;
+using FluentAssertions;
+// using System.Collections.Generic;
+using Xunit;
+using System.Linq;
+
+namespace Recurly.Test
+{
+  public class PurchaseTest : BaseTest
+  {
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void InvoicePurchase()
+    {
+      var account = CreateNewAccountWithBillingInfo();
+      var currency = "USD";
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Plan for Purchase Test" };
+      plan.UnitAmountInCents.Add("USD", 580);
+      plan.Create();
+
+      var purchase = new Purchase(account.AccountCode, currency);
+
+      purchase.Account.BillingInfo = account.BillingInfo;
+
+      var sub = new Subscription(plan.PlanCode);
+      purchase.Subscriptions.Add(sub);
+
+      var collection = Purchase.Invoice(purchase);
+      Assert.NotNull(collection.ChargeInvoice);
+      Assert.Equal(collection.ChargeInvoice.Transactions[0].Account.AccountCode, account.AccountCode);
+      Assert.Equal(collection.ChargeInvoice.Address.Company, "Acme Software");
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void CancelPurchase()
+    {
+      var collection = CreateNewCollection();
+      
+      var transactionUuid = collection.ChargeInvoice.Transactions[0].Uuid;
+      var cancelledCollection = Purchase.Cancel(transactionUuid);
+      cancelledCollection.ChargeInvoice.State.Should().Be(Invoice.InvoiceState.Failed);
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void CapturePurchase()
+    {
+      var collection = CreateNewCollection();
+      
+      var transactionUuid = collection.ChargeInvoice.Transactions[0].Uuid;
+      var capturedCollection = Purchase.Capture(transactionUuid);
+      capturedCollection.ChargeInvoice.State.Should().Be(Invoice.InvoiceState.Paid);
+    }
+  }
+}

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -112,6 +112,7 @@
     <Compile Include="List\TransactionListTest.cs" />
     <Compile Include="PlanTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PurchaseTest.cs" />
     <Compile Include="SettingsManagerTest.cs" />
     <Compile Include="SubscriptionTest.cs" />
     <Compile Include="SystemTest.cs" />


### PR DESCRIPTION
- Add capture function to Purchase object
- Add cancel function to Purchase object
- Create PurchaseTest to check new functions

To capture purchase:
```
var account = Accounts.Get("account_code");
var currency = "USD";
var plan = Plans.Get("plan_code");

var purchase = new Purchase(account.AccountCode, currency);

var sub = new Subscription(plan.PlanCode);
purchase.Subscriptions.Add(sub);

var previewCollection = Purchase.Authorize(purchase);
var transactionUuid = previewCollection.ChargeInvoice.Transactions[0].Uuid;
var capturedCollection = Purchase.Capture(transactionUuid);
```

To cancel purchase:
```
var account = Accounts.Get("account_code");
var currency = "USD";
var plan = Plans.Get("plan_code");

var purchase = new Purchase(account.AccountCode, currency);

var sub = new Subscription(plan.PlanCode);
purchase.Subscriptions.Add(sub);

var previewCollection = Purchase.Authorize(purchase);
var transactionUuid = previewCollection.ChargeInvoice.Transactions[0].Uuid;
var cancelledCollection = Purchase.Cancel(transactionUuid);
```