### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -560,6 +560,30 @@ namespace Recurly
 
         };
 
+        public enum UsageTimeframe
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "billing_period")]
+            BillingPeriod,
+
+            [EnumMember(Value = "subscription_term")]
+            SubscriptionTerm,
+
+        };
+
+        public enum UsageTimeframeCreate
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "billing_period")]
+            BillingPeriod,
+
+            [EnumMember(Value = "subscription_term")]
+            SubscriptionTerm,
+
+        };
+
         public enum CreditPaymentAction
         {
             Undefined = 0,

--- a/Recurly/Resources/AddOn.cs
+++ b/Recurly/Resources/AddOn.cs
@@ -128,6 +128,11 @@ namespace Recurly.Resources
         [JsonProperty("usage_percentage")]
         public decimal? UsagePercentage { get; set; }
 
+        /// <value>The time at which usage totals are reset for billing purposes.</value>
+        [JsonProperty("usage_timeframe")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.UsageTimeframe? UsageTimeframe { get; set; }
+
         /// <value>Type of usage, returns usage type if `add_on_type` is `usage`.</value>
         [JsonProperty("usage_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -126,6 +126,15 @@ namespace Recurly.Resources
         public decimal? UsagePercentage { get; set; }
 
         /// <value>
+        /// The time at which usage totals are reset for billing purposes.
+        /// Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        /// billing periods.
+        /// </value>
+        [JsonProperty("usage_timeframe")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.UsageTimeframeCreate? UsageTimeframe { get; set; }
+
+        /// <value>
         /// Type of usage, required if `add_on_type` is `usage`. See our
         /// [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an
         /// overview of how to configure usage add-ons.

--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -23,6 +23,10 @@ namespace Recurly.Resources
         [JsonProperty("activated_at")]
         public DateTime? ActivatedAt { get; set; }
 
+        /// <value>The invoice ID of the latest invoice created for an active subscription.</value>
+        [JsonProperty("active_invoice_id")]
+        public string ActiveInvoiceId { get; set; }
+
         /// <value>Add-ons</value>
         [JsonProperty("add_ons")]
         public List<SubscriptionAddOn> AddOns { get; set; }

--- a/Recurly/Resources/SubscriptionAddOn.cs
+++ b/Recurly/Resources/SubscriptionAddOn.cs
@@ -102,5 +102,10 @@ namespace Recurly.Resources
         [JsonProperty("usage_percentage")]
         public decimal? UsagePercentage { get; set; }
 
+        /// <value>The time at which usage totals are reset for billing purposes.</value>
+        [JsonProperty("usage_timeframe")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.UsageTimeframe? UsageTimeframe { get; set; }
+
     }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.