### PR TITLE
Wait for invoicing before closing account in test

### DIFF
--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -51,6 +51,7 @@ namespace Recurly.Test
             var invoice = account.InvoicePendingCharges().ChargeInvoice;
             var fromService = Invoices.Get(invoice.InvoiceNumber).Adjustments.First();
 
+            System.Threading.Thread.Sleep(1000);
             Assert.Equal(fromService.CustomFields.First().Name, "color");
             Assert.Equal(fromService.CustomFields.First().Value, "purple");
             account.Close();


### PR DESCRIPTION
Fix flakey test by waiting for invoicing to finish before closing account.