### PR TITLE
Added support for external accounts

### DIFF
--- a/Library/Account.cs
+++ b/Library/Account.cs
@@ -603,6 +603,75 @@ namespace Recurly
                 UrlPrefix + Uri.EscapeDataString(AccountCode) + "/billing_infos/" + billingInfoId);
         }
 
+        /// <summary>
+        /// Returns a specific external_account for this account
+        /// <param name="id"></param>
+        /// </summary>
+        /// <returns>ExternalAccount object</returns>
+        public ExternalAccount GetExternalAccount(string id)
+        {
+            if (id == null)
+                return null;
+
+            var externalAccount = new ExternalAccount();
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/external_accounts/" + id,
+                externalAccount.ReadXml);
+
+            return statusCode == HttpStatusCode.NotFound ? null : externalAccount;
+        }
+
+        /// <summary>
+        /// Returns a list of external_accounts for this account
+        /// </summary>
+        /// <returns>ExternalAccount list</returns>
+        public RecurlyList<ExternalAccount> GetExternalAccounts()
+        {
+            return new ExternalAccountList(Account.UrlPrefix + Uri.EscapeDataString(AccountCode) + "/external_accounts/");
+        }
+
+        /// <summary>
+        /// Create an external_account
+        /// </summary>
+        /// <param name="externalAccount"></param>
+        /// <returns>ExternalAccount object</returns>
+        public ExternalAccount CreateExternalAccount(ExternalAccount externalAccount)
+        {
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/external_accounts",
+                externalAccount.WriteXml,
+                externalAccount.ReadXml);
+
+            return statusCode == HttpStatusCode.Created ? externalAccount : null;
+        }
+
+        /// <summary>
+        /// Updates an external_account
+        /// </summary>
+        /// <param name="externalAccount"></param>
+        /// <returns>ExternalAccount object</returns>
+        public ExternalAccount UpdateExternalAccount(ExternalAccount externalAccount)
+        {
+            var id = externalAccount.Id;
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/external_accounts/" + id,
+                externalAccount.WriteXml,
+                externalAccount.ReadXml);
+
+            return statusCode == HttpStatusCode.OK ? externalAccount : null;
+        }
+
+        /// <summary>
+        /// Deletes an external_account
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public void DeleteExternalAccount(string id)
+        {
+            var statusCode = Client.Instance.PerformRequest(Client.HttpRequestMethod.Delete,
+                UrlPrefix + Uri.EscapeDataString(AccountCode) + "/external_accounts/" + id);
+        }
+
         #region Read and Write XML documents
 
         internal override void ReadXml(XmlTextReader reader)
@@ -953,6 +1022,7 @@ namespace Recurly
             parameters["state"] = state.ToString().EnumNameToTransportCase();
             return new AccountList(Account.UrlPrefix + "?" + parameters.ToString());
         }
+
         /// <summary>
         /// Returns a list of external_invoices for this account
         /// </summary>

--- a/Library/ExternalAccount.cs
+++ b/Library/ExternalAccount.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Xml;
+
+namespace Recurly
+{
+    /// <summary>
+    /// Represents external_accounts associated with Recurly accounts
+    /// </summary>
+    public class ExternalAccount : RecurlyEntity
+    {
+        public string Id { get; set; }
+        public string ExternalAccountCode { get; set; }
+        public string ExternalConnectionType { get; set; }
+        public DateTime? CreatedAt { get; private set; }
+        public DateTime? UpdatedAt { get; private set; }
+
+        public List<ExternalAccount> ExternalAccounts
+        {
+            get { return _externalAccounts ?? (_externalAccounts = new List<ExternalAccount>()); }
+            set { _externalAccounts = value; }
+        }
+
+        private List<ExternalAccount> _externalAccounts;
+
+        public ExternalAccount() { }
+
+        internal ExternalAccount(XmlTextReader reader)
+        {
+            ReadXml(reader);
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "external_account" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType != XmlNodeType.Element)
+                    continue;
+
+                switch (reader.Name)
+                {
+                    case "id":
+                        Id = reader.ReadElementContentAsString();
+                        break;
+                    case "external_account_code":
+                        ExternalAccountCode = reader.ReadElementContentAsString();
+                        break;
+                    case "external_connection_type":
+                        ExternalConnectionType = reader.ReadElementContentAsString();
+                        break;
+                    case "created_at":
+                        CreatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+                    case "updated_at":
+                        UpdatedAt = reader.ReadElementContentAsDateTime();
+                        break;
+                }
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter writer)
+        {
+            writer.WriteStartElement("external_account");
+            writer.WriteElementString("external_account_code", ExternalAccountCode);
+            writer.WriteElementString("external_connection_type", ExternalConnectionType);
+            writer.WriteEndElement();
+        }
+    }
+}

--- a/Library/List/ExternalAccountList.cs
+++ b/Library/List/ExternalAccountList.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Xml;
+
+namespace Recurly
+{
+    public class ExternalAccountList : RecurlyList<ExternalAccount>
+    {
+        internal ExternalAccountList(string baseUrl) : base(Client.HttpRequestMethod.Get, baseUrl)
+        {
+        }
+        public override RecurlyList<ExternalAccount> Start
+        {
+            get { return HasStartPage() ? new ExternalAccountList(StartUrl) : RecurlyList.Empty<ExternalAccount>(); }
+        }
+
+        public override RecurlyList<ExternalAccount> Next
+        {
+            get { return HasNextPage() ? new ExternalAccountList(NextUrl) : RecurlyList.Empty<ExternalAccount>(); }
+        }
+
+        public override RecurlyList<ExternalAccount> Prev
+        {
+            get { return HasPrevPage() ? new ExternalAccountList(PrevUrl) : RecurlyList.Empty<ExternalAccount>(); }
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+        {
+            while (reader.Read())
+            {
+                if (reader.Name == "external_accounts" && reader.NodeType == XmlNodeType.EndElement)
+                    break;
+
+                if (reader.NodeType == XmlNodeType.Element && reader.Name == "external_account")
+                    Add(new ExternalAccount(reader));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for external accounts endpoints:

```
GET /sites/{site_id}/accounts/{account_id}/external_accounts
GET /sites/{site_id}/accounts/{account_id}/external_accounts/{external_account_uuid}
POST /sites/{site_id}/accounts/{account_id}/external_accounts
PUT /sites/{site_id}/accounts/{account_id}/external_accounts/{external_account_uuid}
DELETE /sites/{site_id}/accounts/{account_id}/external_accounts/{external_account_uuid}
```