### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Resources/TaxDetail.cs
+++ b/Recurly/Resources/TaxDetail.cs
@@ -15,11 +15,23 @@ namespace Recurly.Resources
     public class TaxDetail : Resource
     {
 
+        /// <value>Whether or not the line item is taxable. Only populated for a single LineItem fetch when Avalara for Communications is enabled.</value>
+        [JsonProperty("billable")]
+        public bool? Billable { get; set; }
+
+        /// <value>Provides the jurisdiction level for the Communications tax applied. Example values include city, state and federal. Present only when Avalara for Communications is enabled.</value>
+        [JsonProperty("level")]
+        public string Level { get; set; }
+
+        /// <value>Provides the name of the Communications tax applied. Present only when Avalara for Communications is enabled.</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
         /// <value>Provides the tax rate for the region.</value>
         [JsonProperty("rate")]
         public decimal? Rate { get; set; }
 
-        /// <value>Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code.</value>
+        /// <value>Provides the tax region applied on an invoice. For Canadian Sales Tax, this will be either the 2 letter province code or country code. Not present when Avalara for Communications is enabled.</value>
         [JsonProperty("region")]
         public string Region { get; set; }
 
@@ -27,7 +39,7 @@ namespace Recurly.Resources
         [JsonProperty("tax")]
         public decimal? Tax { get; set; }
 
-        /// <value>Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.</value>
+        /// <value>Provides the tax type for the region or type of Comminications tax when Avalara for Communications is enabled. For Canadian Sales Tax, this will be GST, HST, QST or PST.</value>
         [JsonProperty("type")]
         public string Type { get; set; }
 

--- a/Recurly/Resources/TaxInfo.cs
+++ b/Recurly/Resources/TaxInfo.cs
@@ -15,19 +15,19 @@ namespace Recurly.Resources
     public class TaxInfo : Resource
     {
 
-        /// <value>Rate</value>
+        /// <value>The combined tax rate. Not present when Avalara for Communications is enabled.</value>
         [JsonProperty("rate")]
         public decimal? Rate { get; set; }
 
-        /// <value>Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.</value>
+        /// <value>Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST. Not present when Avalara for Communications is enabled.</value>
         [JsonProperty("region")]
         public string Region { get; set; }
 
-        /// <value>Provides additional tax details for Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItem.</value>
+        /// <value>Provides additional tax details for Communications taxes when Avalara for Communications is enabled or Canadian Sales Tax when there is tax applied at both the country and province levels. This will only be populated for the Invoice response when fetching a single invoice and not for the InvoiceList or LineItemList. Only populated for a single LineItem fetch when Avalara for Communications is enabled.</value>
         [JsonProperty("tax_details")]
         public List<TaxDetail> TaxDetails { get; set; }
 
-        /// <value>Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.</value>
+        /// <value>Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries. Not present when Avalara for Communications is enabled.</value>
         [JsonProperty("type")]
         public string Type { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -22347,23 +22347,29 @@ components:
           description: Provides the tax type as "vat" for EU VAT, "usst" for U.S.
             Sales Tax, or the 2 letter country code for country level tax types like
             Canada, Australia, New Zealand, Israel, and all non-EU European countries.
+            Not present when Avalara for Communications is enabled.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For U.S. Sales
             Tax, this will be the 2 letter state code. For EU VAT this will be the
             2 letter country code. For all country level tax types, this will display
-            the regional tax, like VAT, GST, or PST.
+            the regional tax, like VAT, GST, or PST. Not present when Avalara for
+            Communications is enabled.
         rate:
           type: number
           format: float
           title: Rate
+          description: The combined tax rate. Not present when Avalara for Communications
+            is enabled.
         tax_details:
           type: array
-          description: Provides additional tax details for Canadian Sales Tax when
-            there is tax applied at both the country and province levels. This will
-            only be populated for the Invoice response when fetching a single invoice
-            and not for the InvoiceList or LineItem.
+          description: Provides additional tax details for Communications taxes when
+            Avalara for Communications is enabled or Canadian Sales Tax when there
+            is tax applied at both the country and province levels. This will only
+            be populated for the Invoice response when fetching a single invoice and
+            not for the InvoiceList or LineItemList. Only populated for a single LineItem
+            fetch when Avalara for Communications is enabled.
           items:
             "$ref": "#/components/schemas/TaxDetail"
     TaxDetail:
@@ -22373,13 +22379,15 @@ components:
         type:
           type: string
           title: Type
-          description: Provides the tax type for the region. For Canadian Sales Tax,
+          description: Provides the tax type for the region or type of Comminications
+            tax when Avalara for Communications is enabled. For Canadian Sales Tax,
             this will be GST, HST, QST or PST.
         region:
           type: string
           title: Region
           description: Provides the tax region applied on an invoice. For Canadian
             Sales Tax, this will be either the 2 letter province code or country code.
+            Not present when Avalara for Communications is enabled.
         rate:
           type: number
           format: float
@@ -22390,6 +22398,22 @@ components:
           format: float
           title: Tax
           description: The total tax applied for this tax type.
+        name:
+          type: string
+          title: Name
+          description: Provides the name of the Communications tax applied. Present
+            only when Avalara for Communications is enabled.
+        level:
+          type: string
+          title: Level
+          description: Provides the jurisdiction level for the Communications tax
+            applied. Example values include city, state and federal. Present only
+            when Avalara for Communications is enabled.
+        billable:
+          type: boolean
+          title: Billable
+          description: Whether or not the line item is taxable. Only populated for
+            a single LineItem fetch when Avalara for Communications is enabled.
     Transaction:
       type: object
       properties:


### PR DESCRIPTION
LineItem response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`
  * `billable`

Invoice response format has changed:
* Added additional elements to the `TaxDetail` field populated only when Avalara for Communications is enabled:
  * `name`
  * `level`