### PR TITLE
Fix a DateTime Unit Tests when not in UTC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ msbuild.wrn
 
 coverage.*
 coverage_report/
+
+packages/
+.idea/

--- a/Recurly.Tests/UtilsTest.cs
+++ b/Recurly.Tests/UtilsTest.cs
@@ -26,10 +26,10 @@ namespace Recurly.Tests
             d.Add("trueBool", true);
             d.Add("falseBool", false);
             d.Add("int", 123);
-            d.Add("float", 123.456);
-            d.Add("date", new DateTime(2020, 1, 1));
+            d.Add("decimal", 123.456m);
+            d.Add("date", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var result = Utils.QueryString(d);
-            Assert.Equal("?trueBool=true&falseBool=false&int=123&float=123.456&date=2020-01-01T00:00:00.000Z", result);
+            Assert.Equal("?trueBool=true&falseBool=false&int=123&decimal=123.456&date=2020-01-01T00:00:00.000Z", result);
         }
     }
 }

--- a/Recurly.Tests/UtilsTest.cs
+++ b/Recurly.Tests/UtilsTest.cs
@@ -26,10 +26,10 @@ namespace Recurly.Tests
             d.Add("trueBool", true);
             d.Add("falseBool", false);
             d.Add("int", 123);
-            d.Add("decimal", 123.456m);
+            d.Add("float", 123.456f);
             d.Add("date", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var result = Utils.QueryString(d);
-            Assert.Equal("?trueBool=true&falseBool=false&int=123&decimal=123.456&date=2020-01-01T00:00:00.000Z", result);
+            Assert.Equal("?trueBool=true&falseBool=false&int=123&float=123.456&date=2020-01-01T00:00:00.000Z", result);
         }
     }
 }


### PR DESCRIPTION
- Fixes a unit test that fails locally when not in UTC.
- Adds a float specification to the object added to the Dictionary.
- .gitignore updates to not checking build packages or Rider IDE files.