### PR TITLE
Added Support for Ramp Pricing Feature

### DIFF
--- a/Library/PlanRampInterval.cs
+++ b/Library/PlanRampInterval.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Recurly
+{
+    public class PlanRampInterval : RecurlyEntity
+    {
+        /// <summary>Represents the first billing cycle of a ramp.</summary>
+        public int StartingBillingCycle { get; set; }
+
+        /// <summary>Represents the price and currency code for the ramp interval.</summary>
+        public List<PlanRampPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<PlanRampPricing>()); }
+            set { _currencies = value; }
+        }
+
+        private List<PlanRampPricing> _currencies;
+
+        public PlanRampInterval() { }
+
+        public PlanRampInterval(int startingBillingCycle, List<PlanRampPricing> currencies)
+        {
+            StartingBillingCycle = startingBillingCycle;
+            Currencies = currencies;
+        }
+
+        internal PlanRampInterval(XmlTextReader xmlReader)
+        {
+            ReadXml(xmlReader);
+        }
+
+        internal void ReadXmlCurrencies(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "unit_amount_in_cents" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    var currency = new PlanRampPricing()
+                    {
+                        Currency = reader.Name,
+                        UnitAmountInCents = reader.ReadElementContentAsInt()
+                    };
+                    Currencies.Add(currency);
+                }
+            }
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "ramp_interval" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                switch (reader.Name)
+                {
+                    case "starting_billing_cycle":
+                        StartingBillingCycle = reader.ReadElementContentAsInt();
+                        break;
+
+                    case "unit_amount_in_cents":
+                        ReadXmlCurrencies(reader);
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("ramp_interval");
+            xmlWriter.WriteElementString("starting_billing_cycle", StartingBillingCycle.ToString());
+            xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", Currencies, pair => pair.Currency, pair => pair.UnitAmountInCents.ToString());
+            xmlWriter.WriteEndElement();
+        }
+    }
+}

--- a/Library/PlanRampPricing.cs
+++ b/Library/PlanRampPricing.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Xml;
+
+namespace Recurly
+{
+    public class PlanRampPricing : RecurlyEntity
+    {
+        /// <summary>3-letter ISO 4217 currency code.</summary>
+        public string Currency { get; set; }
+
+        /// <summary>Represents the price for the Ramp Interval.</summary>
+        public int UnitAmountInCents { get; set; }
+
+        public PlanRampPricing() { }
+
+        public PlanRampPricing(string currencyCode, int unitAmountInCents)
+        {
+            Currency = currencyCode;
+            UnitAmountInCents = unitAmountInCents;
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal override void ReadXml(XmlTextReader xmlWriter)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Library/PricingModelType.cs
+++ b/Library/PricingModelType.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Recurly
+{
+    /// <summary>
+    /// A fixed pricing model has the same price for each billing period.
+    /// A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+    /// a specified cadence of billing periods. The price change could be an increase or decrease.
+    /// </summary>
+    public enum PricingModelType
+    {
+        [EnumMember(Value = "fixed")]
+        Fixed,
+
+        [EnumMember(Value = "ramp")]
+        Ramp,
+    } 
+}

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -173,6 +173,64 @@ namespace Recurly.Test
             return name + " " + DateTime.Now.ToString("yyyyMMddhhmmFFFFFFF");
         }
 
+        public List<PlanRampInterval> GetMockRampIntervals(int numberOfRamps)
+        {
+            var rampIntervals = new List<PlanRampInterval>();
+
+            for (int i = 0; i < numberOfRamps; i++)
+            {
+                var rampInterval = new PlanRampInterval()
+                {
+                    StartingBillingCycle = (i == 0) ? 1 : i + 2,
+                    Currencies = new List<PlanRampPricing>
+                    {
+                        new PlanRampPricing()
+                        {
+                            Currency = "USD",
+                            UnitAmountInCents = (numberOfRamps * 100) * (i + 1)
+                        }
+                    }
+                };
+                rampIntervals.Add(rampInterval);
+            }
+
+            return rampIntervals;
+        }
+
+        public List<PlanRampInterval> GetMockRampIntervalsMultiCurrency(int numberOfRamps)
+        {
+            var rampIntervals = new List<PlanRampInterval>();
+
+            for (int i = 0; i < numberOfRamps; i++)
+            {
+                var currencies = new List<PlanRampPricing>();
+                var currency1 = new PlanRampPricing()
+                {
+                    Currency = "USD",
+                    UnitAmountInCents = (numberOfRamps * 100) * (i + 1)
+                };
+
+                currencies.Add(currency1);
+
+                var currency2 = new PlanRampPricing()
+                {
+                    Currency = "EUR",
+                    UnitAmountInCents = (numberOfRamps * 200) * (i + 1)
+                };
+
+                currencies.Add(currency2);
+
+                var rampInterval = new PlanRampInterval()
+                {
+                    StartingBillingCycle = (i == 0) ? 1 : i + 2,
+                    Currencies = currencies
+                };
+                rampIntervals.Add(rampInterval);
+            }
+
+            return rampIntervals;
+        }
+
         public string GetMockMeasuredUnitName(string name = "Test Measured Unit")
         {
             return name + " " + DateTime.Now.ToString("yyyyMMddhhmmFFFFFFF");

--- a/Test/List/PlanListTest.cs
+++ b/Test/List/PlanListTest.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Xunit;
+using System.Linq;
 
 namespace Recurly.Test
 {
@@ -15,6 +16,22 @@ namespace Recurly.Test
 
             var plans = Plans.List();
             plans.Should().NotBeEmpty();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void ListPlansWithRampIntervals()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Test Plan List with Ramps" };
+            plan.SetupFeeInCents.Add("USD", 0);
+            plan.PricingModel = PricingModelType.Ramp;
+            plan.RampIntervals = GetMockRampIntervals(3);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var plans = Plans.List();
+            var rampPlan = plans.FirstOrDefault(p => p.PricingModel == PricingModelType.Ramp);
+            rampPlan.Should().NotBeNull();
+            rampPlan.RampIntervals.Count.Should().Be(3);
         }
 
         [Fact(Skip = "utility, for cleaning up test data; may no longer be necessary")]


### PR DESCRIPTION
Added support for ramp pricing on plans.

Add `PlanRampInterval` and `PlanRampPricing` models, as well as `PricingModelType` enum.
Add `List<PlanRampInterval>` and `PricingModel` to the Plan object.
Added support for reading XML responses and writing XML requests for ramp pricing on a plan.
Added unit tests for plan `get`, `create`, and `update` for ramp priced plans.

