### PR TITLE
Add Unit Tests for Purchases with Ramp Pricing

### DIFF
--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -268,6 +268,7 @@ namespace Recurly.Test
         public Plan CreateNewRampPlan(int numberOfRamps)
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Create Ramp Plan" };
+            plan.TaxExempt = true;
             plan.SetupFeeInCents.Add("USD", 0);
             plan.PricingModel = PricingModelType.Ramp;
             plan.RampIntervals = GetMockPlanRampIntervals(numberOfRamps);

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -30,6 +30,112 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void InvoicePurchaseWithRampPlan()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+            var plan = CreateNewRampPlan(3);
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var purchase = new Purchase(account.AccountCode, "USD");
+            purchase.Account.BillingInfo = account.BillingInfo;
+
+            var sub = new Subscription(plan.PlanCode);
+            purchase.Subscriptions.Add(sub);
+
+            var collection = Purchase.Invoice(purchase);
+            int firstRampUnitAmount = plan.RampIntervals[0].Currencies[0].UnitAmountInCents;
+
+            Assert.NotNull(collection.ChargeInvoice);
+            Assert.Equal(collection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.SubtotalBeforeDiscountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].UnitAmountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Transactions[0].AmountInCents, firstRampUnitAmount);
+            account.Close();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void InvoicePurchaseWithCustomRamps()
+        {
+            var plan = CreateNewRampPlan(3);
+            PlansToDeactivateOnDispose.Add(plan);
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.RampIntervals = GetMockSubscriptionRampIntervals(2);
+
+            var purchase = new Purchase(sub.AccountCode, "USD");
+            purchase.Account.BillingInfo = sub.Account.BillingInfo;
+            purchase.Subscriptions.Add(sub);
+
+            var collection = Purchase.Invoice(purchase);
+            int firstRampUnitAmount = sub.RampIntervals[0].UnitAmountInCents;
+
+            Assert.NotNull(collection.ChargeInvoice);
+            Assert.Equal(collection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.SubtotalBeforeDiscountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].UnitAmountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Transactions[0].AmountInCents, firstRampUnitAmount);
+            account.Close();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void PreviewPurchaseWithRamps()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+            var plan = CreateNewRampPlan(3);
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var purchase = new Purchase(account.AccountCode, "USD");
+            purchase.Account.BillingInfo = account.BillingInfo;
+
+            var sub = new Subscription(plan.PlanCode);
+            purchase.Subscriptions.Add(sub);
+
+            var collection = Purchase.Preview(purchase);
+            int firstRampUnitAmount = plan.RampIntervals[0].Currencies[0].UnitAmountInCents;
+
+            Assert.NotNull(collection.ChargeInvoice);
+            Assert.Equal(collection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.SubtotalBeforeDiscountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].UnitAmountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].TotalInCents, firstRampUnitAmount);
+            account.Close();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void PendingPurchaseWithRamps()
+        {
+            var plan = CreateNewRampPlan(3);
+            PlansToDeactivateOnDispose.Add(plan);
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.RampIntervals = GetMockSubscriptionRampIntervals(2);
+
+            var purchase = new Purchase(sub.AccountCode, "USD");
+            purchase.Account.BillingInfo = sub.Account.BillingInfo;
+            // Randomly generate an email address
+            purchase.Account.Email = Guid.NewGuid().ToString().Substring(0, 8) + "@test.com";
+            purchase.Subscriptions.Add(sub);
+
+            var collection = Purchase.Pending(purchase);
+            int firstRampUnitAmount = sub.RampIntervals[0].UnitAmountInCents;
+
+            Assert.NotNull(collection.ChargeInvoice);
+            Assert.Equal(collection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.TotalInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.SubtotalBeforeDiscountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].UnitAmountInCents, firstRampUnitAmount);
+            Assert.Equal(collection.ChargeInvoice.Adjustments[0].TotalInCents, firstRampUnitAmount);
+            account.Close();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void CancelPurchase()
         {
             var collection = CreateNewCollection();
@@ -47,6 +153,31 @@ namespace Recurly.Test
             var transactionUuid = collection.ChargeInvoice.Transactions[0].Uuid;
             var capturedCollection = Purchase.Capture(transactionUuid);
             capturedCollection.ChargeInvoice.State.Should().Be(Invoice.InvoiceState.Paid);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void AuthAndCapturePurchaseWithRamps()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+            var plan = CreateNewRampPlan(3);
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var purchase = new Purchase(account.AccountCode, "USD");
+            purchase.Account.BillingInfo = account.BillingInfo;
+
+            var sub = new Subscription(plan.PlanCode);
+            sub.RampIntervals = GetMockSubscriptionRampIntervals(2);
+            purchase.Subscriptions.Add(sub);
+
+            var collection = Purchase.Authorize(purchase);
+            int firstRampUnitAmount = sub.RampIntervals[0].UnitAmountInCents;
+
+            Assert.Equal(collection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            var transactionUuid = collection.ChargeInvoice.Transactions[0].Uuid;
+            var capturedCollection = Purchase.Capture(transactionUuid);
+            capturedCollection.ChargeInvoice.State.Should().Be(Invoice.InvoiceState.Paid);
+            Assert.Equal(capturedCollection.ChargeInvoice.SubtotalInCents, firstRampUnitAmount);
+            account.Close();
         }
     }
 }


### PR DESCRIPTION
Added unit tests to support Purchases with ramp priced subscriptions.

Added the following unit tests: `InvoicePurchaseWithRampPlan`, `InvoicePurchaseWithCustomRamps`, `PreviewPurchaseWithRamps`, `PendingPurchaseWithRamps`, `AuthAndCapturePurchaseWithRamps`