### PR TITLE
Fixing bug in the Pager that breaks the Count and First methods

### DIFF
--- a/Recurly.Tests/PagerTest.cs
+++ b/Recurly.Tests/PagerTest.cs
@@ -109,6 +109,19 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void EnumerablePagesUrlTest()
+        {
+            var queryParams = new Dictionary<string, object> {
+                { "limit", "200" },
+            };
+            var client = GetPagerSuccessClient(queryParams);
+            var pager = Pager<MyResource>.Build("/resources", queryParams, null, client);
+            var originalUrl = pager.Url;
+            pager.FetchNextPage();
+            Assert.Equal(originalUrl, pager.Url);
+        }
+
+        [Fact]
         public void PagerFirstTest()
         {
             var paramsMatcher = MockClient.QueryParameterMatcher(new Dictionary<string, object> {

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -93,9 +93,6 @@ namespace Recurly
             this.Next = pager.Next;
             this.Data = pager.Data;
             this.HasMore = pager.HasMore;
-            this.Url = pager.Url;
-            this.QueryParams = pager.QueryParams;
-            this.Options = pager.Options;
             this.SetResponse(pager.GetResponse());
             this._pristine = false;
         }

--- a/scripts/test
+++ b/scripts/test
@@ -11,5 +11,8 @@ else
   echo "Style check passed"
 fi
 
-RECURLY_STRICT_MODE=true dotnet test Recurly.Tests/Recurly.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover \
+# Individual tests can be run by including the --filter flag:
+# ./scripts/test --filter DisplayName=Recurly.Tests.PagerTest.EnumerableTest
+
+RECURLY_STRICT_MODE=true dotnet test Recurly.Tests/Recurly.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover  "$@" \
 && dotnet ~/.nuget/packages/reportgenerator/*/tools/netcoreapp*/ReportGenerator.dll -reports:./Recurly.Tests/coverage.opencover.xml -targetdir:./Recurly.Tests/coverage_report


### PR DESCRIPTION
When the `FetchNextPage` or `FetchNextPageAsync` methods were called on the `Pager`, the private method `Clone` would copy properties from the result set into the instance of the pager. The method was unintentionally nulling out properties of the pager instance that would not be present on the result set.

This bug fix will only clone properties that will be present on the result set.