### PR TITLE
Generated Latest Changes for v2021-02-25 (Multiple Business Entities)

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -4826,6 +4826,58 @@ namespace Recurly
 
 
         /// <summary>
+        /// Fetch a business entity <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity">get_business_entity api documentation</see>
+        /// </summary>
+        /// <param name="GetBusinessEntityParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// Business entity details
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public BusinessEntity GetBusinessEntity(string businessEntityId, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "business_entity_id", businessEntityId } };
+            var url = this.InterpolatePath("/business_entities/{business_entity_id}", urlParams);
+            return MakeRequest<BusinessEntity>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Fetch a business entity <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity">get_business_entity api documentation</see>
+        /// </summary>
+        /// <param name="GetBusinessEntityParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// Business entity details
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<BusinessEntity> GetBusinessEntityAsync(string businessEntityId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "business_entity_id", businessEntityId } };
+            var url = this.InterpolatePath("/business_entities/{business_entity_id}", urlParams);
+            return MakeRequestAsync<BusinessEntity>(Method.GET, url, null, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// List business entities <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_business_entities">list_business_entities api documentation</see>
+        /// </summary>
+        /// <param name="ListBusinessEntitiesParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// List of all business entities on your site.
+        /// </returns>
+        public Pager<BusinessEntity> ListBusinessEntities(RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/business_entities", urlParams);
+            return Pager<BusinessEntity>.Build(url, null, options, this);
+        }
+
+
+
+
+
+        /// <summary>
         /// List gift cards <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_gift_cards">list_gift_cards api documentation</see>
         /// </summary>
         /// <param name="ListGiftCardsParams">Optional Parameters for the request</param>
@@ -4976,6 +5028,25 @@ namespace Recurly
             var url = this.InterpolatePath("/gift_cards/{redemption_code}/redeem", urlParams);
             return MakeRequestAsync<GiftCard>(Method.POST, url, body, null, options, cancellationToken);
         }
+
+
+
+        /// <summary>
+        /// List a business entity's invoices <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_business_entity_invoices">list_business_entity_invoices api documentation</see>
+        /// </summary>
+        /// <param name="ListBusinessEntityInvoicesParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A list of the business entity's invoices.
+        /// </returns>
+        public Pager<Invoice> ListBusinessEntityInvoices(string businessEntityId, ListBusinessEntityInvoicesParams optionalParams = null, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "business_entity_id", businessEntityId } };
+            var queryParams = (optionalParams ?? new ListBusinessEntityInvoicesParams()).ToDictionary();
+            var url = this.InterpolatePath("/business_entities/{business_entity_id}/invoices", urlParams);
+            return Pager<Invoice>.Build(url, queryParams, options, this);
+        }
+
+
 
 
     }

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -3114,6 +3114,35 @@ namespace Recurly
 
 
         /// <summary>
+        /// Fetch a business entity <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity">get_business_entity api documentation</see>
+        /// </summary>
+        /// <param name="businessEntityId">Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-entity1`.</param>
+        /// <returns>
+        /// Business entity details
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        BusinessEntity GetBusinessEntity(string businessEntityId, RequestOptions options = null);
+
+        /// <summary>
+        /// Fetch a business entity <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_business_entity">get_business_entity api documentation</see>
+        /// </summary>
+        /// <param name="businessEntityId">Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-entity1`.</param>
+        /// <returns>
+        /// Business entity details
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<BusinessEntity> GetBusinessEntityAsync(string businessEntityId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// List business entities <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_business_entities">list_business_entities api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// List of all business entities on your site.
+        /// </returns>
+        Pager<BusinessEntity> ListBusinessEntities(RequestOptions options = null);
+
+
+        /// <summary>
         /// List gift cards <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_gift_cards">list_gift_cards api documentation</see>
         /// </summary>
         /// <returns>
@@ -3203,5 +3232,22 @@ namespace Recurly
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         Task<GiftCard> RedeemGiftCardAsync(string redemptionCode, GiftCardRedeem body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// List a business entity's invoices <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_business_entity_invoices">list_business_entity_invoices api documentation</see>
+        /// </summary>
+        /// <param name="businessEntityId">Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-entity1`.</param>
+        /// <param name="ids">Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </param>
+        /// <param name="limit">Limit number of records 1-200.</param>
+        /// <param name="order">Sort order.</param>
+        /// <param name="sort">Sort field. You *really* only want to sort by `updated_at` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </param>
+        /// <param name="beginTime">Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.  **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.  </param>
+        /// <param name="endTime">Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.  **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.  </param>
+        /// <param name="type">Filter by type when:  - `type=charge`, only charge invoices will be returned.  - `type=credit`, only credit invoices will be returned.  - `type=non-legacy`, only charge and credit invoices will be returned.  - `type=legacy`, only legacy invoices will be returned.  </param>
+        /// <returns>
+        /// A list of the business entity's invoices.
+        /// </returns>
+        Pager<Invoice> ListBusinessEntityInvoices(string businessEntityId, ListBusinessEntityInvoicesParams optionalParams = null, RequestOptions options = null);
+
     }
 }

