### PR TITLE
Added Support for Ramp Intervals on a Subscription

### DIFF
--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -84,7 +84,7 @@ namespace Recurly
         public PricingModelType? PricingModel { get; set; }
 
         /// <summary>
-        /// The ramp intervals representing the pricing schedule for the subscription
+        /// The ramp intervals representing the pricing schedule for the plan
         /// </summary>
         public List<PlanRampInterval> RampIntervals
         {

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -87,6 +87,16 @@ namespace Recurly
         /// </summary>
         public BillingInfo BillingInfo { get; set; }
 
+        /// <summary>
+        /// The ramp intervals representing the pricing schedule for the subscription
+        /// </summary>
+        public List<SubscriptionRampInterval> RampIntervals
+        {
+            get { return _rampIntervals ?? (_rampIntervals = new List<SubscriptionRampInterval>()); }
+            set { _rampIntervals = value; }
+        }
+
+        private List<SubscriptionRampInterval> _rampIntervals;
 
         /// <summary>
         /// Creates a new subscription change object
@@ -141,6 +151,13 @@ namespace Recurly
 
             if (BillingInfo != null)
                 BillingInfo.WriteXml(xmlWriter);
+
+            if (RampIntervals.HasAny())
+            {
+                xmlWriter.WriteStartElement("ramp_intervals");
+                _rampIntervals.ForEach(ramp => ramp.WriteXml(xmlWriter));
+                xmlWriter.WriteEndElement();
+            }
 
             xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 

--- a/Library/SubscriptionRampInterval.cs
+++ b/Library/SubscriptionRampInterval.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+namespace Recurly
+{
+    public class SubscriptionRampInterval : RecurlyEntity
+    {
+        /// <summary>Represents the billing cycle where a ramp interval starts.</summary>
+        public int StartingBillingCycle { get; set; }
+
+        /// <summary>Represents the price for the ramp interval.</summary>
+        public int UnitAmountInCents { get; set; }
+
+        /// <summary>A readonly element that represents how many billing cycles are left in a ramp interval.</summary>
+        public int? RemainingBillingCycles { get { return _remainingBillingCycles; } }
+
+        private int? _remainingBillingCycles;
+
+        #region Constructors
+        public SubscriptionRampInterval() { }
+
+        public SubscriptionRampInterval(int startingBillingCycle, int unitAmountInCents)
+        {
+            StartingBillingCycle = startingBillingCycle;
+            UnitAmountInCents = unitAmountInCents;
+        }
+
+        public SubscriptionRampInterval(XmlTextReader reader)
+        {
+            ReadXml(reader);
+        }
+        #endregion
+
+
+        #region Read and Write XML documents
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "ramp_interval" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element) continue;
+
+                switch (reader.Name)
+                {
+                    case "starting_billing_cycle":
+                        StartingBillingCycle = reader.ReadElementContentAsInt();
+                        break;
+
+                    case "unit_amount_in_cents":
+                        UnitAmountInCents = reader.ReadElementContentAsInt();
+                        break;
+
+                    case "remaining_billing_cycles":
+                        string elementContent = reader.ReadElementContentAsString();
+                        _remainingBillingCycles = !elementContent.IsNullOrWhiteSpace() ? int.Parse(elementContent) : (int?)null;
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("ramp_interval");
+            xmlWriter.WriteElementString("starting_billing_cycle", StartingBillingCycle.ToString());
+            xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.ToString());
+            xmlWriter.WriteEndElement();
+        }
+        #endregion
+    }
+}

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -173,7 +173,7 @@ namespace Recurly.Test
             return name + " " + DateTime.Now.ToString("yyyyMMddhhmmFFFFFFF");
         }
 
-        public List<PlanRampInterval> GetMockRampIntervals(int numberOfRamps)
+        public List<PlanRampInterval> GetMockPlanRampIntervals(int numberOfRamps)
         {
             var rampIntervals = new List<PlanRampInterval>();
 
@@ -197,7 +197,7 @@ namespace Recurly.Test
             return rampIntervals;
         }
 
-        public List<PlanRampInterval> GetMockRampIntervalsMultiCurrency(int numberOfRamps)
+        public List<PlanRampInterval> GetMockPlanRampIntervalsMultiCurrency(int numberOfRamps)
         {
             var rampIntervals = new List<PlanRampInterval>();
 
@@ -229,6 +229,50 @@ namespace Recurly.Test
             }
 
             return rampIntervals;
