### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -96,6 +96,10 @@ namespace Recurly.Resources
         [JsonProperty("expires_at")]
         public DateTime? ExpiresAt { get; set; }
 
+        /// <value>If present, this subscription's transactions will use the payment gateway with this code.</value>
+        [JsonProperty("gateway_code")]
+        public string GatewayCode { get; set; }
+
         /// <value>Subscription ID</value>
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -158,9 +162,21 @@ namespace Recurly.Resources
         [JsonProperty("subtotal")]
         public decimal? Subtotal { get; set; }
 
+        /// <value>Estimated tax</value>
+        [JsonProperty("tax")]
+        public decimal? Tax { get; set; }
+
+        /// <value>Tax info</value>
+        [JsonProperty("tax_info")]
+        public TaxInfo TaxInfo { get; set; }
+
         /// <value>Terms and conditions</value>
         [JsonProperty("terms_and_conditions")]
         public string TermsAndConditions { get; set; }
+
+        /// <value>Estimated total</value>
+        [JsonProperty("total")]
+        public decimal? Total { get; set; }
 
         /// <value>The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.</value>
         [JsonProperty("total_billing_cycles")]

--- a/Recurly/Resources/SubscriptionChangeShippingCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeShippingCreate.cs
@@ -15,6 +15,14 @@ namespace Recurly.Resources
     public class SubscriptionChangeShippingCreate : Request
     {
 
+
+        [JsonProperty("address")]
+        public ShippingAddressCreate Address { get; set; }
+
+        /// <value>Assign a shipping address from the account's existing shipping addresses. If this and address are both present, address will take precedence.</value>
+        [JsonProperty("address_id")]
+        public string AddressId { get; set; }
+
         /// <value>Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.</value>
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }

--- a/Recurly/Resources/SubscriptionUpdate.cs
+++ b/Recurly/Resources/SubscriptionUpdate.cs
@@ -36,6 +36,10 @@ namespace Recurly.Resources
         [JsonProperty("customer_notes")]
         public string CustomerNotes { get; set; }
 
+        /// <value>If present, this subscription's transactions will use the payment gateway with this code.</value>
+        [JsonProperty("gateway_code")]
+        public string GatewayCode { get; set; }
+
         /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `GatewayCode`.

SubscriptionUpdate request format has changed:
* Added `GatewayCode`.

Subscription response format has changed:
* Added `GatewayCode`.

SubscriptionChangeShippingCreate request format has changed:
* Added `Address`.
* Added `AddressId`.

Added tax information to `Subscription` response
* Added the fields `Tax`, `TaxInfo` and `Total`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.


