### PR TITLE
Add external_sku to Adjustment

### DIFF
--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -39,6 +39,7 @@ namespace Recurly
         public string AccountingCode { get; set; }
         public string ProductCode { get; set; }
         public string ItemCode { get; set; }
+        public string ExternalSku { get; set; }
         public string Origin { get; set; }
         public int UnitAmountInCents { get; set; }
         public int Quantity { get; set; }
@@ -181,6 +182,10 @@ namespace Recurly
                         ItemCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "external_sku":
+                        ExternalSku = reader.ReadElementContentAsString();
+                        break;
+
                     case "origin":
                         Origin = reader.ReadElementContentAsString();
                         break;
@@ -298,6 +303,8 @@ namespace Recurly
 
             if (Description != null)
                 xmlWriter.WriteElementString("description", Description);
+            if (ExternalSku != null)
+                xmlWriter.WriteElementString("external_sku", ExternalSku);
             if (ProductCode != null)
                 xmlWriter.WriteElementString("product_code", ProductCode);
             if (AccountingCode != null)

--- a/Test/AdjustmentTest.cs
+++ b/Test/AdjustmentTest.cs
@@ -8,19 +8,24 @@ namespace Recurly.Test
     {
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
-        public void CreateAdjustment()
+        public void CreateAdjustmentWithItemCode()
         {
             var account = CreateNewAccount();
+            var item = new Item(GetMockItemCode(), GetMockItemName()) {Description = "Test Lookup"};
+            item.Description = "A test description";
+            item.ExternalSku = "tester-sku";
+            item.Create();
 
             var adjustment = account.NewAdjustment("USD", 5000);
-            adjustment.ItemCode = "pink_sweats";   
+            adjustment.ItemCode = item.ItemCode;
             adjustment.StartDate = new DateTime(2019, 6, 11);
             adjustment.EndDate = new DateTime(2045, 7, 11);
             adjustment.Create();
 
             adjustment.CreatedAt.Should().NotBe(default(DateTime));
             Assert.False(adjustment.TaxExempt);
-            Assert.Equal("pink_sweats", adjustment.ItemCode);
+            Assert.Equal(item.ItemCode, adjustment.ItemCode);
+            Assert.Equal(item.ExternalSku, adjustment.ExternalSku);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]


### PR DESCRIPTION
To fetch `external_sku`:
```csharp
var adjustment = account.NewAdjustment("USD", 5000);     
adjustment.ItemCode = 'item_code';                
adjustment.StartDate = new DateTime(2019, 6, 11);
adjustment.EndDate = new DateTime(2045, 7, 11);
adjustment.Create();
                
System.Console.WriteLine("Adjustment created: " + adjustment.ExternalSku);
```