### PR TITLE
Postpone subscriptions using the field next_bill_date

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -496,7 +496,10 @@ namespace Recurly
         /// <summary>
         /// For an active subscription, this will pause the subscription until the specified date.
         /// </summary>
-        /// <param name="nextRenewalDate">The specified time the subscription will be postponed</param>
+        /// <param name="nextRenewalDate">The specified time the subscription will be postponed.
+        /// Although next_renewal_date is deprecated and has been replaced with next_bill_date,
+        /// we have opted to maintain the param name nextRenewalDate to keep compatibility with named arguments.
+        /// </param>
         /// <param name="bulk">bulk = false (default) or true to bypass the 60 second wait while postponing</param>
         public void Postpone(DateTime nextRenewalDate, bool bulk = false)
         {

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -496,11 +496,11 @@ namespace Recurly
         /// <summary>
         /// For an active subscription, this will pause the subscription until the specified date.
         /// </summary>
-        /// <param name="nextBillDate">The specified time the subscription will be postponed</param>
+        /// <param name="nextRenewalDate">The specified time the subscription will be postponed</param>
         /// <param name="bulk">bulk = false (default) or true to bypass the 60 second wait while postponing</param>
-        public void Postpone(DateTime nextBillDate, bool bulk = false)
+        public void Postpone(DateTime nextRenewalDate, bool bulk = false)
         {
-            var dateString = nextBillDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var dateString = nextRenewalDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
 
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                 UrlPrefix + Uri.EscapeDataString(Uuid) + "/postpone?next_bill_date=" + dateString + "&bulk=" + bulk.ToString().ToLower(),

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -496,14 +496,14 @@ namespace Recurly
         /// <summary>
         /// For an active subscription, this will pause the subscription until the specified date.
         /// </summary>
-        /// <param name="nextRenewalDate">The specified time the subscription will be postponed</param>
+        /// <param name="nextBillDate">The specified time the subscription will be postponed</param>
         /// <param name="bulk">bulk = false (default) or true to bypass the 60 second wait while postponing</param>
-        public void Postpone(DateTime nextRenewalDate, bool bulk = false)
+        public void Postpone(DateTime nextBillDate, bool bulk = false)
         {
-            var dateString = nextRenewalDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var dateString = nextBillDate.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
 
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
-                UrlPrefix + Uri.EscapeDataString(Uuid) + "/postpone?next_renewal_date=" + dateString + "&bulk=" + bulk.ToString().ToLower(),
+                UrlPrefix + Uri.EscapeDataString(Uuid) + "/postpone?next_bill_date=" + dateString + "&bulk=" + bulk.ToString().ToLower(),
                 ReadXml);
         }
 

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -539,7 +539,7 @@ namespace Recurly.Test
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
             {
-                Description = "Postpone Subscription Test"
+                Description = "Update Notes Subscription Test"
             };
             plan.UnitAmountInCents.Add("USD", 100);
             plan.Create();


### PR DESCRIPTION
Pospone subscriptions using the `next_bill_date ` field instead of the deprecated `next_renewal_date`.
[DOC](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial)