### PR TITLE
Generated Latest Changes for v2019-10-10 (Tax Inclusive Pricing)

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -617,7 +617,7 @@ namespace Recurly
         /// Fetch a billing info <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info">get_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// A billing info.
         /// </returns>
@@ -635,7 +635,7 @@ namespace Recurly
         /// Fetch a billing info <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info">get_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// A billing info.
         /// </returns>
@@ -653,7 +653,7 @@ namespace Recurly
         /// Update an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info">update_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <param name="body">The body of the request.</param>
         /// <returns>
         /// Updated billing information.
@@ -672,7 +672,7 @@ namespace Recurly
         /// Update an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info">update_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <param name="body">The body of the request.</param>
         /// <returns>
         /// Updated billing information.
@@ -691,7 +691,7 @@ namespace Recurly
         /// Remove an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info">remove_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// Billing information deleted
         /// </returns>
@@ -709,7 +709,7 @@ namespace Recurly
         /// Remove an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info">remove_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// Billing information deleted
         /// </returns>

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -374,7 +374,7 @@ namespace Recurly
         /// Fetch a billing info <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info">get_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// A billing info.
         /// </returns>
@@ -385,7 +385,7 @@ namespace Recurly
         /// Fetch a billing info <see href="https://developers.recurly.com/api/v2019-10-10#operation/get_a_billing_info">get_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// A billing info.
         /// </returns>
@@ -396,7 +396,7 @@ namespace Recurly
         /// Update an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info">update_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <param name="body">The body of the request.</param>
         /// <returns>
         /// Updated billing information.
@@ -408,7 +408,7 @@ namespace Recurly
         /// Update an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/update_a_billing_info">update_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <param name="body">The body of the request.</param>
         /// <returns>
         /// Updated billing information.
@@ -420,7 +420,7 @@ namespace Recurly
         /// Remove an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info">remove_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// Billing information deleted
         /// </returns>
@@ -431,7 +431,7 @@ namespace Recurly
         /// Remove an account's billing information <see href="https://developers.recurly.com/api/v2019-10-10#operation/remove_a_billing_info">remove_a_billing_info api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <param name="billingInfoId">Billing Info ID.</param>
+        /// <param name="billingInfoId">Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.</param>
         /// <returns>
         /// Billing information deleted
         /// </returns>

--- a/Recurly/Resources/AddOnPricing.cs
+++ b/Recurly/Resources/AddOnPricing.cs
@@ -19,6 +19,10 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -27,7 +27,7 @@ namespace Recurly.Resources
         [JsonProperty("balance")]
         public float? Balance { get; set; }
 
-        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.</value>
+        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.</value>
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 

--- a/Recurly/Resources/InvoiceCollect.cs
+++ b/Recurly/Resources/InvoiceCollect.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class InvoiceCollect : Request
     {
 
-        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.</value>
+        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.</value>
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -79,6 +79,10 @@ namespace Recurly.Resources
         [JsonProperty("tax_exempt")]
         public bool? TaxExempt { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Line item type. If `item_code`/`item_id` is present then `type` should not be present. If `item_code`/`item_id` is not present then `type` is required.</value>
         [JsonProperty("type")]
         public string Type { get; set; }

--- a/Recurly/Resources/PlanPricing.cs
+++ b/Recurly/Resources/PlanPricing.cs
@@ -23,6 +23,10 @@ namespace Recurly.Resources
         [JsonProperty("setup_fee")]
         public float? SetupFee { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }

--- a/Recurly/Resources/Pricing.cs
+++ b/Recurly/Resources/Pricing.cs
@@ -19,6 +19,10 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }

--- a/Recurly/Resources/PurchaseCreate.cs
+++ b/Recurly/Resources/PurchaseCreate.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("account")]
         public AccountPurchase Account { get; set; }
 
-        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.</value>
+        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.</value>
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -79,6 +79,10 @@ namespace Recurly.Resources
         [JsonProperty("subscription_id")]
         public string SubscriptionId { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Unit amount</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -80,6 +80,10 @@ namespace Recurly.Resources
         [JsonProperty("shipping")]
         public SubscriptionChangeShippingCreate Shipping { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription term ends. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to `term_end` or `bill_date` so the change takes effect at a scheduled billing date. The `renewal` timeframe option is accepted as an alias for `term_end`.</value>
         [JsonProperty("timeframe")]
         public string Timeframe { get; set; }

--- a/Recurly/Resources/SubscriptionChangePreview.cs
+++ b/Recurly/Resources/SubscriptionChangePreview.cs
@@ -79,6 +79,10 @@ namespace Recurly.Resources
         [JsonProperty("subscription_id")]
         public string SubscriptionId { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>Unit amount</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -27,7 +27,7 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
-        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.</value>
+        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.</value>
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 
@@ -94,6 +94,10 @@ namespace Recurly.Resources
         /// <value>If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.</value>
         [JsonProperty("starts_at")]
         public DateTime? StartsAt { get; set; }
+
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
 
         /// <value>This will default to the Terms and Conditions text specified on the Invoice Settings page in your Recurly admin. Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.</value>
         [JsonProperty("terms_and_conditions")]

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -59,6 +59,10 @@ namespace Recurly.Resources
         [JsonProperty("starts_at")]
         public DateTime? StartsAt { get; set; }
 
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
+
         /// <value>The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.</value>
         [JsonProperty("total_billing_cycles")]
         public int? TotalBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionUpdate.cs
+++ b/Recurly/Resources/SubscriptionUpdate.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
-        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.</value>
+        /// <value>The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.</value>
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 
@@ -62,6 +62,10 @@ namespace Recurly.Resources
         /// <value>Subscription shipping details</value>
         [JsonProperty("shipping")]
         public SubscriptionShippingUpdate Shipping { get; set; }
+
+        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        [JsonProperty("tax_inclusive")]
+        public bool? TaxInclusive { get; set; }
 
         /// <value>Specify custom notes to add or override Terms and Conditions. Custom notes will stay with a subscription on all renewals.</value>
         [JsonProperty("terms_and_conditions")]

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14525,7 +14525,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17683,7 +17684,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17939,7 +17941,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18551,6 +18554,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
             `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -19113,6 +19123,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -19274,6 +19291,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19291,6 +19315,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -20248,6 +20279,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -20353,6 +20391,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20485,7 +20530,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20512,6 +20558,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20649,6 +20702,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20792,6 +20852,13 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20800,7 +20867,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -21469,7 +21537,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           type: string
           title: Collection method


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `tax_inclusive` attribute to the following resources:
- AddOnPricing
- LineItemCreate
- PlanPricing
- Pricing
- SubscriptionChange
- SubscriptionChangeCreate
- SubscriptionChangePreview
- SubscriptionCreate
- SubscriptionPurchase
- SubscriptionUpdate