### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -623,6 +623,18 @@ namespace Recurly
 
         };
 
+        public enum PricingModelType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "fixed")]
+            Fixed,
+
+            [EnumMember(Value = "ramp")]
+            Ramp,
+
+        };
+
         public enum RevenueScheduleType
         {
             Undefined = 0,
@@ -1337,6 +1349,9 @@ namespace Recurly
 
             [EnumMember(Value = "sepadirectdebit")]
             Sepadirectdebit,
+
+            [EnumMember(Value = "venmo")]
+            Venmo,
 
             [EnumMember(Value = "wire_transfer")]
             WireTransfer,

--- a/Recurly/Resources/PaymentMethod.cs
+++ b/Recurly/Resources/PaymentMethod.cs
@@ -78,5 +78,9 @@ namespace Recurly.Resources
         [JsonProperty("routing_number_bank")]
         public string RoutingNumberBank { get; set; }
 
+        /// <value>Username of the associated payment method. Currently only associated with Venmo.</value>
+        [JsonProperty("username")]
+        public string Username { get; set; }
+
     }
 }

--- a/Recurly/Resources/Plan.cs
+++ b/Recurly/Resources/Plan.cs
@@ -88,6 +88,19 @@ namespace Recurly.Resources
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <value>
+        /// A fixed pricing model has the same price for each billing period.
+        /// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        /// a specified cadence of billing periods. The price change could be an increase or decrease.
+        /// </value>
+        [JsonProperty("pricing_model")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.PricingModelType? PricingModel { get; set; }
+
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -76,6 +76,19 @@ namespace Recurly.Resources
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <value>
+        /// A fixed pricing model has the same price for each billing period.
+        /// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        /// a specified cadence of billing periods. The price change could be an increase or decrease.
+        /// </value>
+        [JsonProperty("pricing_model")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.PricingModelType? PricingModel { get; set; }
+
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/PlanRampInterval.cs
+++ b/Recurly/Resources/PlanRampInterval.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class PlanRampInterval : Request
+    {
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("currencies")]
+        public List<PlanRampPricing> Currencies { get; set; }
+
+        /// <value>Represents the first billing cycle of a ramp.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+    }
+}

--- a/Recurly/Resources/PlanRampPricing.cs
+++ b/Recurly/Resources/PlanRampPricing.cs
@@ -12,22 +12,14 @@ using Newtonsoft.Json;
 namespace Recurly.Resources
 {
     [ExcludeFromCodeCoverage]
-    public class PlanPricing : Request
+    public class PlanRampPricing : Request
     {
 
         /// <value>3-letter ISO 4217 currency code.</value>
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <value>Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.</value>
-        [JsonProperty("setup_fee")]
-        public decimal? SetupFee { get; set; }
-
-        /// <value>This field is deprecated. Please do not use it.</value>
-        [JsonProperty("tax_inclusive")]
-        public bool? TaxInclusive { get; set; }
-
-        /// <value>This field should not be sent when the pricing model is 'ramp'.</value>
+        /// <value>Represents the price for the Ramp Interval.</value>
         [JsonProperty("unit_amount")]
         public decimal? UnitAmount { get; set; }
 

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -43,7 +43,7 @@ namespace Recurly.Resources
         [JsonProperty("code")]
         public string Code { get; set; }
 
-        /// <value>Pricing</value>
+        /// <value>Optional when the pricing model is 'ramp'.</value>
         [JsonProperty("currencies")]
         public List<PlanPricing> Currencies { get; set; }
 
@@ -66,6 +66,10 @@ namespace Recurly.Resources
         /// <value>This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>Ramp Intervals</value>
+        [JsonProperty("ramp_intervals")]
+        public List<PlanRampInterval> RampIntervals { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -136,6 +136,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The ramp intervals representing the pricing schedule for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampIntervalResponse> RampIntervals { get; set; }
+
         /// <value>The remaining billing cycles in the current term.</value>
         [JsonProperty("remaining_billing_cycles")]
         public int? RemainingBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -63,6 +63,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The ramp intervals representing the pricing schedule for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampIntervalResponse> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -74,6 +74,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -80,6 +80,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.</value>
         [JsonProperty("renewal_billing_cycles")]
         public int? RenewalBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -43,6 +43,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>The new set of ramp intervals for the subscription.</value>
+        [JsonProperty("ramp_intervals")]
+        public List<SubscriptionRampInterval> RampIntervals { get; set; }
+
         /// <value>If `auto_renew=true`, when a term completes, `total_billing_cycles` takes this value as the length of subsequent terms. Defaults to the plan's `total_billing_cycles`.</value>
         [JsonProperty("renewal_billing_cycles")]
         public int? RenewalBillingCycles { get; set; }

--- a/Recurly/Resources/SubscriptionRampInterval.cs
+++ b/Recurly/Resources/SubscriptionRampInterval.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class SubscriptionRampInterval : Request
+    {
+
+        /// <value>Represents how many billing cycles are included in a ramp interval.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("unit_amount")]
+        public int? UnitAmount { get; set; }
+
+    }
+}

--- a/Recurly/Resources/SubscriptionRampIntervalResponse.cs
+++ b/Recurly/Resources/SubscriptionRampIntervalResponse.cs
@@ -1,0 +1,31 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class SubscriptionRampIntervalResponse : Resource
+    {
+
+        /// <value>Represents how many billing cycles are left in a ramp interval.</value>
+        [JsonProperty("remaining_billing_cycles")]
+        public int? RemainingBillingCycles { get; set; }
+
+        /// <value>Represents how many billing cycles are included in a ramp interval.</value>
+        [JsonProperty("starting_billing_cycle")]
+        public int? StartingBillingCycle { get; set; }
+
+        /// <value>Represents the price for the ramp interval.</value>
+        [JsonProperty("unit_amount")]
+        public int? UnitAmount { get; set; }
+
+    }
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17535,7 +17535,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18959,6 +18959,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19121,6 +19129,14 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          "$ref": "#/components/schemas/PricingModelTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19242,6 +19258,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19250,6 +19267,19 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     PlanUpdate:
       type: object
       properties:
@@ -19316,6 +19346,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -19362,6 +19397,7 @@ components:
         currencies:
           type: array
           title: Pricing
+          description: Optional when the pricing model is 'ramp'.
           items:
             "$ref": "#/components/schemas/PlanPricing"
           minItems: 1
@@ -19441,6 +19477,24 @@ components:
             If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
       required:
       - currency
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
+      required:
+      - currency
+      - unit_amount
     Pricing:
       type: object
       properties:
@@ -20044,6 +20098,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20546,6 +20607,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20671,6 +20739,12 @@ components:
           "$ref": "#/components/schemas/GatewayTransactionTypeEnum"
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription
@@ -20825,6 +20899,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -20964,6 +21044,12 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -21145,6 +21231,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info
@@ -21998,6 +22108,10 @@ components:
         routing_number_bank:
           type: string
           description: The bank name of this routing number.
+        username:
+          type: string
+          description: Username of the associated payment method. Currently only associated
+            with Venmo.
     Error:
       type: object
       properties:
@@ -22327,6 +22441,16 @@ components:
       - api_only
       - read_only
       - write
+    PricingModelTypeEnum:
+      type: string
+      enum:
+      - fixed
+      - ramp
+      default: fixed
+      description: |
+        A fixed pricing model has the same price for each billing period.
+        A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        a specified cadence of billing periods. The price change could be an increase or decrease.
     RevenueScheduleTypeEnum:
       type: string
       enum:
@@ -22594,6 +22718,7 @@ components:
       - paypal_billing_agreement
       - roku
       - sepadirectdebit
+      - venmo
       - wire_transfer
       - braintree_v_zero
     CardTypeEnum:


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription
- Adds `username` property to `PaymentMethod`