### PR TITLE
V2 add ProcessingPrepaymentBalanceInCents to AccountBalance

### DIFF
--- a/Library/AccountBalance.cs
+++ b/Library/AccountBalance.cs
@@ -12,6 +12,7 @@ namespace Recurly
     {
         public bool PastDue { get; internal set; }
         public Dictionary<string, int> BalanceInCents = new Dictionary<string, int>();
+        public Dictionary<string, int> ProcessingPrepaymentBalanceInCents = new Dictionary<string, int>();
         private const string UrlPrefix = "/accounts/";
 
         public static AccountBalance Get(string accountCode)
@@ -55,6 +56,18 @@ namespace Recurly
                             if (reader.NodeType == XmlNodeType.Element)
                             {
                                 BalanceInCents.Add(reader.Name, reader.ReadElementContentAsInt());
+                            }
+                        }
+                        break;
+                    case "processing_prepayment_balance_in_cents":
+                        while (reader.Read())
+                        {
+                            if (reader.Name == "processing_prepayment_balance_in_cents" && reader.NodeType == XmlNodeType.EndElement)
+                                break;
+
+                            if (reader.NodeType == XmlNodeType.Element)
+                            {
+                                ProcessingPrepaymentBalanceInCents.Add(reader.Name, reader.ReadElementContentAsInt());
                             }
                         }
                         break;

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -196,6 +196,7 @@ namespace Recurly.Test
 
             balance.Should().NotBeNull();
             balance.BalanceInCents.First().Value.Should().BeGreaterThan(0);
+            balance.ProcessingPrepaymentBalanceInCents.First().Value.Should().Be(0);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]


### PR DESCRIPTION
Add new add `ProcessingPrepaymentBalanceInCents` attribute to `AccountBalance`. The `ProcessingPrepaymentBalanceInCents` attribute is a similar format to the `BalanceInCents` attribute and contains the total for processing prepayment credit invoices in each currency. This value is useful when trying to determine if the customer's
prepayment balance has run out or if it is currently processing while waiting on a payment for the corresponding purchase invoice.