### PR TITLE
Adding support for ClientOptions in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ var client = new Recurly.Client(apiKey);
 var sub = client.GetSubscription("uuid-abcd123456")
 ```
 
+To access Recurly API in Europe, you will need to specify the EU Region in the `ClientOptions`:
+```csharp
+// Add this on the top of your file
+using Recurly;
+using Recurly.Resources;
+
+const apiKey = "83749879bbde395b5fe0cc1a5abf8e5";
+var options = new ClientOptions()
+{
+    Region = ClientOptions.Regions.EU
+};
+var client = new Recurly.Client(apiKey, options);
+var sub = client.GetSubscription("uuid-abcd123456")
+```
+
 Optional arguments can be provided through object initializers.
 
 ```csharp

--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -36,6 +36,24 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void DefaultsToUSRegionWithoutClientOptions()
+        {
+            var client = new MockClient("myapikey");
+            Assert.Equal("https://v3.recurly.com/", client.RestClient.BaseUrl.AbsoluteUri);
+        }
+
+        [Fact]
+        public void CanInitializeWithEUSDataCenter()
+        {
+            var options = new ClientOptions()
+            {
+                Region = ClientOptions.Regions.EU
+            };
+            var client = new MockClient("myapikey", options);
+            Assert.Equal("https://v3.eu.recurly.com/", client.RestClient.BaseUrl.AbsoluteUri);
+        }
+
+        [Fact]
         public void CanProperlyFetchAResource()
         {
             var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));

--- a/Recurly.Tests/MockClient.cs
+++ b/Recurly.Tests/MockClient.cs
@@ -13,6 +13,7 @@ namespace Recurly.Tests
     {
         public override string ApiVersion => "v2018-08-09";
 
+        public MockClient(string apiKey, ClientOptions options) : base(apiKey, options) { }
         public MockClient(string apiKey) : base(apiKey) { }
 
         internal static MockClient Build<T>(Mock<IRestResponse<T>> response, string apiKey = "myapikey")

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -18,21 +18,22 @@ namespace Recurly
     public class BaseClient
     {
         private string ApiKey { get; }
-        private const string ApiUrl = "https://v3.recurly.com/";
         private string[] BinaryTypes = { "application/pdf" };
         private List<IEventHandler> EventHandlers = new List<IEventHandler>();
         public virtual string ApiVersion { get; protected set; }
 
         internal IRestClient RestClient { get; set; }
 
-        public BaseClient(string apiKey)
+        public BaseClient(string apiKey) : this(apiKey, new ClientOptions()) { }
+
+        public BaseClient(string apiKey, ClientOptions options)
         {
             if (String.IsNullOrEmpty(apiKey))
                 throw new ArgumentException($"apiKey is required. You passed in {apiKey}");
 
             ApiKey = apiKey;
             RestClient = new RestClient();
-            RestClient.BaseUrl = new Uri(ApiUrl);
+            RestClient.BaseUrl = new Uri(options.BaseUrl);
             RestClient.Authenticator = new HttpBasicAuthenticator(ApiKey, "");
 
             // AddDefaultHeader does not work for user-agent

--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -20,6 +20,7 @@ namespace Recurly
     {
         public override string ApiVersion => "v2021-02-25";
 
+        public Client(string apiKey, ClientOptions options) : base(apiKey, options) { }
         public Client(string apiKey) : base(apiKey) { }
 
         /// <summary>

--- a/Recurly/ClientOptions.cs
+++ b/Recurly/ClientOptions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace Recurly
+{
+    public class ClientOptions
+    {
+        public enum Regions { US, EU }
+
+        public Regions Region { get; set; }
+
+        private static readonly Dictionary<Regions, string> _RegionUrlMap = new Dictionary<Regions, string>()
+        {
+            { Regions.US, "https://v3.recurly.com/" },
+            { Regions.EU, "https://v3.eu.recurly.com/" }
+        };
+
+        public ClientOptions()
+        {
+            Region = Regions.US;
+        }
+
+        public string BaseUrl
+        {
+            get
+            {
+                return _RegionUrlMap[Region];
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `ClientOptions` class currently supports the ability to specify what `Region` to use. The `Region` will default to `ClientOptions.Regions.US`, but can be set to use `ClientOptions.Regions.EU` to access the data center that is hosted in the EU.