### PR TITLE
Add card_type to billing_info create/update request

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -22,7 +22,8 @@ namespace Recurly
             Laser,
             Unknown,
             DinersClub,
-            UnionPay
+            UnionPay,
+            CartesBancaires
         }
 
         public enum HppType : short
@@ -548,6 +549,7 @@ namespace Recurly
                     xmlWriter.WriteElementString("year", ExpirationYear.AsString());
 
                     xmlWriter.WriteStringIfValid("verification_value", VerificationValue);
+                    xmlWriter.WriteElementString("card_type", CardType.ToString().EnumNameToTransportCase());
                 }
 
                 if (!RoutingNumber.IsNullOrEmpty())

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -28,6 +28,7 @@ namespace Recurly.Test
             info.Country = "GB";
             info.Currency = "USD";   // Should really be a different currency for testing but test environment doesn't seem set up for multi-currency
             info.IpAddress = "192.0.2.1";    // Reserved address for "TEST-NET-1" (so no country)
+            info.CardType = CreditCardType.CartesBancaires;
             info.CreditCardNumber = TestCreditCardNumbers.MasterCard1;
             info.VerificationValue = "321";
             info.ExpirationMonth = DateTime.Now.AddMonths(3).Month;


### PR DESCRIPTION
This PR is adding the field `card_type` to the billing_info creation/update process, this field was read-only but now can be sent by the merchant to specify the card type, this is useful when using a co-branded card brand like Cartes Bancaires.