### PR TITLE
Generated Latest Changes for v2019-10-10 (Account Hierarchy Invoice Rollup)

### DIFF
--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -43,6 +43,10 @@ namespace Recurly.Resources
         [JsonProperty("avalara_transaction_type")]
         public int? AvalaraTransactionType { get; set; }
 
+        /// <value>The UUID of the account responsible for originating the line item.</value>
+        [JsonProperty("bill_for_account_id")]
+        public string BillForAccountId { get; set; }
+
         /// <value>When the line item was created.</value>
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18279,6 +18279,12 @@ components:
           - carryforward
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21916,6 +21922,8 @@ components:
                 - batch_processing_error
                 - billing_agreement_already_accepted
                 - billing_agreement_not_accepted
+                - billing_agreement_not_found
+                - billing_agreement_replaced
                 - call_issuer
                 - call_issuer_update_cardholder_data
                 - cannot_refund_unsettled_transactions


### PR DESCRIPTION
Add `BillForAccountId` property -- the UUID of the account responsible for originating the line item -- to the `LineItem` class. 