### PR TITLE
Generated Latest Changes for v2021-02-25 (Ramp Dates, Net Terms, Invoice Business Entity)

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -722,6 +722,18 @@ namespace Recurly
 
         };
 
+        public enum NetTermsType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "net")]
+            Net,
+
+            [EnumMember(Value = "eom")]
+            Eom,
+
+        };
+
         public enum InvoiceType
         {
             Undefined = 0,

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -92,9 +92,33 @@ namespace Recurly.Resources
         [JsonProperty("line_items")]
         public List<LineItem> LineItems { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.</value>
         [JsonProperty("number")]

--- a/Recurly/Resources/InvoiceCreate.cs
+++ b/Recurly/Resources/InvoiceCreate.cs
@@ -32,9 +32,33 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>For manual invoicing, this identifies the PO number associated with the subscription.</value>
         [JsonProperty("po_number")]

--- a/Recurly/Resources/InvoiceMini.cs
+++ b/Recurly/Resources/InvoiceMini.cs
@@ -15,6 +15,10 @@ namespace Recurly.Resources
     public class InvoiceMini : Resource
     {
 
+        /// <value>Unique ID to identify the business entity assigned to the invoice. Available when the `Multiple Business Entities` feature is enabled.</value>
+        [JsonProperty("business_entity_id")]
+        public string BusinessEntityId { get; set; }
+
         /// <value>Invoice ID</value>
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/Recurly/Resources/PurchaseCreate.cs
+++ b/Recurly/Resources/PurchaseCreate.cs
@@ -56,9 +56,33 @@ namespace Recurly.Resources
         [JsonProperty("line_items")]
         public List<LineItemCreate> LineItems { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>For manual invoicing, this identifies the PO number associated with the subscription.</value>
         [JsonProperty("po_number")]

--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -112,9 +112,33 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>Object type</value>
         [JsonProperty("object")]

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -54,9 +54,26 @@ namespace Recurly.Resources
         [JsonProperty("custom_fields")]
         public List<CustomField> CustomFields { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer normally paired with `Net Terms Type` and representing the number of days past
+        /// the current date (for `net` Net Terms Type) or days after the last day of the current
+        /// month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+        /// change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+        /// 
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>If you want to change to a new plan, you can provide the plan's code or id. If both are provided the `plan_id` will be used.</value>
         [JsonProperty("plan_code")]

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -60,9 +60,33 @@ namespace Recurly.Resources
         [JsonProperty("gift_card_redemption_code")]
         public string GiftCardRedemptionCode { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.</value>
         [JsonProperty("next_bill_date")]

--- a/Recurly/Resources/SubscriptionRampIntervalResponse.cs
+++ b/Recurly/Resources/SubscriptionRampIntervalResponse.cs
@@ -15,6 +15,10 @@ namespace Recurly.Resources
     public class SubscriptionRampIntervalResponse : Resource
     {
 
+        /// <value>Date the ramp interval ends</value>
+        [JsonProperty("ending_on")]
+        public DateTime? EndingOn { get; set; }
+
         /// <value>Represents how many billing cycles are left in a ramp interval.</value>
         [JsonProperty("remaining_billing_cycles")]
         public int? RemainingBillingCycles { get; set; }
@@ -22,6 +26,10 @@ namespace Recurly.Resources
         /// <value>Represents the billing cycle where a ramp interval starts.</value>
         [JsonProperty("starting_billing_cycle")]
         public int? StartingBillingCycle { get; set; }
+
+        /// <value>Date the ramp interval starts</value>
+        [JsonProperty("starting_on")]
+        public DateTime? StartingOn { get; set; }
 
         /// <value>Represents the price for the ramp interval.</value>
         [JsonProperty("unit_amount")]

--- a/Recurly/Resources/SubscriptionUpdate.cs
+++ b/Recurly/Resources/SubscriptionUpdate.cs
@@ -40,9 +40,33 @@ namespace Recurly.Resources
         [JsonProperty("gateway_code")]
         public string GatewayCode { get; set; }
 
-        /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
+        /// <value>
+        /// Integer paired with `Net Terms Type` and representing the number
+        /// of days past the current date (for `net` Net Terms Type) or days after
+        /// the last day of the current month (for `eom` Net Terms Type) that the
+        /// invoice will become past due. For any value, an additional 24 hours is
+        /// added to ensure the customer has the entire last day to make payment before
+        /// becoming past due.  For example:
+        /// 
+        /// If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+        /// If an invoice is due `net 30`, it will become past due at 31 days exactly.
+        /// If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+        /// 
+        /// When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+        /// For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }
+
+        /// <value>
+        /// Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        /// When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        /// When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+        /// 
+        /// This field is only available when the EOM Net Terms feature is enabled.
+        /// </value>
+        [JsonProperty("net_terms_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.NetTermsType? NetTermsType { get; set; }
 
         /// <value>If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. For a subscription in a trial period, this will change when the trial expires. This parameter is useful for postponement of a subscription to change its billing date without proration.</value>
         [JsonProperty("next_bill_date")]

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15202,7 +15202,7 @@ paths:
 
         Use for **Adyen HPP** and **Online Banking** transaction requests.
         This runs the validations but not the transactions.
-        The API request allows the inclusion of one of the following fields: **external_hpp_type** with `'adyen'` and **online_banking_payment_type** with `'ideal'` or `'sofort'` in the **billing_info** object.
+        The API request allows the inclusion of the following field: **external_hpp_type** with `'adyen'` in the **billing_info** object.
 
         For additional information regarding shipping fees, please see https://docs.recurly.com/docs/shipping
 
@@ -18291,6 +18291,7 @@ components:
           "$ref": "#/components/schemas/ExternalHppTypeEnum"
         online_banking_payment_type:
           "$ref": "#/components/schemas/OnlineBankingPaymentTypeEnum"
+          deprecated: true
         card_type:
           "$ref": "#/components/schemas/CardTypeEnum"
     BillingInfoVerify:
@@ -19332,13 +19333,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         address:
           "$ref": "#/components/schemas/InvoiceAddress"
         shipping_address:
@@ -19516,13 +19528,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
-          default: 0
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
+          default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         po_number:
           type: string
           title: Purchase order number
@@ -19629,6 +19652,11 @@ components:
         number:
           type: string
           title: Invoice number
+        business_entity_id:
+          type: string
+          title: Business Entity ID
+          description: Unique ID to identify the business entity assigned to the invoice.
+            Available when the `Multiple Business Entities` feature is enabled.
         type:
           title: Invoice type
           "$ref": "#/components/schemas/InvoiceTypeEnum"
@@ -21600,13 +21628,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -22162,13 +22201,17 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer normally paired with `Net Terms Type` and representing the number of days past
+            the current date (for `net` Net Terms Type) or days after the last day of the current
+            month (for `eom` Net Terms Type) that the invoice will become past due. During a subscription
+            change, it's not necessary to provide both the `Net Terms Type` and `Net Terms` parameters.
+
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22373,13 +22416,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         transaction_type:
           description: An optional type designation for the payment gateway transaction
             created by this request. Supports 'moto' value, which is the acronym for
@@ -22549,13 +22603,24 @@ components:
         net_terms:
           type: integer
           title: Terms that the subscription is due on
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         gateway_code:
           type: string
           title: Gateway Code
@@ -22694,6 +22759,14 @@ components:
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
+        starting_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval starts
+        ending_on:
+          type: string
+          format: date-time
+          title: Date the ramp interval ends
         unit_amount:
           type: number
           format: float
@@ -23253,13 +23326,24 @@ components:
         net_terms:
           type: integer
           title: Net terms
-          description: Integer representing the number of days after an invoice's
-            creation that the invoice will become past due. If an invoice's net terms
-            are set to '0', it is due 'On Receipt' and will become past due 24 hours
-            after it’s created. If an invoice is due net 30, it will become past due
-            at 31 days exactly.
+          description: |-
+            Integer paired with `Net Terms Type` and representing the number
+            of days past the current date (for `net` Net Terms Type) or days after
+            the last day of the current month (for `eom` Net Terms Type) that the
+            invoice will become past due. For any value, an additional 24 hours is
+            added to ensure the customer has the entire last day to make payment before
+            becoming past due.  For example:
+
+            If an invoice is due `net 0`, it is due 'On Receipt' and will become past due 24 hours after it's created.
+            If an invoice is due `net 30`, it will become past due at 31 days exactly.
+            If an invoice is due `eom 30`, it will become past due 31 days from the last day of the current month.
+
+            When `eom` Net Terms Type is passed, the value for `Net Terms` is restricted to `0, 15, 30, 45, 60, or 90`.
+            For more information please visit our docs page (https://docs.recurly.com/docs/manual-payments#section-collection-terms)
           minimum: 0
           default: 0
+        net_terms_type:
+          "$ref": "#/components/schemas/NetTermsTypeEnum"
         terms_and_conditions:
           type: string
           title: Terms and conditions
@@ -24798,6 +24882,19 @@ components:
       - at_range_start
       - evenly
       - never
+    NetTermsTypeEnum:
+      type: string
+      title: Net Terms Type
+      description: |
+        Optionally supplied string that may be either `net` or `eom` (end-of-month).
+        When `net`, an invoice becomes past due the specified number of `Net Terms` days from the current date.
+        When `eom` an invoice becomes past due the specified number of `Net Terms` days from the last day of the current month.
+
+        This field is only available when the EOM Net Terms feature is enabled.
+      enum:
+      - net
+      - eom
+      default: net
     InvoiceTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adds `NetTermsType` to the `Subscription`, `SubscriptionChange`, `Purchase`, and `Invoice` resources
- Adds `BusinessEntityId` to the `InvoiceMini` resource
- Adds `StartingOn` and `EndingOn` to `SubscriptionRampIntervalResponse` resources