### PR TITLE
Add UsedTaxService to Invoice response

### DIFF
--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -121,6 +121,7 @@ namespace Recurly
         public string TaxType { get; private set; }
         public string TaxRegion { get; private set; }
         public decimal? TaxRate { get; private set; }
+        public bool? UsedTaxService { get; private set; }
 
         public RecurlyList<TaxDetail> TaxDetails { get; private set; }
         public RecurlyList<Adjustment> Adjustments { get; private set; }
@@ -586,6 +587,10 @@ namespace Recurly
 
                     case "tax_region":
                         TaxRegion = reader.ReadElementContentAsString();
+                        break;
+
+                    case "used_tax_service":
+                        UsedTaxService = reader.ReadElementContentAsBoolean();
                         break;
 
                     case "net_terms":

--- a/Test/Fixtures/invoices/mark_failed-200.xml
+++ b/Test/Fixtures/invoices/mark_failed-200.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <total_in_cents type="integer">2995</total_in_cents>
   <currency>USD</currency>
   <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/190357944dad4d461272774dd184a17e" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/Test/Fixtures/invoices/mark_successful-200.xml
+++ b/Test/Fixtures/invoices/mark_successful-200.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <total_in_cents type="integer">2995</total_in_cents>
   <currency>USD</currency>
   <created_at type="datetime">2012-05-28T17:44:13Z</created_at>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/190357944dad4d461272774dd184a17e" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/Test/Fixtures/invoices/show-200.xml
+++ b/Test/Fixtures/invoices/show-200.xml
@@ -19,6 +19,7 @@ Content-Type: application/xml; charset=utf-8
   <net_terms type="integer">0</net_terms>
   <collection_method>automatic</collection_method>
   <dunning_campaign_id>1234abcd</dunning_campaign_id>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/012345678901234567890123456789ab" type="charge">
       <account href="https://api.recurly.com/v2/accounts/1"/>

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -18,6 +18,7 @@ namespace Recurly.Test
             var invoice = account.InvoicePendingCharges().ChargeInvoice;
             Assert.Equal("usst", invoice.TaxType);
             Assert.Equal(0.08625M, invoice.TaxRate.Value);
+            Assert.True(invoice.UsedTaxService.GetValueOrDefault());
 
             var fromService = Invoices.Get(invoice.InvoiceNumber);
 


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `<used_tax_service>`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.