### PR TITLE
[V2] Add RevRec settings to business entities

### DIFF
--- a/Library/BusinessEntity.cs
+++ b/Library/BusinessEntity.cs
@@ -17,6 +17,8 @@ namespace Recurly
         public TaxAddress TaxAddress { get; set; }
         public string DefaultVatNumber { get; set; }
         public string DefaultRegistrationNumber { get; set; }
+        public string DefaultLiabilityGlAccountId { get; private set; }
+        public string DefaultRevenueGlAccountId { get; private set; }
         public DateTime? CreatedAt { get; private set; }
         public DateTime? UpdatedAt { get; private set; }
 
@@ -87,6 +89,12 @@ namespace Recurly
                         break;
                     case "default_registration_number":
                         DefaultRegistrationNumber = reader.ReadElementContentAsString();
+                        break;
+                    case "default_liability_gl_account_id":
+                        DefaultLiabilityGlAccountId = reader.ReadElementContentAsString();
+                        break;
+                    case "default_revenue_gl_account_id":
+                        DefaultRevenueGlAccountId = reader.ReadElementContentAsString();
                         break;
                     case "created_at":
                         CreatedAt = reader.ReadElementContentAsDateTime();

--- a/Test/BusinessEntityTest.cs
+++ b/Test/BusinessEntityTest.cs
@@ -1,7 +1,8 @@
-using System;
-using System.Collections.Generic;
+using System.Xml;
 using FluentAssertions;
-using Xunit;
+
+using Recurly.Test.Fixtures;
+
 
 namespace Recurly.Test
 {
@@ -17,6 +18,19 @@ namespace Recurly.Test
             businessEntity.InvoiceDisplayAddress.Country.Should().Be("US");
             businessEntity.TaxAddress.Country.Should().Be("US");
             businessEntity.GetInvoices().Should().BeOfType<InvoiceList>();
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var businessEntity = new BusinessEntity();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.BusinessEntities, "show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            businessEntity.ReadXml(reader);
+
+            businessEntity.DefaultLiabilityGlAccountId.Should().Be("twrbsq39zvo5");
+            businessEntity.DefaultRevenueGlAccountId.Should().Be("bwrks63lznoi");
         }
     }
 }

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -26,6 +26,7 @@ namespace Recurly.Test.Fixtures
                 throw new InvalidEnumArgumentException("type", (int)type, typeof(FixtureType));
 
             var fixturePath = string.Format("Fixtures/{0}/{1}.xml", GetFixtureTypeDescription(type), name);
+            Console.WriteLine("Loading fixture for test: {0}", fixturePath);
 
             if (!File.Exists(fixturePath))
                 throw new FileNotFoundException("Could not locate the fixture response file!", fixturePath);
@@ -76,6 +77,8 @@ namespace Recurly.Test.Fixtures
     public enum FixtureType
     {
         Accounts,
+        [Description("business_entities")]
+        BusinessEntities,
         [Description("external_payment_phases")]
         ExternalPaymentPhases,
         [Description("external_invoices")]

--- a/Test/Fixtures/business_entities/show-200.xml
+++ b/Test/Fixtures/business_entities/show-200.xml
@@ -1,0 +1,36 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<business_entity href="https://api.recurly.com/v2/business_entities/ske68up0zvae">
+  <invoices href="https://api.recurly.com/v2/business_entities/ske68up0zvae/invoices"/>
+  <id>ske68up0zvae</id>
+  <code>default</code>
+  <name>My Company, LLC</name>
+  <invoice_display_address>
+    <address1>1 Main</address1>
+    <address2></address2>
+    <city>San Jose</city>
+    <state>CA</state>
+    <zip>95120</zip>
+    <country>US</country>
+    <phone>317-555-6666</phone>
+  </invoice_display_address>
+  <tax_address>
+    <address1>1 Main</address1>
+    <address2></address2>
+    <city>San Jose</city>
+    <state>CA</state>
+    <zip>95120</zip>
+    <country>US</country>
+    <phone>317-555-6666</phone>
+  </tax_address>
+  <subscriber_location_countries type="array">
+  </subscriber_location_countries>
+  <default_vat_number></default_vat_number>
+  <default_registration_number></default_registration_number>
+  <created_at type="datetime">2023-03-16T18:29:52Z</created_at>
+  <updated_at type="datetime">2024-01-31T18:59:45Z</updated_at>
+  <default_liability_gl_account_id>twrbsq39zvo5</default_liability_gl_account_id>
+  <default_revenue_gl_account_id>bwrks63lznoi</default_revenue_gl_account_id>
+</business_entity>

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -134,6 +134,9 @@
     <Content Include="Fixtures\billinginfo\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\business_entities\show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\client\gateway-unavailable-502.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Adds the `DefaultLiabilityGlAccountId` and `DefaultRevenueGlAccountId` properties to the `BusinessEntity` entity for the V2 client.


### Examples

These IDs cannot be added to business entities from the client/API, only the UI.
```csharp
var businessEntity = BusinessEntities.Get(id);

Console.WriteLine("Liability ID: {0}", businessEntity.DefaultLiabilityGlAccountId);
Console.WriteLine("Revenue ID: {0}", businessEntity.DefaultRevenueGlAccountId);
```