### PR TITLE
Generated Latest Changes for v2019-10-10 (get_preview_renewal)

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -3501,6 +3501,40 @@ namespace Recurly
 
 
         /// <summary>
+        /// Fetch a preview of a subscription's renewal invoice(s) <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal">get_preview_renewal api documentation</see>
+        /// </summary>
+        /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
+        /// <returns>
+        /// A preview of the subscription's renewal invoice(s).
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public InvoiceCollection GetPreviewRenewal(string subscriptionId, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
+            var url = this.InterpolatePath("/subscriptions/{subscription_id}/preview_renewal", urlParams);
+            return MakeRequest<InvoiceCollection>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Fetch a preview of a subscription's renewal invoice(s) <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal">get_preview_renewal api documentation</see>
+        /// </summary>
+        /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
+        /// <returns>
+        /// A preview of the subscription's renewal invoice(s).
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<InvoiceCollection> GetPreviewRenewalAsync(string subscriptionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
+            var url = this.InterpolatePath("/subscriptions/{subscription_id}/preview_renewal", urlParams);
+            return MakeRequestAsync<InvoiceCollection>(Method.GET, url, null, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
         /// Fetch a subscription's pending change <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_subscription_change">get_subscription_change api documentation</see>
         /// </summary>
         /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -2127,6 +2127,26 @@ namespace Recurly
         Task<Subscription> ConvertTrialAsync(string subscriptionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
 
         /// <summary>
+        /// Fetch a preview of a subscription's renewal invoice(s) <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal">get_preview_renewal api documentation</see>
+        /// </summary>
+        /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
+        /// <returns>
+        /// A preview of the subscription's renewal invoice(s).
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        InvoiceCollection GetPreviewRenewal(string subscriptionId, RequestOptions options = null);
+
+        /// <summary>
+        /// Fetch a preview of a subscription's renewal invoice(s) <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_preview_renewal">get_preview_renewal api documentation</see>
+        /// </summary>
+        /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
+        /// <returns>
+        /// A preview of the subscription's renewal invoice(s).
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<InvoiceCollection> GetPreviewRenewalAsync(string subscriptionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
         /// Fetch a subscription's pending change <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_subscription_change">get_subscription_change api documentation</see>
         /// </summary>
         /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>

--- a/Recurly/Resources/SubscriptionPause.cs
+++ b/Recurly/Resources/SubscriptionPause.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class SubscriptionPause : Request
     {
 
-        /// <value>Number of billing cycles to pause the subscriptions.</value>
+        /// <value>Number of billing cycles to pause the subscriptions. A value of 0 will cancel any pending pauses on the subscription.</value>
         [JsonProperty("remaining_pause_cycles")]
         public int? RemainingPauseCycles { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12405,6 +12405,43 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/sites/{site_id}/subscriptions/{subscription_id}/preview_renewal":
+    get:
+      tags:
+      - subscription
+      operationId: get_preview_renewal
+      summary: Fetch a preview of a subscription's renewal invoice(s)
+      description: The subscriptions's renewal invoice(s) will be returned if they
+        exist; if they don't (for example, if the subscription is not set to renew),
+        it will return an result with no invoices.
+      parameters:
+      - "$ref": "#/components/parameters/subscription_id"
+      responses:
+        '200':
+          description: A preview of the subscription's renewal invoice(s).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceCollection"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or subscription ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/sites/{site_id}/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -20568,7 +20605,8 @@ components:
         remaining_pause_cycles:
           type: integer
           title: Remaining pause cycles
-          description: Number of billing cycles to pause the subscriptions.
+          description: Number of billing cycles to pause the subscriptions. A value
+            of 0 will cancel any pending pauses on the subscription.
       required:
       - remaining_pause_cycles
     SubscriptionShipping:


### PR DESCRIPTION
* Adds new endpoint `GET /sites/:site_id/subscriptions/:id/preview_renewal` which returns a preview of the subscription's renewal invoice(s)