### PR TITLE
Generated Latest Changes for v2019-10-10 (gateway_attributes on PaymentMethod)

### DIFF
--- a/Recurly/Resources/BillingInfoCreate.cs
+++ b/Recurly/Resources/BillingInfoCreate.cs
@@ -55,6 +55,10 @@ namespace Recurly.Resources
         [JsonProperty("fraud_session_id")]
         public string FraudSessionId { get; set; }
 
+        /// <value>Additional attributes to send to the gateway.</value>
+        [JsonProperty("gateway_attributes")]
+        public GatewayAttributes GatewayAttributes { get; set; }
+
         /// <value>An identifier for a specific payment gateway. Must be used in conjunction with `gateway_token`.</value>
         [JsonProperty("gateway_code")]
         public string GatewayCode { get; set; }

--- a/Recurly/Resources/GatewayAttributes.cs
+++ b/Recurly/Resources/GatewayAttributes.cs
@@ -1,0 +1,23 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class GatewayAttributes : Request
+    {
+
+        /// <value>Used by Adyen gateways. The Shopper Reference value used when the external token was created. Must be used in conjunction with gateway_token and gateway_code.</value>
+        [JsonProperty("account_reference")]
+        public string AccountReference { get; set; }
+
+    }
+}

--- a/Recurly/Resources/PaymentMethod.cs
+++ b/Recurly/Resources/PaymentMethod.cs
@@ -43,6 +43,10 @@ namespace Recurly.Resources
         [JsonProperty("first_six")]
         public string FirstSix { get; set; }
 
+        /// <value>Gateway specific attributes associated with this PaymentMethod</value>
+        [JsonProperty("gateway_attributes")]
+        public GatewayAttributes GatewayAttributes { get; set; }
+
         /// <value>An identifier for a specific payment gateway.</value>
         [JsonProperty("gateway_code")]
         public string GatewayCode { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16645,6 +16645,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -21470,6 +21481,7 @@ components:
           - force_collect
           - refunded_externally
           - chargeback
+          - external_recovery
         currency:
           type: string
           title: Currency
@@ -22185,6 +22197,7 @@ components:
         object:
           type: string
           enum:
+          - bacs
           - credit_card
           - paypal
           - amazon
@@ -22255,6 +22268,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present
