### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/Recurly/Resources/AccountBalanceAmount.cs
+++ b/Recurly/Resources/AccountBalanceAmount.cs
@@ -23,5 +23,9 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <value>Total amount for the prepayment credit invoices in a `processing` state on the account.</value>
+        [JsonProperty("processing_prepayment_amount")]
+        public float? ProcessingPrepaymentAmount { get; set; }
+
     }
 }

--- a/Recurly/Resources/AddOnPricing.cs
+++ b/Recurly/Resources/AddOnPricing.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/PlanPricing.cs
+++ b/Recurly/Resources/PlanPricing.cs
@@ -23,7 +23,7 @@ namespace Recurly.Resources
         [JsonProperty("setup_fee")]
         public float? SetupFee { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/Pricing.cs
+++ b/Recurly/Resources/Pricing.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -79,7 +79,7 @@ namespace Recurly.Resources
         [JsonProperty("subscription_id")]
         public string SubscriptionId { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -80,7 +80,7 @@ namespace Recurly.Resources
         [JsonProperty("shipping")]
         public SubscriptionChangeShippingCreate Shipping { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/SubscriptionChangePreview.cs
+++ b/Recurly/Resources/SubscriptionChangePreview.cs
@@ -79,7 +79,7 @@ namespace Recurly.Resources
         [JsonProperty("subscription_id")]
         public string SubscriptionId { get; set; }
 
-        /// <value>Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/Recurly/Resources/SubscriptionUpdate.cs
+++ b/Recurly/Resources/SubscriptionUpdate.cs
@@ -63,7 +63,7 @@ namespace Recurly.Resources
         [JsonProperty("shipping")]
         public SubscriptionShippingUpdate Shipping { get; set; }
 
-        /// <value>This field is deprecated. Do not use it anymore to update a subscription's tax inclusivity. Use the POST subscription change route instead.</value>
+        /// <value>This field is deprecated. Please do not use it.</value>
         [JsonProperty("tax_inclusive")]
         public bool? TaxInclusive { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.