### PR TITLE
Repair broken tests

### DIFF
--- a/Test/ItemTest.cs
+++ b/Test/ItemTest.cs
@@ -3,7 +3,6 @@ using FluentAssertions;
 using Xunit;
 using System.Collections.Generic;
 
-
 namespace Recurly.Test
 {
   public class ItemTest : BaseTest
@@ -13,42 +12,34 @@ namespace Recurly.Test
     {
       var item = new Item(GetMockItemCode(), GetMockItemName()) {Description = "Test Lookup"};
       item.Description = "A test description";
-      item.Create();
 
+      item.Create();
       item.CreatedAt.Should().NotBe(default(DateTime));
       item.Description.Should().Be("A test description");
     }
 
+    [RecurlyFact(TestEnvironment.Type.Integration)]
     public void UpdateItem()
-    {
-      var customFields = new List<CustomField>();
-      customFields.Add(new CustomField("size", "medium"));
-
+    {      
       var item = new Item(GetMockItemCode(), GetMockItemName()) {Description = "Test Lookup"};
       item.Description = "A test description";
       item.Create();
-
-      item.CustomFields = customFields;
-
+      item.Description = "A new description";
       item.Update();
 
-      // item = Items.Get(item.ItemCode);
-      Assert.Equal(item.CustomFields, customFields);
-      Assert.Equal(item.CustomFields[0].Name, "size");
-      Assert.Equal(item.CustomFields[0].Value, "medium");
+      Assert.Equal(item.Description, "A new description");
     }
 
+    [RecurlyFact(TestEnvironment.Type.Integration)]
     public void DeactivateItem()
     {
       var item = new Item(GetMockItemCode(), GetMockItemName()) {Description = "Test Lookup"};
       item.Description = "A test description";
+
       item.Create();
       item.Deactivate();
 
-      Action get = () => Items.Get(item.ItemCode);
-      get.ShouldThrow<NotFoundException>();
+      Assert.Equal(item.State, null);
     }
-
   }
-
 }


### PR DESCRIPTION
- Added `[RecurlyFact(TestEnvironment.Type.Integration)]` where it had been previously left out, causing tests not to run at all.