### PR TITLE
[V2] Add starting_on and ending_on to subscription ramps

### DIFF
--- a/Library/SubscriptionRampInterval.cs
+++ b/Library/SubscriptionRampInterval.cs
@@ -13,6 +13,12 @@ namespace Recurly
         /// <summary>Represents the price for the ramp interval.</summary>
         public int UnitAmountInCents { get; set; }
 
+        /// <summary>Represents the date on which the ramp interval starts.</summary>
+        public DateTime StartingOn { get; set; }
+
+        /// <summary>Represents the date on which the ramp interval ends.</summary>
+        public DateTime? EndingOn { get; set; }
+
         /// <summary>A readonly element that represents how many billing cycles are left in a ramp interval.</summary>
         public int? RemainingBillingCycles { get { return _remainingBillingCycles; } }
 
@@ -21,10 +27,12 @@ namespace Recurly
         #region Constructors
         public SubscriptionRampInterval() { }
 
-        public SubscriptionRampInterval(int startingBillingCycle, int unitAmountInCents)
+        public SubscriptionRampInterval(int startingBillingCycle, int unitAmountInCents, DateTime startingOn, DateTime endingOn)
         {
             StartingBillingCycle = startingBillingCycle;
             UnitAmountInCents = unitAmountInCents;
+            StartingOn = startingOn;
+            EndingOn = endingOn;
         }
 
         public SubscriptionRampInterval(XmlTextReader reader)
@@ -52,6 +60,19 @@ namespace Recurly
 
                     case "unit_amount_in_cents":
                         UnitAmountInCents = reader.ReadElementContentAsInt();
+                        break;
+
+                    case "starting_on":
+                        StartingOn = reader.ReadElementContentAsDateTime();
+                        break;
+
+                    case "ending_on":
+                        DateTime endingOn;
+
+                        if (!reader.IsEmptyElement && DateTime.TryParse(reader.ReadElementContentAsString(), out endingOn))
+                        {
+                            EndingOn = endingOn;
+                        }
                         break;
 
                     case "remaining_billing_cycles":

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -856,6 +856,7 @@ namespace Recurly.Test
             var subscription = new Subscription(account, plan, "USD");
             subscription.RampIntervals = GetMockSubscriptionRampIntervals(5);
             subscription.RampIntervals.Count.Should().Be(5);
+            subscription.StartsAt = 1.January(2099);
             subscription.Create();
 
             var fromService = Subscriptions.Get(subscription.Uuid);
@@ -863,14 +864,24 @@ namespace Recurly.Test
 
             fromService.RampIntervals[0].StartingBillingCycle.Should().Be(1);
             fromService.RampIntervals[0].UnitAmountInCents.Should().Be(500);
+            fromService.RampIntervals[0].StartingOn.Should().Be(1.January(2099));
+            fromService.RampIntervals[0].EndingOn.Should().Be(1.March(2099));
             fromService.RampIntervals[1].StartingBillingCycle.Should().Be(3);
             fromService.RampIntervals[1].UnitAmountInCents.Should().Be(1000);
+            fromService.RampIntervals[1].StartingOn.Should().Be(1.March(2099));
+            fromService.RampIntervals[1].EndingOn.Should().Be(1.April(2099));
             fromService.RampIntervals[2].StartingBillingCycle.Should().Be(4);
             fromService.RampIntervals[2].UnitAmountInCents.Should().Be(1500);
+            fromService.RampIntervals[2].StartingOn.Should().Be(1.April(2099));
+            fromService.RampIntervals[2].EndingOn.Should().Be(1.May(2099));
             fromService.RampIntervals[3].StartingBillingCycle.Should().Be(5);
             fromService.RampIntervals[3].UnitAmountInCents.Should().Be(2000);
+            fromService.RampIntervals[3].StartingOn.Should().Be(1.May(2099));
+            fromService.RampIntervals[3].EndingOn.Should().Be(1.June(2099));
             fromService.RampIntervals[4].StartingBillingCycle.Should().Be(6);
             fromService.RampIntervals[4].UnitAmountInCents.Should().Be(2500);
+            fromService.RampIntervals[4].StartingOn.Should().Be(1.June(2099));
+            fromService.RampIntervals[4].EndingOn.Should().BeNull();
 
             subscription.Cancel();
             account.Close();


### PR DESCRIPTION
Adds `starting_on` and `ending_on` to `SubscriptionRampInterval`