### PR TITLE
Generated Latest Changes for v2021-02-25 (Proration Settings)

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -14,6 +14,36 @@ namespace Recurly
     namespace Constants
     {
 
+        public enum ProrationSettingsCharge
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "full_amount")]
+            FullAmount,
+
+            [EnumMember(Value = "prorated_amount")]
+            ProratedAmount,
+
+            [EnumMember(Value = "none")]
+            None,
+
+        };
+
+        public enum ProrationSettingsCredit
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "full_amount")]
+            FullAmount,
+
+            [EnumMember(Value = "prorated_amount")]
+            ProratedAmount,
+
+            [EnumMember(Value = "none")]
+            None,
+
+        };
+
         public enum ExternalProductReferenceConnectionType
         {
             Undefined = 0,

--- a/Recurly/Resources/ProrationSettings.cs
+++ b/Recurly/Resources/ProrationSettings.cs
@@ -1,0 +1,29 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class ProrationSettings : Request
+    {
+
+        /// <value>Determines how the amount charged is determined for this change</value>
+        [JsonProperty("charge")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.ProrationSettingsCharge? Charge { get; set; }
+
+        /// <value>Determines how the amount credited is determined for this change</value>
+        [JsonProperty("credit")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.ProrationSettingsCredit? Credit { get; set; }
+
+    }
+}

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -86,6 +86,10 @@ namespace Recurly.Resources
         [JsonProperty("po_number")]
         public string PoNumber { get; set; }
 
+        /// <value>Allows you to control how any resulting charges and credits will be calculated and prorated.</value>
+        [JsonProperty("proration_settings")]
+        public ProrationSettings ProrationSettings { get; set; }
+
         /// <value>Optionally override the default quantity of 1.</value>
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21253,6 +21253,34 @@ components:
           description: |
             The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places represented as a string.
+    ProrationSettings:
+      type: object
+      title: Proration Settings
+      description: Allows you to control how any resulting charges and credits will
+        be calculated and prorated.
+      properties:
+        charge:
+          "$ref": "#/components/schemas/ProrationSettingsChargeEnum"
+        credit:
+          "$ref": "#/components/schemas/ProrationSettingsCreditEnum"
+    ProrationSettingsChargeEnum:
+      type: string
+      title: Charge
+      description: Determines how the amount charged is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
+    ProrationSettingsCreditEnum:
+      type: string
+      title: Credit
+      description: Determines how the amount credited is determined for this change
+      default: prorated_amount
+      enum:
+      - full_amount
+      - prorated_amount
+      - none
     Settings:
       type: object
       properties:
@@ -22476,6 +22504,8 @@ components:
           description: The new set of ramp intervals for the subscription.
           items:
             "$ref": "#/components/schemas/SubscriptionRampInterval"
+        proration_settings:
+          "$ref": "#/components/schemas/ProrationSettings"
     SubscriptionChangeShippingCreate:
       type: object
       title: Shipping details that will be changed on a subscription


### PR DESCRIPTION
Adds support for passing `proration_settings` to the following endpoints:

- POST /subscriptions/:id/change
- POST /subscriptions/:id/change/preview