### PR TITLE
[V2] Add RevRec Settings to Adjustments

### DIFF
--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -7,7 +7,7 @@ namespace Recurly
     /// <summary>
     /// Represents adjustments - credits and charges - on accounts.
     /// </summary>
-    public class Adjustment : RecurlyEntity
+    public class Adjustment : RevRecEntity
     {
         // The currently valid adjustment types
         public enum AdjustmentType : short
@@ -39,6 +39,8 @@ namespace Recurly
         public string Uuid { get; protected set; }
         public string Description { get; set; }
         public string AccountingCode { get; set; }
+        public string LiabilityGlAccountCode { get; private set; }
+        public string RevenueGlAccountCode { get; private set; }
         public string ProductCode { get; set; }
         public string ItemCode { get; set; }
         public string ExternalSku { get; set; }
@@ -171,6 +173,9 @@ namespace Recurly
                     break;
 
                 if (reader.NodeType != XmlNodeType.Element) continue;
+
+                ReadRevRecPobNode(reader);
+
                 switch (reader.Name)
                 {
                     case "account":
@@ -193,6 +198,14 @@ namespace Recurly
 
                     case "accounting_code":
                         AccountingCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "liability_gl_account_code":
+                        LiabilityGlAccountCode = reader.ReadElementContentAsString();
+                        break;
+
+                    case "revenue_gl_account_code":
+                        RevenueGlAccountCode = reader.ReadElementContentAsString();
                         break;
 
                     case "product_code":
@@ -372,6 +385,9 @@ namespace Recurly
                 xmlWriter.WriteElementString("currency", Currency);
             if (RevenueScheduleType.HasValue)
                 xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+
+            WriteRevRecNodes(xmlWriter);
+
             if (TaxCode != null)
                 xmlWriter.WriteElementString("tax_code", TaxCode);
             if (StartDate != DateTime.MinValue)

--- a/Library/RevRecEntity.cs
+++ b/Library/RevRecEntity.cs
@@ -21,9 +21,15 @@ namespace Recurly
                     break;
 
                 case "performance_obligation_id":
-                    PerformanceObligationId = reader.ReadElementContentAsString();
+                    ReadRevRecPobNode(reader);
                     break;
             };
+        }
+
+        internal protected void ReadRevRecPobNode(XmlTextReader reader)
+        {
+            if (reader.Name == "performance_obligation_id")
+                PerformanceObligationId = reader.ReadElementContentAsString();
         }
 
         internal protected void WriteRevRecNodes(XmlTextWriter writer)

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -80,6 +80,8 @@ namespace Recurly.Test.Fixtures
         Accounts,
         [Description("addons")]
         AddOns,
+        [Description("adjustments")]
+        Adjustments,
         [Description("business_entities")]
         BusinessEntities,
         [Description("external_payment_phases")]

--- a/Test/Fixtures/adjustments/revrec.show-200.xml
+++ b/Test/Fixtures/adjustments/revrec.show-200.xml
@@ -1,0 +1,29 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment href="https://api.recurly.com/v2/adjustments/abcdef1234567890" type="charge">
+  <account href="https://api.recurly.com/v2/accounts/account"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1234"/>
+  <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+  <uuid>abcdef1234567890</uuid>
+  <state>invoiced</state>
+  <description>$12 Annual Subscription</description>
+  <item_code></item_code>
+  <accounting_code></accounting_code>
+  <liability_gl_account_code>100</liability_gl_account_code>
+  <revenue_gl_account_code>200</revenue_gl_account_code>
+  <performance_obligation_id>7pu</performance_obligation_id>
+  <product_code nil="nil"></product_code>
+  <origin>plan</origin>
+  <unit_amount_in_cents type="integer">1200</unit_amount_in_cents>
+  <quantity type="integer">1</quantity>
+  <discount_in_cents type="integer">0</discount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">1200</total_in_cents>
+  <currency>USD</currency>
+  <taxable type="boolean">false</taxable>
+  <start_date type="datetime">2011-04-30T07:00:00Z</start_date>
+  <end_date type="datetime">2011-04-30T07:00:00Z</end_date>
+  <created_at type="datetime">2011-08-31T03:30:00Z</created_at>
+</adjustment>

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -128,6 +128,9 @@
     <Content Include="Fixtures\adjustments\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\adjustments\revrec.show-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\adjustments\show-404.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Adds the following properties to the `Adjustment` entity for the V2 client:
- `LiabilityGlAccountId`
- `RevenueGlAccountId`
- `PerformanceObligationId`


### Examples

```csharp
//** create an add-on with default (or non-default, by assignment) RevRec settings
var adjustment = new Adjustment();
// ...
adjustment.Create();
Console.WriteLine("Liability ID: {0}", adjustment.LiabilityGlAccountId); // => ""
Console.WriteLine("Revenue ID: {0}", adjustment.RevenueGlAccountId);     // => ""
Console.WriteLine("POB ID: {0}", adjustment.PerformanceObligationId);    // => "abc" (default POB)
```