### PR TITLE
[V2] Adds RevRec features to AddOns

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -4,7 +4,7 @@ using System.Xml;
 
 namespace Recurly
 {
-    public class AddOn : RecurlyEntity
+    public class AddOn : RevRecEntity
     {
         public enum Type
         {
@@ -172,6 +172,8 @@ namespace Recurly
 
                 if (reader.NodeType != XmlNodeType.Element) continue;
 
+                ReadRevRecNode(reader);
+
                 switch (reader.Name)
                 {
                     case "add_on_code":
@@ -276,6 +278,8 @@ namespace Recurly
             xmlWriter.WriteStringIfValid("name", Name);
             xmlWriter.WriteStringIfValid("accounting_code", AccountingCode);
 
+            WriteRevRecNodes(xmlWriter);
+
             if (DefaultQuantity.HasValue)
                 xmlWriter.WriteElementString("default_quantity", DefaultQuantity.Value.AsString());
 
@@ -322,6 +326,8 @@ namespace Recurly
         internal void WriteItemBackedUpdateXml(XmlTextWriter xmlWriter)
         {
             xmlWriter.WriteStartElement("add_on");
+
+            WriteRevRecNodes(xmlWriter);
 
             if (DefaultQuantity.HasValue)
                 xmlWriter.WriteElementString("default_quantity", DefaultQuantity.Value.AsString());

--- a/Test/AddOnTest.cs
+++ b/Test/AddOnTest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Xml;
 using FluentAssertions;
+using Recurly.Test.Fixtures;
 using Xunit;
 
 namespace Recurly.Test
@@ -156,6 +158,52 @@ namespace Recurly.Test
 
             addon.CurrencyPercentageTiers[0].PercentageTiers[0].EndingAmountInCents.Should().Be(2000);
             addon.CurrencyPercentageTiers[0].PercentageTiers[0].UsagePercentage.Should().Be("25");
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecData()
+        {
+            var addOn = new AddOn();
+
+            var xmlFixture = FixtureImporter.Get(FixtureType.AddOns, "revrec.show-200").Xml;
+            XmlTextReader reader = new XmlTextReader(new System.IO.StringReader(xmlFixture));
+            addOn.ReadXml(reader);
+
+            addOn.LiabilityGlAccountId.Should().Be("suaz415ebc94");
+            addOn.RevenueGlAccountId.Should().Be("sxo2b1hpjrye");
+            addOn.PerformanceObligationId.Should().Be("7pu");
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForRevRecDataOut()
+        {
+            var addOn = new AddOn();
+
+            addOn.LiabilityGlAccountId = "suaz415ebc94";
+            addOn.RevenueGlAccountId = "sxo2b1hpjrye";
+            addOn.PerformanceObligationId = "7pu";
+
+            var xml = XmlToString(addOn.WriteXml);
+
+            xml.Should().Contain("<liability_gl_account_id>suaz415ebc94</liability_gl_account_id>");
+            xml.Should().Contain("<revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>");
+            xml.Should().Contain("<performance_obligation_id>7pu</performance_obligation_id>");
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void CheckForItemBackedRevRecDataOut()
+        {
+            var addOn = new AddOn();
+
+            addOn.LiabilityGlAccountId = "suaz415ebc94";
+            addOn.RevenueGlAccountId = "sxo2b1hpjrye";
+            addOn.PerformanceObligationId = "7pu";
+
+            var xml = XmlToString(addOn.WriteItemBackedUpdateXml);
+
+            xml.Should().Contain("<liability_gl_account_id>suaz415ebc94</liability_gl_account_id>");
+            xml.Should().Contain("<revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>");
+            xml.Should().Contain("<performance_obligation_id>7pu</performance_obligation_id>");
         }
     }
 }

--- a/Test/BaseTest.cs
+++ b/Test/BaseTest.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
 
 namespace Recurly.Test
 {
     public abstract class BaseTest : IDisposable
     {
+        protected delegate void WriteXmlDelegate(XmlTextWriter xmlWriter);
+
         protected const string NullString = null;
         protected const string EmptyString = "";
 
@@ -360,6 +365,27 @@ namespace Recurly.Test
                 {
                 }
             }
+        }
+
+        /// <summary>
+        /// Use this helper to test entity WriteXml methods to ensure data
+        /// is written correctly to nodes for outgoing requests.
+        /// </summary>
+        /// <param name="writeXmlDelegate"></param>
+        /// <returns>string</returns>
+        protected string XmlToString(WriteXmlDelegate writeXmlDelegate)
+        {
+            var s = new MemoryStream();
+            using (var xmlWriter = new XmlTextWriter(s, Encoding.UTF8))
+            {
+                xmlWriter.WriteStartDocument();
+                xmlWriter.Formatting = Formatting.Indented;
+
+                writeXmlDelegate(xmlWriter);
+
+                xmlWriter.WriteEndDocument();
+            }
+            return Encoding.UTF8.GetString(s.ToArray());
         }
     }
 }

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -76,7 +76,10 @@ namespace Recurly.Test.Fixtures
 
     public enum FixtureType
     {
+        [Description("accounts")]
         Accounts,
+        [Description("addons")]
+        AddOns,
         [Description("business_entities")]
         BusinessEntities,
         [Description("external_payment_phases")]

--- a/Test/Fixtures/addons/revrec.show-200.xml
+++ b/Test/Fixtures/addons/revrec.show-200.xml
@@ -1,0 +1,19 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+ETag: "a81253e90a4f16089b951028675c58d2"
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on href="https://api.recurly.com/v2/plans/gold/add_ons/ipaddresses">
+  <plan href="https://api.recurly.com/v2/plans/gold"/>
+  <add_on_code>ipaddresses</add_on_code>
+  <name>IP Addresses</name>
+  <display_quantity_on_hosted_page type="boolean">false</display_quantity_on_hosted_page>
+  <default_quantity type="integer">1</default_quantity>
+  <unit_amount_in_cents>
+    <USD type="integer">200</USD>
+  </unit_amount_in_cents>
+  <liability_gl_account_id>suaz415ebc94</liability_gl_account_id>
+  <revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>
+  <performance_obligation_id>7pu</performance_obligation_id>
+  <created_at type="datetime">2011-06-28T12:34:56Z</created_at>
+</add_on>

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -116,6 +116,9 @@
     <Content Include="Fixtures\addons\destroy-204.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\addons\revrec.show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\addons\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Adds the following properties to the `AddOn` entity for the V2 client:
- `LiabilityGlAccountId`
- `RevenueGlAccountId`
- `PerformanceObligationId`


### Examples

```csharp
//** create an add-on with default RevRec settings
var addOn = new AddOn();
// ...
addOn.Create();
Console.WriteLine("Liability ID: {0}", addOn.LiabilityGlAccountId); // => ""
Console.WriteLine("Revenue ID: {0}", addOn.RevenueGlAccountId);     // => ""
Console.WriteLine("POB ID: {0}", addOn.PerformanceObligationId);    // => "abc" (default POB)

//** remove (or change) RevRec settings from an add-on
var addOn = AddOns.Get(addOnCode);

// note that POB IDs cannot be removed, but they can be changed
addOn.LiabilityGlAccountId = null;
addOn.RevenueGlAccountId = null;
addOn.Update();
```