### PR TITLE
[V2] Adds RevRec features to Item, GiftCard, and ShippingMethod

### DIFF
--- a/Library/GiftCard.cs
+++ b/Library/GiftCard.cs
@@ -9,7 +9,7 @@ namespace Recurly
     ///
     /// https://dev.recurly.com/docs/gift-card-object
     /// </summary>
-    public class GiftCard : RecurlyEntity
+    public class GiftCard : RevRecEntity
     {
         /// <summary>
         /// Unique ID assigned to this gift card.
@@ -99,7 +99,7 @@ namespace Recurly
         /// <summary>
         /// When the gift card was sent to the recipient by Recurly via email,
         /// if method was email and the "Gift Card Delivery" email template was enabled.
-        /// This will be empty for post delivery or email delivery 
+        /// This will be empty for post delivery or email delivery
         /// where the email template was disabled.
         /// </summary>
         public DateTime? DeliveredAt { get; private set; }
@@ -233,6 +233,8 @@ namespace Recurly
 
                 DateTime dateVal;
 
+                ReadRevRecNode(reader);
+
                 switch (reader.Name)
                 {
                     case "id":
@@ -332,6 +334,8 @@ namespace Recurly
             xmlWriter.WriteElementString("product_code", ProductCode);
             xmlWriter.WriteElementString("currency", Currency);
             xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.ToString());
+
+            WriteRevRecNodes(xmlWriter);
 
             if (GifterAccount != null)
                 GifterAccount.WriteXml(xmlWriter, "gifter_account");

--- a/Library/Item.cs
+++ b/Library/Item.cs
@@ -10,7 +10,7 @@ namespace Recurly
     /// An item in Recurly.
     ///
     /// </summary>
-    public class Item : RecurlyEntity
+    public class Item : RevRecEntity
     {
         public string ItemCode { get; set; }
 
@@ -108,6 +108,8 @@ namespace Recurly
 
                 if (reader.NodeType != XmlNodeType.Element) continue;
 
+                ReadRevRecNode(reader);
+
                 switch (reader.Name)
                 {
                     case "item_code":
@@ -135,6 +137,7 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("external_sku", ExternalSku);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
             xmlWriter.WriteStringIfValid("revenue_schedule_type", RevenueScheduleType);
+            WriteRevRecNodes(xmlWriter);
             xmlWriter.WriteStringIfValid("state", State);
             xmlWriter.WriteIfCollectionHasAny("custom_fields", CustomFields);
 

--- a/Library/ShippingMethod.cs
+++ b/Library/ShippingMethod.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 namespace Recurly
 {
-    public class ShippingMethod : RecurlyEntity
+    public class ShippingMethod : RevRecEntity
     {
         public string Code { get; set; }
         public string Name { get; set; }
@@ -46,6 +46,8 @@ namespace Recurly
 
                 if (reader.NodeType != XmlNodeType.Element) continue;
 
+                ReadRevRecNode(reader);
+
                 switch (reader.Name)
                 {
                     case "code":
@@ -82,6 +84,7 @@ namespace Recurly
             xmlWriter.WriteElementString("code", Code);
             xmlWriter.WriteElementString("name", Name);
             xmlWriter.WriteElementString("accounting_code", AccountingCode);
+            WriteRevRecNodes(xmlWriter);
             xmlWriter.WriteElementString("tax_code", TaxCode);
 
             xmlWriter.WriteEndElement(); // End: shipping_method

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -85,9 +85,15 @@ namespace Recurly.Test.Fixtures
         ExternalInvoices,
         [Description("general_ledger_accounts")]
         GeneralLedgerAccounts,
+        [Description("gift_cards")]
+        GiftCards,
+        [Description("items")]
+        Items,
         [Description("performance_obligations")]
         PerformanceObligations,
         [Description("plans")]
         Plans,
+        [Description("shipping_methods")]
+        ShippingMethods,
     }
 }

--- a/Test/Fixtures/gift_cards/revrec.show-200.xml
+++ b/Test/Fixtures/gift_cards/revrec.show-200.xml
@@ -1,0 +1,32 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<gift_card href="https://api.recurly.com/v2/gift_cards/1998400800965102260">
+  <gifter_account href="https://api.recurly.com/v2/accounts/eteum"/>
+  <purchase_invoice href="https://api.recurly.com/v2/invoices/1056"/>
+  <id type="integer">1998400800965102260</id>
+  <redemption_code>S2TNPI1Z4BRKM9U0</redemption_code>
+  <product_code>first-gift-card</product_code>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <delivery>
+    <method>email</method>
+    <email_address>sally@example.com</email_address>
+    <deliver_at nil="nil"></deliver_at>
+    <first_name>Sally</first_name>
+    <last_name>DuMonde</last_name>
+    <address nil="nil"></address>
+    <gifter_name>Benjamin</gifter_name>
+    <personal_message>Happy birthday!</personal_message>
+  </delivery>
+  <created_at type="datetime">2024-02-08T17:48:38Z</created_at>
+  <updated_at type="datetime">2024-02-08T17:48:38Z</updated_at>
+  <delivered_at type="datetime">2024-02-08T17:48:38Z</delivered_at>
+  <redeemed_at nil="nil"></redeemed_at>
+  <canceled_at nil="nil"></canceled_at>
+  <a name="redeem" href="https://api.recurly.com/v2/gift_cards/S2TNPI1Z4BRKM9U0/redeem" method="post"/>
+  <liability_gl_account_id>suaz415ebc94</liability_gl_account_id>
+  <revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>
+  <performance_obligation_id>7pu</performance_obligation_id>
+</gift_card>

--- a/Test/Fixtures/items/revrec.show-200.xml
+++ b/Test/Fixtures/items/revrec.show-200.xml
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<item href="https://api.recurly.com/v2/items/plastic_gloves">
+  <item_code>plastic_gloves</item_code>
+  <name>Awesome Plastic Gloves</name>
+  <description>Sleek Plastic</description>
+  <external_sku>awesome-plastic-gloves</external_sku>
+  <accounting_code>1569273944</accounting_code>
+  <revenue_schedule_type>never</revenue_schedule_type>
+  <tax_exempt type="boolean">true</tax_exempt>
+  <tax_code nil="nil"/>
+  <state>active</state>
+  <liability_gl_account_id>suaz415ebc94</liability_gl_account_id>
+  <revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>
+  <performance_obligation_id>7pu</performance_obligation_id>
+  <created_at type="datetime">2019-09-23T21:25:45Z</created_at>
+  <updated_at type="datetime">2019-09-23T21:25:45Z</updated_at>
+  <deleted_at nil="nil"/>
+</item>

--- a/Test/Fixtures/shipping_methods/revrec.show-200.xml
+++ b/Test/Fixtures/shipping_methods/revrec.show-200.xml
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_method href="https://api.recurly.com/v2/shipping_methods/ups-ground">
+  <code>ups-ground</code>
+  <name>UPS - Ground</name>
+  <accounting_code></accounting_code>
+  <tax_code nil="nil"></tax_code>
+  <liability_gl_account_id>suaz415ebc94</liability_gl_account_id>
+  <revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>
+  <performance_obligation_id>7pu</performance_obligation_id>
+  <created_at type="datetime">2023-07-10T19:54:21Z</created_at>
+  <updated_at type="datetime">2023-12-04T18:54:45Z</updated_at>
+</shipping_method>

--- a/Test/GiftCardTest.cs
+++ b/Test/GiftCardTest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using FluentAssertions;
+using Recurly.Test.Fixtures;
+using Xunit;
+
+namespace Recurly.Test
+{
+    public class GiftCardTest : BaseTest
+    {
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var giftCard = new GiftCard();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.GiftCards, "revrec.show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            giftCard.ReadXml(reader);
+
+            giftCard.LiabilityGlAccountId.Should().Be("suaz415ebc94");
+            giftCard.RevenueGlAccountId.Should().Be("sxo2b1hpjrye");
+            giftCard.PerformanceObligationId.Should().Be("7pu");
+        }
+    }
+}

--- a/Test/ItemTest.cs
+++ b/Test/ItemTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Xml;
 using FluentAssertions;
+using Recurly.Test.Fixtures;
 using Xunit;
 
 namespace Recurly.Test
@@ -40,6 +42,20 @@ namespace Recurly.Test
             item.Deactivate();
 
             Assert.Equal(item.State, null);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var item = new Item();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.Items, "revrec.show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            item.ReadXml(reader);
+
+            item.LiabilityGlAccountId.Should().Be("suaz415ebc94");
+            item.RevenueGlAccountId.Should().Be("sxo2b1hpjrye");
+            item.PerformanceObligationId.Should().Be("7pu");
         }
     }
 }

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -161,10 +161,25 @@
     <Content Include="Fixtures\coupons\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\external_invoices\index-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\external_invoices\show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\external_payment_phases\index-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\external_payment_phases\show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\general_ledger_accounts\index-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\general_ledger_accounts\show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\gift_cards\revrec.show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\invoices\create-201.xml">
