### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -285,6 +285,9 @@ namespace Recurly
             [EnumMember(Value = "en-GB")]
             EnGb,
 
+            [EnumMember(Value = "en-IE")]
+            EnIe,
+
             [EnumMember(Value = "en-NZ")]
             EnNz,
 
@@ -300,6 +303,9 @@ namespace Recurly
             [EnumMember(Value = "es-US")]
             EsUs,
 
+            [EnumMember(Value = "fi-FI")]
+            FiFi,
+
             [EnumMember(Value = "fr-CA")]
             FrCa,
 
@@ -309,8 +315,14 @@ namespace Recurly
             [EnumMember(Value = "hi-IN")]
             HiIn,
 
+            [EnumMember(Value = "it-IT")]
+            ItIt,
+
             [EnumMember(Value = "ja-JP")]
             JaJp,
+
+            [EnumMember(Value = "ko-KR")]
+            KoKr,
 
             [EnumMember(Value = "nl-BE")]
             NlBe,
@@ -324,8 +336,14 @@ namespace Recurly
             [EnumMember(Value = "pt-PT")]
             PtPt,
 
+            [EnumMember(Value = "ro-RO")]
+            RoRo,
+
             [EnumMember(Value = "ru-RU")]
             RuRu,
+
+            [EnumMember(Value = "sk-SK")]
+            SkSk,
 
             [EnumMember(Value = "tr-TR")]
             TrTr,
@@ -612,8 +630,17 @@ namespace Recurly
         {
             Undefined = 0,
 
+            [EnumMember(Value = "carryforward_credit")]
+            CarryforwardCredit,
+
+            [EnumMember(Value = "carryforward_gift_credit")]
+            CarryforwardGiftCredit,
+
             [EnumMember(Value = "credit")]
             Credit,
+
+            [EnumMember(Value = "external_refund")]
+            ExternalRefund,
 
             [EnumMember(Value = "gift_card")]
             GiftCard,
@@ -621,14 +648,23 @@ namespace Recurly
             [EnumMember(Value = "immediate_change")]
             ImmediateChange,
 
+            [EnumMember(Value = "import")]
+            Import,
+
             [EnumMember(Value = "line_item_refund")]
             LineItemRefund,
 
             [EnumMember(Value = "open_amount_refund")]
             OpenAmountRefund,
 
+            [EnumMember(Value = "prepayment")]
+            Prepayment,
+
             [EnumMember(Value = "purchase")]
             Purchase,
+
+            [EnumMember(Value = "refund")]
+            Refund,
 
             [EnumMember(Value = "renewal")]
             Renewal,
@@ -636,11 +672,11 @@ namespace Recurly
             [EnumMember(Value = "termination")]
             Termination,
 
+            [EnumMember(Value = "usage_correction")]
+            UsageCorrection,
+
             [EnumMember(Value = "write_off")]
             WriteOff,
-
-            [EnumMember(Value = "prepayment")]
-            Prepayment,
 
         };
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21380,20 +21380,26 @@ components:
       - en-AU
       - en-CA
       - en-GB
+      - en-IE
       - en-NZ
       - en-US
       - es-ES
       - es-MX
       - es-US
+      - fi-FI
       - fr-CA
       - fr-FR
       - hi-IN
+      - it-IT
       - ja-JP
+      - ko-KR
       - nl-BE
       - nl-NL
       - pt-BR
       - pt-PT
+      - ro-RO
       - ru-RU
+      - sk-SK
       - tr-TR
       - zh-CN
     BillToEnum:
@@ -21533,16 +21539,22 @@ components:
     OriginEnum:
       type: string
       enum:
+      - carryforward_credit
+      - carryforward_gift_credit
       - credit
+      - external_refund
       - gift_card
       - immediate_change
+      - import
       - line_item_refund
       - open_amount_refund
+      - prepayment
       - purchase
+      - refund
       - renewal
       - termination
+      - usage_correction
       - write_off
-      - prepayment
     InvoiceStateEnum:
       type: string
       enum:


### PR DESCRIPTION
- Added additional enum values for `Invoice` `origin`:
  - `refund`
  - `external_refund`
  - `carryforward_credit`
  - `carryforward_gift_credit`
  - `usage_correction`
  - `import`

- Added additional enum values for `Account` `preferred_locale`:
  - `en-IE`
  - `fi-FI`
  - `it-IT`
  - `ko-KR`
  - `ro-RO`
  - `sk-SK`
