### PR TITLE
Added DeclineCode to TransactionError

### DIFF
--- a/Library/TransactionDeclineEnum.cs
+++ b/Library/TransactionDeclineEnum.cs
@@ -1,0 +1,43 @@
+﻿namespace Recurly
+{
+    /// <summary>
+    /// Transaction Decline Codes Enum
+    /// </summary>
+    public enum TransactionDeclineCodeEnum
+    {
+        account_closed,
+        call_issuer,
+        card_not_activated,
+        card_not_supported,
+        cardholder_requested_stop,
+        do_not_honor,
+        do_not_try_again,
+        exceeds_daily_limit,
+        generic_decline,
+        expired_card,
+        fraudulent,
+        insufficient_funds,
+        incorrect_address,
+        incorrect_security_code,
+        invalid_amount,
+        invalid_number,
+        invalid_transaction,
+        issuer_unavailable,
+        lifecycle_decline,
+        lost_card,
+        pickup_card,
+        policy_decline,
+        restricted_card,
+        restricted_card_chargeback,
+        security_decline,
+        stolen_card,
+        try_again,
+        update_cardholder_data,
+        requires_3d_secure,
+
+        // NOTE: not_recognized is used as a default and does not reflect a
+        // valid value from the Recurly API. To preserve backwards compatibility,
+        // order of this enum should be preserved and new values must be appended.
+        not_recognized
+    }
+}

--- a/Library/TransactionError.cs
+++ b/Library/TransactionError.cs
@@ -32,6 +32,26 @@ namespace Recurly
         }
 
         /// <summary>
+        /// Transaction Decline Code
+        /// </summary>
+        public string DeclineCode { get; internal set; }
+        public TransactionDeclineCodeEnum DeclineCodeEnum
+        {
+            get
+            {
+                TransactionDeclineCodeEnum declineEnum;
+                if (Enum.TryParse(DeclineCode, out declineEnum))
+                {
+                    return declineEnum;
+                }
+                else
+                {
+                    return TransactionDeclineCodeEnum.not_recognized;
+                }
+            }
+        }
+
+        /// <summary>
         /// Category of error
         /// </summary>
         public string ErrorCategory { get; internal set; }
@@ -87,6 +107,9 @@ namespace Recurly
                     case "three_d_secure_action_token_id":
                         ThreeDSecureActionTokenId = reader.ReadElementContentAsString();
                         break;
+                    case "decline_code":
+                        DeclineCode = reader.ReadElementContentAsString();
+                        break
                 }
             }
         }

--- a/Library/TransactionError.cs
+++ b/Library/TransactionError.cs
@@ -109,7 +109,7 @@ namespace Recurly
                         break;
                     case "decline_code":
                         DeclineCode = reader.ReadElementContentAsString();
-                        break
+                        break;
                 }
             }
         }


### PR DESCRIPTION
This PR adds DeclineCode field to the TransactionError response. This will be populated when a transactions are declined from the issuer.