@@ -180,6 +195,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\invoices\show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Fixtures\items\revrec.show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\items\show-200.xml">
@@ -206,6 +224,9 @@
     <Content Include="Fixtures\subscriptions\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\shipping_methods\revrec.show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\transactions\create-422.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -219,18 +240,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Fixtures\transactions\show-200.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Fixtures/external_payment_phases/index-200.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Fixtures/external_payment_phases/show-200.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Fixtures/external_invoices/index-200.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Fixtures/external_invoices/show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/Test/ShippingMethodTest.cs
+++ b/Test/ShippingMethodTest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using FluentAssertions;
+using Recurly.Test.Fixtures;
+using Xunit;
+
+namespace Recurly.Test
+{
+    public class ShippingMethodTest : BaseTest
+    {
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var shippingMethod = new ShippingMethod();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.ShippingMethods, "revrec.show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            shippingMethod.ReadXml(reader);
+
+            shippingMethod.LiabilityGlAccountId.Should().Be("suaz415ebc94");
+            shippingMethod.RevenueGlAccountId.Should().Be("sxo2b1hpjrye");
+            shippingMethod.PerformanceObligationId.Should().Be("7pu");
+        }
+    }
+}


### PR DESCRIPTION
Adds the following properties to the `GiftCard`, `Item`, and `ShippingMethod` entities for the V2 client:
- `LiabilityGlAccountId`
- `RevenueGlAccountId`
- `PerformanceObligationId`


### Examples

For gift cards and shipping methods, you will need to first create one of each and assign any desired GLA/POB settings **_in the Admin UI_**. Then just use the `.Get()`/`.List()` methods for those entities to gain access to the new properties. Item functionality is shown below.
```csharp
//** create an item with default RevRec settings
var item = new Item();
// ...
item.Create();
Console.WriteLine("Liability ID: {0}", item.LiabilityGlAccountId); // => ""
Console.WriteLine("Revenue ID: {0}", item.RevenueGlAccountId);     // => ""
Console.WriteLine("POB ID: {0}", item.PerformanceObligationId);    // => "abc" (default POB)

//** change/remove RevRec settings from an item
var item = Items.Get(itemCode);

// var liabilityGla = ...
// var revenueGla = ...
// var pob = ...

item.LiabilityGlAccountId = liabilityGla.Id;
item.RevenueGlAccountId = RevenueGla.Id;
item.PerformanceObligationId = pob.Id;
item.Update();

// note that POB IDs cannot be removed, but they can be changed
item.LiabilityGlAccountId = null;
item.RevenueGlAccountId = null;
item.Update();
```