### PR TITLE
Release 1.17.2

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 Unreleased
 ===============
 
+1.17.2 (stable) / 2020-02-20
+===============
+
+This brings us up to API version 2.25. There are no breaking changes.
+
+- Add ConvertTrial() to Subscription [PR](https://github.com/recurly/recurly-client-net/pull/480)
+
 1.17.1 (stable) / 2020-02-18
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.1.0")]
-[assembly: AssemblyFileVersion("1.17.1.0")]
+[assembly: AssemblyVersion("1.17.2.0")]
+[assembly: AssemblyFileVersion("1.17.2.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.1</version>
+    <version>1.17.2</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
This brings us up to API version 2.25. There are no breaking changes.

- Add ConvertTrial() to Subscription (https://github.com/recurly/recurly-client-net/pull/480)