### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -1578,6 +1578,9 @@ namespace Recurly
             [EnumMember(Value = "billing_agreement_not_found")]
             BillingAgreementNotFound,
 
+            [EnumMember(Value = "billing_agreement_replaced")]
+            BillingAgreementReplaced,
+
             [EnumMember(Value = "call_issuer")]
             CallIssuer,
 
@@ -1973,6 +1976,27 @@ namespace Recurly
 
             [EnumMember(Value = "trial")]
             Trial,
+
+        };
+
+        public enum AchType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "bacs")]
+            Bacs,
+
+        };
+
+        public enum AchAccountType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "checking")]
+            Checking,
+
+            [EnumMember(Value = "savings")]
+            Savings,
 
         };
 

--- a/Recurly/Resources/BillingInfoCreate.cs
+++ b/Recurly/Resources/BillingInfoCreate.cs
@@ -15,6 +15,15 @@ namespace Recurly.Resources
     public class BillingInfoCreate : Request
     {
 
+        /// <value>The bank account number. (ACH, Bacs only)</value>
+        [JsonProperty("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <value>The bank account type. (ACH only)</value>
+        [JsonProperty("account_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.AchAccountType? AccountType { get; set; }
+
 
         [JsonProperty("address")]
         public Address Address { get; set; }
@@ -67,6 +76,10 @@ namespace Recurly.Resources
         [JsonProperty("month")]
         public string Month { get; set; }
 
+        /// <value>The name associated with the bank account (ACH, SEPA, Bacs only)</value>
+        [JsonProperty("name_on_account")]
+        public string NameOnAccount { get; set; }
+
         /// <value>Credit card number, spaces and dashes are accepted.</value>
         [JsonProperty("number")]
         public string Number { get; set; }
@@ -78,6 +91,14 @@ namespace Recurly.Resources
         /// <value>The `primary_payment_method` field is used to designate the primary billing info on the account. The first billing info created on an account will always become primary. Adding additional billing infos provides the flexibility to mark another billing info as primary, or adding additional non-primary billing infos. This can be accomplished by passing the `primary_payment_method` with a value of `true`. When adding billing infos via the billing_info and /accounts endpoints, this value is not permitted, and will return an error if provided.</value>
         [JsonProperty("primary_payment_method")]
         public bool? PrimaryPaymentMethod { get; set; }
+
+        /// <value>The bank's rounting number. (ACH only)</value>
+        [JsonProperty("routing_number")]
+        public string RoutingNumber { get; set; }
+
+        /// <value>Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)</value>
+        [JsonProperty("sort_code")]
+        public string SortCode { get; set; }
 
         /// <value>Tax identifier is required if adding a billing info that is a consumer card in Brazil or in Argentina. This would be the customer's CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for all residents who pay taxes in Brazil and Argentina respectively.</value>
         [JsonProperty("tax_identifier")]
@@ -100,6 +121,11 @@ namespace Recurly.Resources
         [JsonProperty("transaction_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.GatewayTransactionType? TransactionType { get; set; }
+
+        /// <value>The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)</value>
+        [JsonProperty("type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.AchType? Type { get; set; }
 
         /// <value>VAT number</value>
         [JsonProperty("vat_number")]

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -43,6 +43,10 @@ namespace Recurly.Resources
         [JsonProperty("avalara_transaction_type")]
         public int? AvalaraTransactionType { get; set; }
 
+        /// <value>The UUID of the account responsible for originating the line item.</value>
+        [JsonProperty("bill_for_account_id")]
+        public string BillForAccountId { get; set; }
+
         /// <value>When the line item was created.</value>
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16345,6 +16345,28 @@ components:
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
             routing information
+        name_on_account:
+          type: string
+          maxLength: 255
+          description: The name associated with the bank account (ACH, SEPA, Bacs
+            only)
+        account_number:
+          type: string
+          maxLength: 255
+          description: The bank account number. (ACH, Bacs only)
+        routing_number:
+          type: string
+          maxLength: 15
+          description: The bank's rounting number. (ACH only)
+        sort_code:
+          type: string
+          maxLength: 15
+          description: Bank identifier code for UK based banks. Required for Bacs
+            based billing infos. (Bacs only)
+        type:
+          "$ref": "#/components/schemas/AchTypeEnum"
+        account_type:
+          "$ref": "#/components/schemas/AchAccountTypeEnum"
         tax_identifier:
           type: string
           description: Tax identifier is required if adding a billing info that is
@@ -17898,6 +17920,12 @@ components:
           "$ref": "#/components/schemas/LegacyCategoryEnum"
         account:
           "$ref": "#/components/schemas/AccountMini"
+        bill_for_account_id:
+          type: string
+          title: Bill For Account ID
+          maxLength: 13
+          description: The UUID of the account responsible for originating the line
+            item.
         subscription_id:
           type: string
           title: Subscription ID
@@ -21885,6 +21913,7 @@ components:
       - billing_agreement_already_accepted
       - billing_agreement_not_accepted
       - billing_agreement_not_found
+      - billing_agreement_replaced
       - call_issuer
       - call_issuer_update_cardholder_data
       - cancelled
@@ -22058,3 +22087,15 @@ components:
       - automatic
       - manual
       - trial
+    AchTypeEnum:
+      type: string
+      description: The payment method type for a non-credit card based billing info.
+        The value of `bacs` is the only accepted value (Bacs only)
+      enum:
+      - bacs
+    AchAccountTypeEnum:
+      type: string
+      description: The bank account type. (ACH only)
+      enum:
+      - checking
+      - savings


### PR DESCRIPTION
Support for Account Hierarchy Invoice Rollup:
- Add `BillForAccountId` property -- the UUID of the account responsible for originating the line item -- to the `LineItem` class.

BillingInfoCreate request format has changed:
- Added `NameOnAccount`
- Added `AccountNumber`
- Added `RoutingNumber`
- Added `SortCode`
- Added `Type`
- Added `AccountType`