### PR TITLE
feat add event handlers to make request async

### DIFF
--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -183,6 +183,23 @@ namespace Recurly.Tests
             Assert.Equal("benjamin", resource.MyString);
         }
 
+        [Fact]
+        public async void WillTriggerHookIfAvailableAsync()
+        {
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
+            var mockHandler = new Mock<IEventHandler>();
+            mockHandler
+              .Setup(x => x.OnRequest(It.IsAny<Recurly.Http.Request>()));
+            mockHandler
+              .Setup(x => x.OnResponse(It.IsAny<Recurly.Http.Response>()));
+            client.AddEventHandler(mockHandler.Object);
+            MyResource resource = await client.GetResourceAsync("benjamin", "param1", new DateTime());
+
+            Assert.Equal("benjamin", resource.MyString);
+            mockHandler.Verify(v => v.OnRequest(It.IsAny<Recurly.Http.Request>()), Times.Once());
+            mockHandler.Verify(v => v.OnResponse(It.IsAny<Recurly.Http.Response>()), Times.Once());
+        }
+
         private Mock<IRestResponse<MyResource>> SuccessResponse(System.Net.HttpStatusCode status)
         {
             var data = new MyResource()

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -68,12 +68,24 @@ namespace Recurly
                 Body = body
             };
             var restRequest = BuildRequest(method, url, body, queryParams, options);
+
+            foreach (var handler in this.EventHandlers)
+            {
+                handler.OnRequest(httpRequest);
+            }
+
             var task = RestClient.ExecuteAsync<T>(restRequest, cancellationToken);
             return await task.ContinueWith(t =>
             {
                 var restResponse = t.Result;
                 this.HandleResponse(restResponse);
                 var httpResponse = Http.Response.Build(restResponse, httpRequest);
+
+                foreach (var handler in this.EventHandlers)
+                {
+                    handler.OnResponse(httpResponse);
+                }
+
                 if (restResponse.Data is Resource)
                     restResponse.Data.SetResponse(httpResponse);
                 return restResponse.Data;


### PR DESCRIPTION
### Issue we are facing
The issue we are facing is we have a multi tenant application and we need to add tracing/monitoring for Recurly http calls per tenant, so we can monitor the amount off calls being made by each tenant which include paged requests that happen in the background.
BaseClient MakeRequest<T> has Event handlers which can be used to hook into http request and responses.
MakeRequestAsync<T> that we use in our service is currently missing the Event Handling processing,

### Proposed solution
Add the event handling logic  to the MakeRequestAsync<T> method.

There may be a better way to solve this issue, so we are open to your suggestions on the best implementation to resolve this issue.