### PR TITLE
add net_terms_type to invoice, purchase, and subscription

### DIFF
--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -89,6 +89,11 @@ namespace Recurly
         public int TaxInCents { get; protected set; }
         public int TotalInCents { get; protected set; }
         public string Currency { get; protected set; }
+
+        /// <summary>
+        /// The net terms for the invoice.
+        /// If net terms type is 'eom', NetTerms must be one of 0, 15, 30, 45, 60, or 90
+        /// </summary>
         public int? NetTerms
         {
             get { return _netTerms; }
@@ -98,6 +103,10 @@ namespace Recurly
         private int? _netTerms;
         private bool _netTermsChanged = false;
 
+        /// <summary>
+        /// The net terms type for the invoice.  Can be a 'net' or 'eom'
+        /// </summary>
+        public NetTermsType? NetTermsType { get; set; }
         public Collection CollectionMethod { get; set; }
         public DateTime? CreatedAt { get; private set; }
         public DateTime? UpdatedAt { get; private set; }
@@ -641,6 +650,10 @@ namespace Recurly
                         }
                         break;
 
+                    case "net_terms_type":
+                        NetTermsType = reader.ReadElementContentAsString().ParseAsEnum<NetTermsType>();
+                        break;
+
                     case "collection_method":
                         var method = reader.ReadElementContentAsString();
                         if (!method.IsNullOrEmpty())
@@ -761,14 +774,17 @@ namespace Recurly
             if (CollectionMethod == Collection.Manual)
             {
                 xmlWriter.WriteElementString("collection_method", "manual");
-
-                if (NetTerms.HasValue)
-                    xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
             }
             else if (CollectionMethod == Collection.Automatic)
             {
                 xmlWriter.WriteElementString("collection_method", "automatic");
             }
+
+            if (NetTerms.HasValue)
+                xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
+
+            if (NetTermsType.HasValue)
+                xmlWriter.WriteElementString("net_terms_type", NetTermsType.ToString().EnumNameToTransportCase());
 
             xmlWriter.WriteEndElement(); // End: invoice
         }

--- a/Library/NetTermsType.cs
+++ b/Library/NetTermsType.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+namespace Recurly
+{
+    /// <summary>
+    /// Optionally supplied string that may be either net or eom(end-of-month).
+    /// When 'net', an invoice becomes past due the specified number of net_terms
+    /// days from the current date.  When 'eom' an invoice becomes past due the
+    /// specified number of net_terms days from the last day of the current month.
+    /// If NetTermsType is 'eom' then NetTerms must be one of 0, 15, 30, 45, 60, or 90
+    /// </summary>
+    public enum NetTermsType
+    {
+        [EnumMember(Value = "net")]
+        NET,
+
+        [EnumMember(Value = "eom")]
+        EOM,
+    }
+}

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -34,8 +34,14 @@ namespace Recurly
 
         /// <summary>
         /// The net terms for the invoice.
+        /// If net terms type is 'eom', NetTerms must be one of 0, 15, 30, 45, 60, or 90
         /// </summary>
         public int? NetTerms { get; set; }
+
+        /// <summary>
+        /// The net terms type for the invoice.  Can be a 'net' or 'eom'
+        /// </summary>
+        public NetTermsType? NetTermsType { get; set; }
 
         /// <summary>
         /// A gift card redemption code to apply to this purchase.
@@ -277,6 +283,9 @@ namespace Recurly
 
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.ToString());
+
+            if (NetTermsType.HasValue)
+                xmlWriter.WriteElementString("net_terms_type", NetTermsType.ToString().EnumNameToTransportCase());
 
             if (PoNumber != null)
                 xmlWriter.WriteElementString("po_number", PoNumber);

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -278,7 +278,16 @@ namespace Recurly
         internal const string UrlPrefix = "/subscriptions/";
 
         public string CollectionMethod { get; set; }
+        /// <summary>
+        /// The net terms for the subscription.
+        /// If net terms type is 'eom', NetTerms must be one of 0, 15, 30, 45, 60, or 90
+        /// </summary>
         public int? NetTerms { get; set; }
+
+        /// <summary>
+        /// The net terms type for the subscription.  Can be a 'net' or 'eom'
+        /// </summary>
+        public NetTermsType? NetTermsType { get; set; }
         public string PoNumber { get; set; }
 
         /// <summary>
@@ -862,6 +871,10 @@ namespace Recurly
                         NetTerms = reader.ReadElementContentAsInt();
                         break;
 
+                    case "net_terms_type":
+                        NetTermsType = reader.ReadElementContentAsString().ParseAsEnum<NetTermsType>();
+                        break;
+
                     case "po_number":
                         PoNumber = reader.ReadElementContentAsString();
                         break;
@@ -1102,11 +1115,15 @@ namespace Recurly
             {
                 xmlWriter.WriteElementString("collection_method", "manual");
 
-                if (NetTerms.HasValue)
-                    xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
             }
             else if (CollectionMethod.Like("automatic"))
                 xmlWriter.WriteElementString("collection_method", "automatic");