--- a/Recurly/Resources/Account.cs
+++ b/Recurly/Resources/Account.cs
@@ -116,6 +116,10 @@ namespace Recurly.Resources
         [JsonProperty("object")]
         public string Object { get; set; }
 
+        /// <value>Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("override_business_entity_id")]
+        public string OverrideBusinessEntityId { get; set; }
+
         /// <value>The UUID of the parent account associated with this account.</value>
         [JsonProperty("parent_account_id")]
         public string ParentAccountId { get; set; }

--- a/Recurly/Resources/AccountCreate.cs
+++ b/Recurly/Resources/AccountCreate.cs
@@ -76,6 +76,10 @@ namespace Recurly.Resources
         [JsonProperty("last_name")]
         public string LastName { get; set; }
 
+        /// <value>Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("override_business_entity_id")]
+        public string OverrideBusinessEntityId { get; set; }
+
         /// <value>The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.</value>
         [JsonProperty("parent_account_code")]
         public string ParentAccountCode { get; set; }

--- a/Recurly/Resources/AccountPurchase.cs
+++ b/Recurly/Resources/AccountPurchase.cs
@@ -76,6 +76,10 @@ namespace Recurly.Resources
         [JsonProperty("last_name")]
         public string LastName { get; set; }
 
+        /// <value>Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("override_business_entity_id")]
+        public string OverrideBusinessEntityId { get; set; }
+
         /// <value>The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.</value>
         [JsonProperty("parent_account_code")]
         public string ParentAccountCode { get; set; }

--- a/Recurly/Resources/AccountUpdate.cs
+++ b/Recurly/Resources/AccountUpdate.cs
@@ -64,6 +64,10 @@ namespace Recurly.Resources
         [JsonProperty("last_name")]
         public string LastName { get; set; }
 
+        /// <value>Unique ID to identify the business entity assigned to the account. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("override_business_entity_id")]
+        public string OverrideBusinessEntityId { get; set; }
+
         /// <value>The account code of the parent account to be associated with this account. Passing an empty value removes any existing parent association from this account. If both `parent_account_code` and `parent_account_id` are passed, the non-blank value in `parent_account_id` will be used. Only one level of parent child relationship is allowed. You cannot assign a parent account that itself has a parent account.</value>
         [JsonProperty("parent_account_code")]
         public string ParentAccountCode { get; set; }

--- a/Recurly/Resources/BusinessEntity.cs
+++ b/Recurly/Resources/BusinessEntity.cs
@@ -1,0 +1,63 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class BusinessEntity : Resource
+    {
+
+        /// <value>The entity code of the business entity.</value>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <value>Created at</value>
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <value>Registration number for the customer used on the invoice.</value>
+        [JsonProperty("default_registration_number")]
+        public string DefaultRegistrationNumber { get; set; }
+
+        /// <value>VAT number for the customer used on the invoice.</value>
+        [JsonProperty("default_vat_number")]
+        public string DefaultVatNumber { get; set; }
+
+        /// <value>Business entity ID</value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <value>Address information for the business entity that will appear on the invoice.</value>
+        [JsonProperty("invoice_display_address")]
+        public Address InvoiceDisplayAddress { get; set; }
+
+        /// <value>This name describes your business entity and will appear on the invoice.</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <value>Object type</value>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <value>List of countries for which the business entity will be used.</value>
+        [JsonProperty("subscriber_location_countries")]
+        public List<string> SubscriberLocationCountries { get; set; }
+
+        /// <value>Address information for the business entity that will be used for calculating taxes.</value>
+        [JsonProperty("tax_address")]
+        public Address TaxAddress { get; set; }
+
+        /// <value>Last updated at</value>
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+    }
+}

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -31,6 +31,10 @@ namespace Recurly.Resources
         [JsonProperty("billing_info_id")]
         public string BillingInfoId { get; set; }
 
+        /// <value>Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("business_entity_id")]
+        public string BusinessEntityId { get; set; }
+
         /// <value>Date invoice was marked paid or failed.</value>
         [JsonProperty("closed_at")]
         public DateTime? ClosedAt { get; set; }

--- a/Recurly/Resources/ListBusinessEntityInvoicesParams.cs
+++ b/Recurly/Resources/ListBusinessEntityInvoicesParams.cs
@@ -1,0 +1,49 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListBusinessEntityInvoicesParams : OptionalParams
+    {
+
+        /// <value>Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </value>
+        [JsonProperty("ids")]
+        public IList<string> Ids { get; set; }
+
+        /// <value>Limit number of records 1-200.</value>
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        /// <value>Sort order.</value>
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        /// <value>Sort field. You *really* only want to sort by `updated_at` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </value>
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        /// <value>Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.  **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.  </value>
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        /// <value>Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.  **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.  </value>
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        /// <value>Filter by type when:  - `type=charge`, only charge invoices will be returned.  - `type=credit`, only credit invoices will be returned.  - `type=non-legacy`, only charge and credit invoices will be returned.  - `type=legacy`, only legacy invoices will be returned.  </value>
+        [JsonProperty("type")]
+        public Constants.FilterInvoiceType? Type { get; set; }
+
+    }
+}
+

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -228,6 +228,7 @@ x-tagGroups:
   - custom_field_definition
   - shipping_method
   - dunning_campaigns
