### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -1989,6 +1989,9 @@ namespace Recurly
             [EnumMember(Value = "bacs")]
             Bacs,
 
+            [EnumMember(Value = "becs")]
+            Becs,
+
         };
 
         public enum AchAccountType

--- a/Recurly/Resources/Account.cs
+++ b/Recurly/Resources/Account.cs
@@ -100,6 +100,10 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>Invoice template associated to the account. Available when invoice customization flag is enabled.</value>
+        [JsonProperty("invoice_template")]
+        public AccountInvoiceTemplate InvoiceTemplate { get; set; }
+
 
         [JsonProperty("last_name")]
         public string LastName { get; set; }

--- a/Recurly/Resources/AccountInvoiceTemplate.cs
+++ b/Recurly/Resources/AccountInvoiceTemplate.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class AccountInvoiceTemplate : Resource
+    {
+
+        /// <value>Unique ID to identify the invoice template.</value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <value>Template name</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+    }
+}

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -56,11 +56,11 @@ namespace Recurly.Resources
         [JsonProperty("display_quantity")]
         public bool? DisplayQuantity { get; set; }
 
-        /// <value>Unique code to identify an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
+        /// <value>Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
         [JsonProperty("item_code")]
         public string ItemCode { get; set; }
 
-        /// <value>System-generated unique identifier for an item. Available when the `Credit Invoices` and `Subscription Billing Terms` features are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
+        /// <value>System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
 

--- a/Recurly/Resources/BillingInfoCreate.cs
+++ b/Recurly/Resources/BillingInfoCreate.cs
@@ -122,7 +122,7 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.GatewayTransactionType? TransactionType { get; set; }
 
-        /// <value>The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)</value>
+        /// <value>The payment method type for a non-credit card based billing info. `bacs` and `becs` are the only accepted values.</value>
         [JsonProperty("type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.AchType? Type { get; set; }

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -76,7 +76,7 @@ namespace Recurly.Resources
         [JsonProperty("end_date")]
         public DateTime? EndDate { get; set; }
 
-        /// <value>Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.</value>
+        /// <value>Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is enabled.</value>
         [JsonProperty("external_sku")]
         public string ExternalSku { get; set; }
 
@@ -92,11 +92,11 @@ namespace Recurly.Resources
         [JsonProperty("invoice_number")]
         public string InvoiceNumber { get; set; }
 
-        /// <value>Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.</value>
+        /// <value>Unique code to identify an item. Available when the Credit Invoices feature is enabled.</value>
         [JsonProperty("item_code")]
         public string ItemCode { get; set; }
 
-        /// <value>System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.</value>
+        /// <value>System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.</value>
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
 

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -44,11 +44,11 @@ namespace Recurly.Resources
         [JsonProperty("end_date")]
         public DateTime? EndDate { get; set; }
 
-        /// <value>Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.</value>
+        /// <value>Unique code to identify an item. Available when the Credit Invoices feature is enabled.</value>
         [JsonProperty("item_code")]
         public string ItemCode { get; set; }
 
-        /// <value>System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.</value>
+        /// <value>System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.</value>
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)


### PR DESCRIPTION
Support `Becs` as a payment method type for non-credit card based billing info.
- Added `Becs` as a valid non-credit card payment method type.

Support `InvoiceTemplate` in account when invoice customization feature is enabled.
- Added `InvoiceTemplate` object to account.

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.