+        }
+
+        public List<SubscriptionRampInterval> GetMockSubscriptionRampIntervals(int numberOfRamps)
+        {
+            var rampIntervals = new List<SubscriptionRampInterval>();
+
+            for (int i = 0; i < numberOfRamps; i++)
+            {
+                var rampInterval = new SubscriptionRampInterval()
+                {
+                    StartingBillingCycle = (i == 0) ? 1 : i + 2,
+                    UnitAmountInCents = (numberOfRamps * 100) * (i + 1)
+                };
+                rampIntervals.Add(rampInterval);
+            }
+
+            return rampIntervals;
+        }
+
+        public Subscription CreateNewRampSubscription(int numberOfRamps)
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Create Ramp Subscription" };
+            plan.SetupFeeInCents.Add("USD", 0);
+            plan.PricingModel = PricingModelType.Ramp;
+            plan.RampIntervals = GetMockPlanRampIntervals(numberOfRamps);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.Create();
+
+            return Subscriptions.Get(sub.Uuid);
+        }
+
+        public Plan CreateNewRampPlan(int numberOfRamps)
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Create Ramp Plan" };
+            plan.SetupFeeInCents.Add("USD", 0);
+            plan.PricingModel = PricingModelType.Ramp;
+            plan.RampIntervals = GetMockPlanRampIntervals(numberOfRamps);
+            plan.Create();
+            return Plans.Get(plan.PlanCode);
         }
 
         public string GetMockMeasuredUnitName(string name = "Test Measured Unit")

--- a/Test/List/PlanListTest.cs
+++ b/Test/List/PlanListTest.cs
@@ -24,7 +24,7 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Test Plan List with Ramps" };
             plan.SetupFeeInCents.Add("USD", 0);
             plan.PricingModel = PricingModelType.Ramp;
-            plan.RampIntervals = GetMockRampIntervals(3);
+            plan.RampIntervals = GetMockPlanRampIntervals(3);
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
 

--- a/Test/List/SubscriptionListTest.cs
+++ b/Test/List/SubscriptionListTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -207,6 +208,21 @@ namespace Recurly.Test
 
             var list = account.GetSubscriptions(Subscription.SubscriptionState.All);
             list.Should().NotBeEmpty();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void ListSubscriptionsWithRampIntervals()
+        {
+            var subscription = CreateNewRampSubscription(3);
+
+            var list = Subscriptions.List(Subscription.SubscriptionState.Active);
+
+            var rampSubscription = list.FirstOrDefault(sub => sub.RampIntervals.Count > 0);
+
+            rampSubscription.Should().NotBeNull();
+            rampSubscription.RampIntervals.Count.Should().Be(3);
+            subscription.Cancel();
+            subscription.Account.Close();
         }
     }
 }

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -35,7 +35,7 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Test Ramp Lookup" };
             plan.SetupFeeInCents.Add("USD", 0);
             plan.PricingModel = PricingModelType.Ramp;
-            plan.RampIntervals = GetMockRampIntervals(3);
+            plan.RampIntervals = GetMockPlanRampIntervals(3);
 
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
@@ -52,7 +52,7 @@ namespace Recurly.Test
             plan.SetupFeeInCents.Add("USD", 0);
 
             plan.PricingModel = PricingModelType.Ramp;
-            plan.RampIntervals = GetMockRampIntervalsMultiCurrency(3);
+            plan.RampIntervals = GetMockPlanRampIntervalsMultiCurrency(3);
 
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
@@ -72,7 +72,7 @@ namespace Recurly.Test
             plan.PlanIntervalUnit = Plan.IntervalUnit.Months;
             plan.SetupFeeInCents.Add("USD", 0);
             plan.PricingModel = PricingModelType.Ramp;
-            plan.RampIntervals = GetMockRampIntervals(2);
+            plan.RampIntervals = GetMockPlanRampIntervals(2);
 
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
@@ -96,11 +96,11 @@ namespace Recurly.Test
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Test Update Plan with Ramps" };
             plan.SetupFeeInCents.Add("USD", 0);
             plan.PricingModel = PricingModelType.Ramp;
-            plan.RampIntervals = GetMockRampIntervals(2);
+            plan.RampIntervals = GetMockPlanRampIntervals(2);
             plan.Create();
             PlansToDeactivateOnDispose.Add(plan);
 
-            plan.RampIntervals = GetMockRampIntervalsMultiCurrency(4);
+            plan.RampIntervals = GetMockPlanRampIntervalsMultiCurrency(4);
             plan.Update();
 
             var updatedPlan = Plans.Get(plan.PlanCode);


### PR DESCRIPTION
Added support for ramp pricing on subscriptions.

Add `SubscriptionRampInterval` model.
Add `List<SubscriptionRampInterval>` to the `Subscription` and `SubscriptionChange` objects.
Added support for reading XML responses and writing XML requests for ramp pricing on a subscription and a subscription change.
Added unit tests for subscription `list`, `get`, `create`, and `update` for ramp priced subscriptions.