### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/Recurly/Resources/Plan.cs
+++ b/Recurly/Resources/Plan.cs
@@ -87,6 +87,18 @@ namespace Recurly.Resources
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <value>
+        /// A fixed pricing model has the same price for each billing period.
+        /// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        /// a specified cadence of billing periods. The price change could be an increase or decrease.
+        /// </value>
+        [JsonProperty("pricing_model")]
+        public string PricingModel { get; set; }
+
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -75,6 +75,18 @@ namespace Recurly.Resources
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <value>
+        /// A fixed pricing model has the same price for each billing period.
+        /// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        /// a specified cadence of billing periods. The price change could be an increase or decrease.
+        /// </value>
+        [JsonProperty("pricing_model")]
+        public string PricingModel { get; set; }
+
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/PlanRampInterval.cs
+++ b/Recurly/Resources/PlanRampInterval.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class PlanRampInterval : Request
+    {
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("currencies")]
+        public List<PlanRampPricing> Currencies { get; set; }
+
+        /// <value>Represents the first billing cycle of a ramp.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+    }
+}

--- a/Recurly/Resources/PlanRampPricing.cs
+++ b/Recurly/Resources/PlanRampPricing.cs
@@ -12,22 +12,14 @@ using Newtonsoft.Json;
 namespace Recurly.Resources
 {
     [ExcludeFromCodeCoverage]
-    public class PlanPricing : Request
+    public class PlanRampPricing : Request
     {
 
         /// <value>3-letter ISO 4217 currency code.</value>
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <value>Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.</value>
-        [JsonProperty("setup_fee")]
-        public float? SetupFee { get; set; }
-
-        /// <value>This field is deprecated. Please do not use it.</value>
-        [JsonProperty("tax_inclusive")]
-        public bool? TaxInclusive { get; set; }
-
-        /// <value>This field should not be sent when the pricing model is 'ramp'.</value>
+        /// <value>Represents the price for the Ramp Interval.</value>
         [JsonProperty("unit_amount")]
         public float? UnitAmount { get; set; }
 

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -67,6 +67,10 @@ namespace Recurly.Resources
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -131,6 +131,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The ramp intervals representing the pricing schedule for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampIntervalResponse> RampIntervals { get; set; }
+
         /// <value>The remaining billing cycles in the current term.</value>
         [JsonProperty("remaining_billing_cycles")]
         public int? RemainingBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -63,6 +63,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The ramp intervals representing the pricing schedule for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampIntervalResponse> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -72,6 +72,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/SubscriptionChangePreview.cs
+++ b/Recurly/Resources/SubscriptionChangePreview.cs
@@ -63,6 +63,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The ramp intervals representing the pricing schedule for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampIntervalResponse> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         public string RevenueScheduleType { get; set; }

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -79,6 +79,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.</value>
         [JsonProperty("renewal_billing_cycles")]
         public int? RenewalBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -43,6 +43,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.</value>
         [JsonProperty("renewal_billing_cycles")]
         public int? RenewalBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionRampInterval.cs
+++ b/Recurly/Resources/SubscriptionRampInterval.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class SubscriptionRampInterval : Request
+    {
+
+        /// <value>Represents how many billing cycles are included in a ramp interval.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("unit_amount")]
+        public int? UnitAmount { get; set; }
+
+    }
+}

--- a/Recurly/Resources/SubscriptionRampIntervalResponse.cs
+++ b/Recurly/Resources/SubscriptionRampIntervalResponse.cs
@@ -1,0 +1,31 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class SubscriptionRampIntervalResponse : Resource
+    {
+
+        /// <value>Represents how many billing cycles are left in a ramp interval.</value>
+        [JsonProperty("remaining_billing_cycles")]
+        public int? RemainingBillingCycles { get; set; }
+
+        /// <value>Represents how many billing cycles are included in a ramp interval.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("unit_amount")]
+        public int? UnitAmount { get; set; }
+
+    }
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17259,7 +17259,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18828,6 +18828,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         accounting_code:
           type: string
           title: Plan accounting code
@@ -19006,6 +19022,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19137,6 +19169,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19214,6 +19247,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19291,6 +19329,19 @@ components:
             a non-default dunning campaign should be assigned to this plan. For sites
             without multiple dunning campaigns enabled, the default dunning campaign
             will always be used.
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     AddOnPricing:
       type: object
       properties:
@@ -19311,6 +19362,24 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+      required:
+      - currency
+      - unit_amount
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
       required:
       - currency
       - unit_amount
@@ -19899,6 +19968,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20362,6 +20438,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20501,6 +20584,12 @@ components:
           - moto
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangePreview:
       type: object
       allOf:
@@ -20652,6 +20741,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -20803,6 +20898,12 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -20986,6 +21087,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription