### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -23,6 +23,10 @@ namespace Recurly.Resources
         [JsonProperty("activated_at")]
         public DateTime? ActivatedAt { get; set; }
 
+        /// <value>The invoice ID of the latest invoice created for an active subscription.</value>
+        [JsonProperty("active_invoice_id")]
+        public string ActiveInvoiceId { get; set; }
+
         /// <value>Add-ons</value>
         [JsonProperty("add_ons")]
         public List<SubscriptionAddOn> AddOns { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19999,6 +19999,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.