### PR TITLE
[V2] Add RevRec settings to the Plan entity

### DIFF
--- a/Library/Extensions/XmlWriterExtensions.cs
+++ b/Library/Extensions/XmlWriterExtensions.cs
@@ -20,6 +20,31 @@ namespace Recurly
         }
 
         /// <summary>
+        /// Convenience implementation that allows specifically writing "nil nodes" for the
+        /// purpose of unsetting associations from models. Using a simply JSON `null` is
+        /// simple enough in V3, but in V2, we need to write a `nil` attribute.
+        ///
+        /// An empty string for <paramref name="value"/> will result in the node not being
+        /// created. If it is `null`, the node will be created with the attribute.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:System.Xml.XmlWriter"/> that will be written to.</param>
+        /// <param name="localName"></param>
+        /// <param name="value"></param>
+        public static void WriteValidStringOrNil(this XmlWriter writer, string localName, string value)
+        {
+            if (value == null)
+            {
+                writer.WriteStartElement(localName);
+                writer.WriteAttributeString("nil", "nil");
+                writer.WriteEndElement();
+            }
+            else
+            {
+                writer.WriteStringIfValid(localName, value);
+            }
+        }
+
+        /// <summary>
         /// If the given collection <paramref name="items"/> has any elements, writes the contents to the <see cref="T:System.Xml.XmlTextWriter"/> <paramref name="writer"/>
         /// using the provided <paramref name="localName"/> and <paramref name="stringValue"/> <see cref="T:System.Func{T,TResult}"/>s.
         /// </summary>
@@ -42,7 +67,7 @@ namespace Recurly
         }
 
         /// <summary>
-        /// If the given collection has any elements, writes the contents of the <paramref name="items"/> to the <see cref="T:System.Xml.XmlTextWriter"/> 
+        /// If the given collection has any elements, writes the contents of the <paramref name="items"/> to the <see cref="T:System.Xml.XmlTextWriter"/>
         /// using each element's <see cref="Recurly.RecurlyEntity.WriteXml"/> implementation.
         /// </summary>
         /// <typeparam name="T">The type of each element of <paramref name="items"/>, derived from <see cref="Recurly.RecurlyEntity"/>.</typeparam>
@@ -57,7 +82,7 @@ namespace Recurly
         }
 
         /// <summary>
