### PR TITLE
remove unintended debug log

### DIFF
--- a/Recurly/Utils.cs
+++ b/Recurly/Utils.cs
@@ -66,7 +66,6 @@ namespace Recurly
                         stringRepr = param.Value.ToString();
 
                         var type = param.Value.GetType();
-                        Console.WriteLine($"TYPE {type}");
                         var memInfos = type.GetMember(param.Value.ToString());
                         foreach (var memInfo in memInfos)
                             foreach (var attr in memInfo.GetCustomAttributes(true))


### PR DESCRIPTION
We have noticed odd logs appearing in our Kubernetes hosted service:
TYPE Recurly.Constants.AlphanumericSort
TYPE Recurly.Constants.TimestampSort

I have traced this to a Console.WriteLine call in Recurly library, which definitely looks like an unintended debug log leftover.

If there are any convention requirements like specific commit message format, please let me know.