### PR TITLE
Adding tests to protect against committing changes for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ dist/*.nupkg
 dist/lib/net*
 
 testrunner/
+test-report.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - nuget install xunit.runner.console -Version 2.4.0 -OutputDirectory testrunner
 script:
   - xbuild /p:Configuration=Release Recurly.sln
-  - ./scripts/test Release
+  - ./scripts/test -R

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ foreach (var account in accounts)
 Every `List()` method takes a `FilterCriteria` as the final parameter, but differs in the endpoint specific filters.
 The best way to learn about this is by looking at the source code or the code docs.
 
+## Testing
+
+The test suite can be run using the `scripts/test` script. This script provides some optional configuration that can be viewed by passing the `-h` flag:
+
+```
+$ ./scripts/test -h
+Supported Options:
+
+  -R     Use the Release build configuration (Debug is used by default).
+  -r     Output test results to test-report.html file.
+  -c     Test class to run. Cannot be used with -m option.
+  -m     Test method to run. Cannot be used with -c option.
+  -h     Print this help.
+
+Example:
+  ./scripts/test -m SettingsTest.ValidDomainTest
+  ./scripts/test -c SettingsTest -r
+```
+
 ## Support
 
 Looking for help? Please contact [support@recurly.com](mailto:support@recurly.com) or visit

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -119,6 +119,7 @@
     <Compile Include="SubscriptionTest.cs" />
     <Compile Include="SubscriptionAddOnTest.cs" />
     <Compile Include="SystemTest.cs" />
+    <Compile Include="SettingsTest.cs" />
     <Compile Include="TestCreditCardNumbers.cs" />
     <Compile Include="TestEnvironment.cs" />
     <Compile Include="TransactionTest.cs" />

--- a/Test/SettingsTest.cs
+++ b/Test/SettingsTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Recurly.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Recurly.Test
+{
+    public class SettingsTest : BaseTest
+    {
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void ValidDomainTest()
+        {
+            Settings.ValidDomain.Should().Be(".recurly.com");
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void ImplicitRecurlyServerUriTest()
+        {
+            // Implicitly tests that RecurlyServerUri == "https://{0}.recurly.com/v2{1}"
+            var uri = Settings.Instance.GetServerUri("/test");
+            uri.Should().Be($"https://{Settings.Instance.Subdomain}.recurly.com/v2/test");
+        }
+    }
+}

--- a/scripts/test
+++ b/scripts/test
@@ -1,19 +1,45 @@
 #!/usr/bin/env bash
 set -e
 
-CONFIGURATION=${1:-Debug}
+usage () {
+  echo "Supported Options:"
+  echo
+  echo "  -R     Use the Release build configuration (Debug is used by default)."
+  echo "  -r     Output test results to test-report.html file."
+  echo "  -c     Test class to run. Cannot be used with -m option."
+  echo "  -m     Test method to run. Cannot be used with -c option."
+  echo "  -h     Print this help."
+  echo
+  echo "Example:"
+  echo "  ./scripts/test -m SettingsTest.ValidDomainTest"
+  echo "  ./scripts/test -c SettingsTest -r"
+}
 
-[[ -z "$2" ]] && METHOD="" || METHOD="-method Recurly.Test.$2"
+config="Debug"
 
-if [ "$CONFIGURATION" != "Debug" ] && [ "$CONFIGURATION" != "Release" ]; then
-    # Assume the user wanted Debug
-    CONFIGURATION="Debug"
-    # If they passed in anything, assume it was the method they want to run
-    METHOD="-method Recurly.Test.$1"
+options=':Rrc:m:h'
+while getopts $options option
+do
+    case "$option" in
+        R) config="Release";;
+        r) report="-html test-report.html";;
+        c) test_class="-class Recurly.Test.$OPTARG";;
+        m) test_method="-method Recurly.Test.$OPTARG";;
+        h) usage; exit;;
+        \?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+        :) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+    esac
+done
+
+if [ -n "$test_method" ] && [ -n "$test_class" ]; then
+  echo "The -c and -m options cannot be used together"
+  echo
+  usage
+  exit 1
 fi
 
 if [[ -z "${TRAVIS}" ]]; then
-  ./scripts/build $CONFIGURATION
+  ./scripts/build $config
 fi
 
-mono ./testrunner/xunit.runner.console.2.4.0/tools/net472/xunit.console.exe ./Test/bin/$CONFIGURATION/Recurly.Test.dll $METHOD
+mono ./testrunner/xunit.runner.console.2.4.0/tools/net472/xunit.console.exe ./Test/bin/$config/Recurly.Test.dll $report $test_class $test_method


### PR DESCRIPTION
Internal test to ensure that the `ValidDomain` and `RecurlyServerUri` constants in `Settings` are not accidentally committed and included in a pull request.