-        /// If the given collection has any elements, writes the contents of the <paramref name="items"/> to the <see cref="T:System.Xml.XmlTextWriter"/> 
+        /// If the given collection has any elements, writes the contents of the <paramref name="items"/> to the <see cref="T:System.Xml.XmlTextWriter"/>
         /// using each element's <see cref="Recurly.RecurlyEntity.WriteXml"/> implementation. If the collection needs to write an empty element for an empty collection, it will do so.
         /// </summary>
         /// <typeparam name="T">The type of each element of <paramref name="items"/>, derived from <see cref="Recurly.RecurlyEntity"/>.</typeparam>

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 namespace Recurly
 {
-    public class Plan : RecurlyEntity
+    public class Plan : RevRecEntity
     {
         public enum IntervalUnit
         {
@@ -40,6 +40,10 @@ namespace Recurly
 
         public string AccountingCode { get; set; }
         public string SetupFeeAccountingCode { get; set; }
+
+        public string SetupFeeLiabilityGlAccountId = "";
+        public string SetupFeeRevenueGlAccountId = "";
+        public string SetupFeePerformanceObligationId { get; set; }
 
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
@@ -288,6 +292,10 @@ namespace Recurly
 
                 bool b;
 
+                // reading standard revrec nodes. setup fee revrec nodes are
+                // implemented manually, in this class.
+                ReadRevRecNode(reader);
+
                 switch (reader.Name)
                 {
                     case "plan_code":
@@ -362,6 +370,18 @@ namespace Recurly
 
                     case "setup_fee_accounting_code":
                         SetupFeeAccountingCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "setup_fee_liability_gl_account_id":
+                        SetupFeeLiabilityGlAccountId = reader.ReadElementContentAsString();
+                        break;
+
+                    case "setup_fee_revenue_gl_account_id":
+                        SetupFeeRevenueGlAccountId = reader.ReadElementContentAsString();
+                        break;
+
+                    case "setup_fee_performance_obligation_id":
+                        SetupFeePerformanceObligationId = reader.ReadElementContentAsString();
                         break;
 
                     case "dunning_campaign_id":
@@ -454,6 +474,12 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("description", Description);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
             xmlWriter.WriteStringIfValid("setup_fee_accounting_code", SetupFeeAccountingCode);
+
+            // product revrec features (and setup fee revrec features)
+            WriteRevRecNodes(xmlWriter);
+            xmlWriter.WriteValidStringOrNil("setup_fee_liability_gl_account_id", SetupFeeLiabilityGlAccountId);
+            xmlWriter.WriteValidStringOrNil("setup_fee_revenue_gl_account_id", SetupFeeRevenueGlAccountId);
+            xmlWriter.WriteStringIfValid("setup_fee_performance_obligation_id", SetupFeePerformanceObligationId);
 
             if (DunningCampaignId != null)
                 xmlWriter.WriteElementString("dunning_campaign_id", DunningCampaignId);

--- a/Library/RevRecEntity.cs
+++ b/Library/RevRecEntity.cs
@@ -1,0 +1,36 @@
+﻿using System.Xml;
+
+namespace Recurly
+{
+    public abstract class RevRecEntity : RecurlyEntity
+    {
+        public string LiabilityGlAccountId = "";
+        public string RevenueGlAccountId = "";
+        public string PerformanceObligationId { get; set; }
+
+        internal protected void ReadRevRecNode(XmlTextReader reader)
+        {
+            switch (reader.Name)
+            {
+                case "liability_gl_account_id":
+                    LiabilityGlAccountId = reader.ReadElementContentAsString();
+                    break;
+
+                case "revenue_gl_account_id":
+                    RevenueGlAccountId = reader.ReadElementContentAsString();
+                    break;
+
+                case "performance_obligation_id":
+                    PerformanceObligationId = reader.ReadElementContentAsString();
+                    break;
+            };
+        }
+
+        internal protected void WriteRevRecNodes(XmlTextWriter writer)
+        {
+            writer.WriteValidStringOrNil("liability_gl_account_id", LiabilityGlAccountId);
+            writer.WriteValidStringOrNil("revenue_gl_account_id", RevenueGlAccountId);
+            writer.WriteStringIfValid("performance_obligation_id", PerformanceObligationId);
+        }
+    }
+}

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -87,5 +87,7 @@ namespace Recurly.Test.Fixtures
         GeneralLedgerAccounts,
         [Description("performance_obligations")]
         PerformanceObligations,
+        [Description("plans")]
+        Plans,
     }
 }

--- a/Test/Fixtures/plans/show-200.xml
+++ b/Test/Fixtures/plans/show-200.xml
@@ -22,6 +22,12 @@ Content-Type: application/xml; charset=utf-8
   <total_billing_cycles type="integer">6</total_billing_cycles>
   <accounting_code nil="nil"></accounting_code>
   <dunning_campaign_id>1234abcd</dunning_campaign_id>
+  <liability_gl_account_id>twrbsq39zvo5</liability_gl_account_id>
+  <revenue_gl_account_id>bwrks63lznoi</revenue_gl_account_id>
+  <performance_obligation_id>rkslzn</performance_obligation_id>
+  <setup_fee_liability_gl_account_id>twrisqjjzvo5</setup_fee_liability_gl_account_id>
+  <setup_fee_revenue_gl_account_id>dlrk123lzabc</setup_fee_revenue_gl_account_id>
+  <setup_fee_performance_obligation_id>bks6noi</setup_fee_performance_obligation_id>
   <created_at type="datetime">2011-04-19T07:00:00Z</created_at>
   <unit_amount_in_cents>
     <USD type="integer">1000</USD>

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -1,8 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using FluentAssertions;
+using Recurly.Test.Fixtures;
 using Xunit;
+
+
 
 namespace Recurly.Test
 {
@@ -284,5 +287,21 @@ namespace Recurly.Test
             get.ShouldThrow<NotFoundException>();
         }
 
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var plan = new Plan();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.Plans, "show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            plan.ReadXml(reader);
+
+            plan.LiabilityGlAccountId.Should().Be("twrbsq39zvo5");
+            plan.RevenueGlAccountId.Should().Be("bwrks63lznoi");
+            plan.PerformanceObligationId.Should().Be("rkslzn");
+            plan.SetupFeeLiabilityGlAccountId.Should().Be("twrisqjjzvo5");
+            plan.SetupFeeRevenueGlAccountId.Should().Be("dlrk123lzabc");
+            plan.SetupFeePerformanceObligationId.Should().Be("bks6noi");
+        }
     }
 }


### PR DESCRIPTION
Adds the following properties to the `Plan` entity for the V2 client:
- `LiabilityGlAccountId`
- `RevenueGlAccountId`
- `PerformanceObligationId`
- `SetupFeeLiabilityGlAccountId`
- `SetupFeeRevenueGlAccountId`
- `SetupFeePerformanceObligationId`


### Examples

The following examples only show the base fee RevRec settings for brevity, but the `SetupFee*` properties behave the same way.
```csharp
## create a plan with default RevRec settings
var plan = new Plan();
# ...
plan.Create();
Console.WriteLine("Liability ID: {0}", plan.LiabilityGlAccountId); # => ""
Console.WriteLine("Revenue ID: {0}", plan.RevenueGlAccountId);     # => ""
Console.WriteLine("POB ID: {0}", plan.PerformanceObligationId);    # => "abc" (default POB)

## remove RevRec settings from a plan
var plan = Plans.Get(planCode);

# note that POB IDs cannot be removed, but they can be changed
plan.LiabilityGlAccountId = null;
plan.RevenueGlAccountId = null;
plan.Update();
```