+  - business_entities
 tags:
 - name: site
   x-displayName: Site
@@ -374,6 +375,10 @@ tags:
   description: An account from an external resource that is not managed by the Recurly
     platform and instead is managed by third-party platforms like Apple App Store
     and Google Play Store.
+- name: business_entities
+  x-displayName: Business Entities
+  description: Describes the business address that will be used for invoices and taxes
+    depending on settings and subscriber location.
 paths:
   "/sites":
     get:
@@ -15974,6 +15979,60 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}":
+    parameters:
+    - "$ref": "#/components/parameters/business_entity_id"
+    get:
+      tags:
+      - business_entities
+      operationId: get_business_entity
+      summary: Fetch a business entity
+      responses:
+        '200':
+          description: Business entity details
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntity"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/business_entities":
+    get:
+      tags:
+      - business_entities
+      operationId: list_business_entities
+      summary: List business entities
+      responses:
+        '200':
+          description: List of all business entities on your site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BusinessEntityList"
+        '404':
+          description: Incorrect site.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/gift_cards":
     get:
       tags:
@@ -16143,6 +16202,49 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/business_entities/{business_entity_id}/invoices":
+    get:
+      tags:
+      - invoice
+      operationId: list_business_entity_invoices
+      summary: List a business entity's invoices
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/business_entity_id"
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/filter_begin_time"
+      - "$ref": "#/components/parameters/filter_end_time"
+      - "$ref": "#/components/parameters/filter_invoice_type"
+      responses:
+        '200':
+          description: A list of the business entity's invoices.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceList"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site or business entity ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
 servers:
 - url: https://v3.recurly.com
 - url: https://v3.eu.recurly.com
@@ -16177,6 +16279,14 @@ components:
       in: path
       description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
         feature.
+      required: true
+      schema:
+        type: string
+    business_entity_id:
+      name: business_entity_id
+      in: path
+      description: Business Entity ID. For ID no prefix is used e.g. `e28zov4fw0v2`.
+        For code use prefix `code-`, e.g. `code-entity1`.
       required: true
       schema:
         type: string
@@ -17101,6 +17211,11 @@ components:
             merchant has an integration for the Vertex tax provider, this optional
             value will be sent in any tax calculation requests for the account.
           maxLength: 30
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         parent_account_code:
           type: string
           maxLength: 50
@@ -17169,6 +17284,11 @@ components:
             The customer will also use this email address to log into your hosted
             account management pages. This value does not need to be unique.
           maxLength: 255
+        override_business_entity_id:
+          type: string
+          title: Override Business Entity ID
+          description: Unique ID to identify the business entity assigned to the account.
+            Available when the `Multiple Business Entities` feature is enabled.
         preferred_locale:
           description: Used to determine the language and locale of emails sent on
             behalf of the merchant to the customer.
@@ -19358,6 +19478,11 @@ components:
           type: boolean
           title: Final Dunning Event
           description: Last communication attempt.
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
     InvoiceCreate:
       type: object
       properties:
@@ -23939,6 +24064,84 @@ components:
           type: string
           description: Username of the associated payment method. Currently only associated
             with Venmo.
+    BusinessEntityList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/BusinessEntity"
+    BusinessEntity:
+      type: object
+      description: Business entity details
+      properties:
+        id:
+          title: Business entity ID
+          type: string
+          maxLength: 13
+          readOnly: true
+        object:
+          title: Object type
+          type: string
+          readOnly: true
+        code:
+          title: Business entity code
+          type: string
+          maxLength: 50
+          description: The entity code of the business entity.
+        name:
+          type: string
+          title: Name
+          description: This name describes your business entity and will appear on
+            the invoice.
+          maxLength: 255
+        invoice_display_address:
+          title: Invoice display address
+          description: Address information for the business entity that will appear
+            on the invoice.
+          "$ref": "#/components/schemas/Address"
+        tax_address:
+          title: Tax address
+          description: Address information for the business entity that will be used
+            for calculating taxes.
+          "$ref": "#/components/schemas/Address"
+        default_vat_number:
+          type: string
+          title: Default VAT number
+          description: VAT number for the customer used on the invoice.
+          maxLength: 20
+        default_registration_number:
+          type: string
+          title: Default registration number
+          description: Registration number for the customer used on the invoice.
+          maxLength: 30
+        subscriber_location_countries:
+          type: array
+          title: Subscriber location countries
+          description: List of countries for which the business entity will be used.
+          items:
+            type: string
+            title: Country code
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
     GiftCardList:
       type: object
       properties:


### PR DESCRIPTION
Adds support for Multiple Business Entities:
  - Adds operations for Multiple Business Entities:
    - `GetBusinessEntity`
    - `GetBusinessEntityAsync`
    - `ListBusinessEntities`
    - `ListBusinessEntityInvoices`
  - Adds `OverrideBusinessEntityId` to the `Account` resource and as params for the following requests:
    - `AccountCreate`
    - `AccountUpdate`
    - `AccountPurchase`
  - Adds `BusinessEntityId` to the `Invoice` resource