### PR TITLE
V2 add support for Apply Credit Balance to existing invoice feature

### DIFF
--- a/Library/AccountBalance.cs
+++ b/Library/AccountBalance.cs
@@ -13,6 +13,7 @@ namespace Recurly
         public bool PastDue { get; internal set; }
         public Dictionary<string, int> BalanceInCents = new Dictionary<string, int>();
         public Dictionary<string, int> ProcessingPrepaymentBalanceInCents = new Dictionary<string, int>();
+        public Dictionary<string, int> AvailableCreditBalanceInCents = new Dictionary<string, int>();
         private const string UrlPrefix = "/accounts/";
 
         public static AccountBalance Get(string accountCode)
@@ -68,6 +69,18 @@ namespace Recurly
                             if (reader.NodeType == XmlNodeType.Element)
                             {
                                 ProcessingPrepaymentBalanceInCents.Add(reader.Name, reader.ReadElementContentAsInt());
+                            }
+                        }
+                        break;
+                    case "available_credit_balance_in_cents":
+                        while (reader.Read())
+                        {
+                            if (reader.Name == "available_credit_balance_in_cents" && reader.NodeType == XmlNodeType.EndElement)
+                                break;
+
+                            if (reader.NodeType == XmlNodeType.Element)
+                            {
+                                AvailableCreditBalanceInCents.Add(reader.Name, reader.ReadElementContentAsInt());
                             }
                         }
                         break;

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -245,6 +245,14 @@ namespace Recurly
         }
 
         /// <summary>
+        /// Applies the open credit balance on an account to a collectible charge invoice
+        /// </summary>
+        public void ApplyCreditBalance()
+        {
+            Client.Instance.PerformRequest(Client.HttpRequestMethod.Put, memberUrl() + "/apply_credit_balance", ReadXml);
+        }
+
+        /// <summary>
         /// Marks an invoice as failed. This returns a
         /// new invoice collection and does not update the
         /// this invoice object.

--- a/Test/AccountTest.cs
+++ b/Test/AccountTest.cs
@@ -199,6 +199,7 @@ namespace Recurly.Test
             balance.Should().NotBeNull();
             balance.BalanceInCents.First().Value.Should().BeGreaterThan(0);
             balance.ProcessingPrepaymentBalanceInCents.First().Value.Should().Be(0);
+            balance.AvailableCreditBalanceInCents.First().Value.Should().Be(0);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -184,6 +184,31 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void ApplyCreditBalance()
+        {
+            var account = CreateNewAccount();
+
+            var adjustment = account.NewAdjustment("USD", 3999, "Test Charge");
+            adjustment.Create();
+
+            var invoiceData = new Invoice()
+            {
+                CollectionMethod = Invoice.Collection.Manual
+            };
+
+            var collection = account.InvoicePendingCharges(invoiceData);
+            var invoice = collection.ChargeInvoice;
+
+            var credit = account.NewAdjustment("USD", -4999, "Test Credit");
+            credit.Create();
+            account.InvoicePendingCharges();
+
+            invoice.ApplyCreditBalance();
+
+            invoice.State.Should().Be(Invoice.InvoiceState.Paid);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void FailedCollection()
         {
             var account = CreateNewAccountWithBillingInfo();


### PR DESCRIPTION
Add new `AvailableCreditBalanceInCents` attribute to `AccountBalance`. The `AvailableCreditBalanceInCents` attribute is a similar format to the `BalanceInCents` attribute and contains the total of open balances for credit invoices in each currency. This value is useful when trying to determine if the customer's account has any available credit that can be applied to an existing collectible invoice on the account.

Add new `ApplyCreditBalance` method to `Invoice`. This action will be available for collectible charge invoices. If the account has available credit it will be applied to pay down the balance on the invoice.