### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/Recurly/Resources/BillingInfoCreate.cs
+++ b/Recurly/Resources/BillingInfoCreate.cs
@@ -49,7 +49,7 @@ namespace Recurly.Resources
         [JsonProperty("cvv")]
         public string Cvv { get; set; }
 
-        /// <value>Use for Adyen HPP billing info.</value>
+        /// <value>Use for Adyen HPP billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.</value>
         [JsonProperty("external_hpp_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.ExternalHppType? ExternalHppType { get; set; }
@@ -94,7 +94,7 @@ namespace Recurly.Resources
         [JsonProperty("number")]
         public string Number { get; set; }
 
-        /// <value>Use for Online Banking billing info.</value>
+        /// <value>Use for Online Banking billing info. This should only be used as part of a pending purchase request, when the billing info is nested inside an account object.</value>
         [JsonProperty("online_banking_payment_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.OnlineBankingPaymentType? OnlineBankingPaymentType { get; set; }

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -68,6 +68,14 @@ namespace Recurly.Resources
         [JsonProperty("dunning_campaign_id")]
         public string DunningCampaignId { get; set; }
 
+        /// <value>Number of times the event was sent.</value>
+        [JsonProperty("dunning_events_sent")]
+        public int? DunningEventsSent { get; set; }
+
+        /// <value>Last communication attempt.</value>
+        [JsonProperty("final_dunning_event")]
+        public bool? FinalDunningEvent { get; set; }
+
         /// <value>Identifies if the invoice has more line items than are returned in `line_items`. If `has_more_line_items` is `true`, then a request needs to be made to the `list_invoice_line_items` endpoint.</value>
         [JsonProperty("has_more_line_items")]
         public bool? HasMoreLineItems { get; set; }

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -148,6 +148,10 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.</value>
+        [JsonProperty("quantity_decimal")]
+        public string QuantityDecimal { get; set; }
+
         /// <value>Refund?</value>
         [JsonProperty("refund")]
         public bool? Refund { get; set; }
@@ -155,6 +159,10 @@ namespace Recurly.Resources
         /// <value>For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).</value>
         [JsonProperty("refunded_quantity")]
         public int? RefundedQuantity { get; set; }
+
+        /// <value>A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.</value>
+        [JsonProperty("refunded_quantity_decimal")]
+        public string RefundedQuantityDecimal { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/LineItemRefund.cs
+++ b/Recurly/Resources/LineItemRefund.cs
@@ -30,5 +30,9 @@ namespace Recurly.Resources
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
 
+        /// <value>A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.</value>
+        [JsonProperty("quantity_decimal")]
+        public string QuantityDecimal { get; set; }
+
     }
 }

--- a/Recurly/Resources/Usage.cs
+++ b/Recurly/Resources/Usage.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class Usage : Resource
     {
 
-        /// <value>The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").</value>
+        /// <value>The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").</value>
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }
 

--- a/Recurly/Resources/UsageCreate.cs
+++ b/Recurly/Resources/UsageCreate.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class UsageCreate : Request
     {
 
-        /// <value>The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").</value>
+        /// <value>The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").</value>
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `QuantityDecimal ` and `RefundedQuantityDecimal ` properties to `LineItem` class
- Add `QuantityDecimal ` property to `LineItemRefund` class.
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`