### PR TITLE
Bug fix for optional bodies not being included in requests

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -515,7 +515,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/billing_info/verify", urlParams);
-            return MakeRequest<Transaction>(Method.POST, url, null, null, options);
+            return MakeRequest<Transaction>(Method.POST, url, body, null, options);
         }
 
 
@@ -532,7 +532,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/billing_info/verify", urlParams);
-            return MakeRequestAsync<Transaction>(Method.POST, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<Transaction>(Method.POST, url, body, null, options, cancellationToken);
         }
 
 
@@ -2258,7 +2258,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
             var url = this.InterpolatePath("/invoices/{invoice_id}/collect", urlParams);
-            return MakeRequest<Invoice>(Method.PUT, url, null, null, options);
+            return MakeRequest<Invoice>(Method.PUT, url, body, null, options);
         }
 
 
@@ -2275,7 +2275,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
             var url = this.InterpolatePath("/invoices/{invoice_id}/collect", urlParams);
-            return MakeRequestAsync<Invoice>(Method.PUT, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<Invoice>(Method.PUT, url, body, null, options, cancellationToken);
         }
 
 
@@ -3314,7 +3314,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/cancel", urlParams);
-            return MakeRequest<Subscription>(Method.PUT, url, null, null, options);
+            return MakeRequest<Subscription>(Method.PUT, url, body, null, options);
         }
 
 
@@ -3331,7 +3331,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/cancel", urlParams);
-            return MakeRequestAsync<Subscription>(Method.PUT, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<Subscription>(Method.PUT, url, body, null, options, cancellationToken);
         }
 
 


### PR DESCRIPTION
Resovles https://github.com/recurly/recurly-client-dotnet/issues/773 by properly including the optional body in the request.