### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Resources/SubscriptionRampIntervalResponse.cs
+++ b/Recurly/Resources/SubscriptionRampIntervalResponse.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>Represents the price for the ramp interval.</value>
         [JsonProperty("unit_amount")]
-        public int? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21302,7 +21302,9 @@ components:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object


### PR DESCRIPTION
Fixed incorrect type in OpenAPI spec for SubscriptionRampIntervalResponse, `unit_amount` is now `decimal`