+
+            if (NetTerms.HasValue)
+                xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
+
+            if (NetTermsType.HasValue)
+                xmlWriter.WriteElementString("net_terms_type", NetTermsType.ToString().EnumNameToTransportCase());
 
             if (ShippingAddressId.HasValue)
             {

--- a/Library/SubscriptionChange.cs
+++ b/Library/SubscriptionChange.cs
@@ -56,7 +56,16 @@ namespace Recurly
 
         public string CollectionMethod { get; set; }
 
+        /// <summary>
+        /// The net terms for the subscription.
+        /// If net terms type is 'eom', NetTerms must be one of 0, 15, 30, 45, 60, or 90
+        /// </summary>
         public int? NetTerms { get; set; }
+
+        /// <summary>
+        /// The net terms type for the invoice.  Can be a 'net' or 'eom'
+        /// </summary>
+        public NetTermsType? NetTermsType { get; set; }
 
         public string PoNumber { get; set; }
 
@@ -130,6 +139,9 @@ namespace Recurly
 
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.AsString());
+
+            if (NetTermsType.HasValue)
+                xmlWriter.WriteElementString("net_terms_type", NetTermsType.ToString().EnumNameToTransportCase());
 
             if (PoNumber != null)
                 xmlWriter.WriteElementString("po_number", PoNumber);

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -465,5 +465,26 @@ namespace Recurly.Test
             var recordedTransaction = invoice.EnterOfflinePayment(offlineTransaction);
             Assert.Equal(recordedTransaction.Status, Recurly.Transaction.TransactionState.Success);
         }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateInvoiceWithEOMNetTerms()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+
+            var adjustment = account.NewAdjustment("USD", 5000, "Test Charge");
+            adjustment.Create();
+
+            var collection = account.InvoicePendingCharges(new Invoice
+            {
+                NetTerms = 45,
+                NetTermsType = NetTermsType.EOM,
+            });
+
+            var invoice = collection.ChargeInvoice;
+            var response = Invoices.Get(invoice.InvoiceNumber);
+
+            Assert.Equal(response.NetTerms, 45);
+            Assert.Equal(response.NetTermsType, NetTermsType.EOM);
+        }
     }
 }

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -254,5 +254,29 @@ namespace Recurly.Test
             Assert.Equal(capturedResponse.ChargeInvoice.Adjustments[0].CustomFields[0].Value, "purple");
             account.Close();
         }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void PurchaseWithEOMNetTerms()
+        {
+            var account = CreateNewAccountWithBillingInfo();
+            var currency = "USD";
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Plan for Purchase Test" };
+            plan.UnitAmountInCents.Add("USD", 580);
+            plan.Create();
+
+            var purchase = new Purchase(account.AccountCode, currency);
+
+            purchase.Account.BillingInfo = account.BillingInfo;
+            purchase.NetTerms = 45;
+            purchase.NetTermsType = NetTermsType.EOM;
+
+            var sub = new Subscription(plan.PlanCode);
+            purchase.Subscriptions.Add(sub);
+
+            var response = Purchase.Invoice(purchase);
+            Assert.NotNull(response.ChargeInvoice);
+            Assert.Equal(response.ChargeInvoice.NetTerms, 45);
+            response.ChargeInvoice.NetTermsType.Should().Be(NetTermsType.EOM);
+        }
     }
 }

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -290,7 +290,9 @@ namespace Recurly.Test
             var subChange = new SubscriptionChange()
             {
                 PlanCode = plan2.PlanCode,
-                BillingInfoUuid = account.GetBillingInfos()[0].Id
+                BillingInfoUuid = account.GetBillingInfos()[0].Id,
+                NetTerms = 10,
+                NetTermsType = NetTermsType.NET
             };
 
             Subscription.ChangeSubscription(sub.Uuid, subChange);
@@ -299,6 +301,8 @@ namespace Recurly.Test
 
             newSubscription.PendingSubscription.Should().BeNull();
             newSubscription.Plan.Should().Be(plan2);
+            Assert.Equal(newSubscription.NetTerms, 10);
+            Assert.Equal(newSubscription.NetTermsType, NetTermsType.NET);
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
@@ -933,6 +937,28 @@ namespace Recurly.Test
             {
                 account.Close();
             }
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateSubscriptionWithEOMNetTerms()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) { Description = "Lookup Subscription Test" };
+            plan.UnitAmountInCents.Add("USD", 1500);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.NetTerms = 15;
+            sub.NetTermsType = NetTermsType.EOM;
+            sub.Create();
+
+            var response = Subscriptions.Get(sub.Uuid);
+
+            response.Should().Be(sub);
+            Assert.Equal(response.NetTerms, 15);
+            response.NetTermsType.Should().Be(NetTermsType.EOM);
         }
     }
 }


### PR DESCRIPTION
Add net_terms_type for purchases, invoices, and subscriptions to support both net and eom

Playground PR: https://github.com/recurly/v2-playground/pull/201