### PR TITLE
Generated Latest Changes for v2021-02-25 (Taxable Address Control, RevRec)

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -1766,7 +1766,7 @@ namespace Recurly
         /// </summary>
         /// <param name="GetCustomFieldDefinitionParams">Optional Parameters for the request</param>
         /// <returns>
-        /// An custom field definition.
+        /// A custom field definition.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         public CustomFieldDefinition GetCustomFieldDefinition(string customFieldDefinitionId, RequestOptions options = null)
@@ -1783,7 +1783,7 @@ namespace Recurly
         /// </summary>
         /// <param name="GetCustomFieldDefinitionParams">Optional Parameters for the request</param>
         /// <returns>
-        /// An custom field definition.
+        /// A custom field definition.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         public Task<CustomFieldDefinition> GetCustomFieldDefinitionAsync(string customFieldDefinitionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
@@ -1792,6 +1792,179 @@ namespace Recurly
             var url = this.InterpolatePath("/custom_field_definitions/{custom_field_definition_id}", urlParams);
             return MakeRequestAsync<CustomFieldDefinition>(Method.GET, url, null, null, options, cancellationToken);
         }
+
+
+
+        /// <summary>
+        /// Create a new general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account">create_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="CreateGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A new general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public GeneralLedgerAccount CreateGeneralLedgerAccount(GeneralLedgerAccountCreate body, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/general_ledger_accounts", urlParams);
+            return MakeRequest<GeneralLedgerAccount>(Method.POST, url, body, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Create a new general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account">create_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="CreateGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A new general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<GeneralLedgerAccount> CreateGeneralLedgerAccountAsync(GeneralLedgerAccountCreate body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/general_ledger_accounts", urlParams);
+            return MakeRequestAsync<GeneralLedgerAccount>(Method.POST, url, body, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// List a site's general ledger accounts <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_general_ledger_accounts">list_general_ledger_accounts api documentation</see>
+        /// </summary>
+        /// <param name="ListGeneralLedgerAccountsParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A list of the site's general ledger accounts.
+        /// </returns>
+        public Pager<GeneralLedgerAccount> ListGeneralLedgerAccounts(ListGeneralLedgerAccountsParams optionalParams = null, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var queryParams = (optionalParams ?? new ListGeneralLedgerAccountsParams()).ToDictionary();
+            var url = this.InterpolatePath("/general_ledger_accounts", urlParams);
+            return Pager<GeneralLedgerAccount>.Build(url, queryParams, options, this);
+        }
+
+
+
+
+
+        /// <summary>
+        /// Fetch a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account">get_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="GetGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public GeneralLedgerAccount GetGeneralLedgerAccount(string generalLedgerAccountId, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "general_ledger_account_id", generalLedgerAccountId } };
+            var url = this.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", urlParams);
+            return MakeRequest<GeneralLedgerAccount>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Fetch a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account">get_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="GetGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<GeneralLedgerAccount> GetGeneralLedgerAccountAsync(string generalLedgerAccountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "general_ledger_account_id", generalLedgerAccountId } };
+            var url = this.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", urlParams);
+            return MakeRequestAsync<GeneralLedgerAccount>(Method.GET, url, null, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// Update a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account">update_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="UpdateGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// The updated general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public GeneralLedgerAccount UpdateGeneralLedgerAccount(string generalLedgerAccountId, GeneralLedgerAccountUpdate body, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "general_ledger_account_id", generalLedgerAccountId } };
+            var url = this.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", urlParams);
+            return MakeRequest<GeneralLedgerAccount>(Method.PUT, url, body, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Update a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account">update_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="UpdateGeneralLedgerAccountParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// The updated general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<GeneralLedgerAccount> UpdateGeneralLedgerAccountAsync(string generalLedgerAccountId, GeneralLedgerAccountUpdate body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "general_ledger_account_id", generalLedgerAccountId } };
+            var url = this.InterpolatePath("/general_ledger_accounts/{general_ledger_account_id}", urlParams);
+            return MakeRequestAsync<GeneralLedgerAccount>(Method.PUT, url, body, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// Get a single Performance Obligation. <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation">get_performance_obligation api documentation</see>
+        /// </summary>
+        /// <param name="GetPerformanceObligationParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A single Performance Obligation.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public PerformanceObligation GetPerformanceObligation(string performanceObligationId, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "performance_obligation_id", performanceObligationId } };
+            var url = this.InterpolatePath("/performance_obligations/{performance_obligation_id}", urlParams);
+            return MakeRequest<PerformanceObligation>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// Get a single Performance Obligation. <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation">get_performance_obligation api documentation</see>
+        /// </summary>
+        /// <param name="GetPerformanceObligationParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A single Performance Obligation.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<PerformanceObligation> GetPerformanceObligationAsync(string performanceObligationId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "performance_obligation_id", performanceObligationId } };
+            var url = this.InterpolatePath("/performance_obligations/{performance_obligation_id}", urlParams);
+            return MakeRequestAsync<PerformanceObligation>(Method.GET, url, null, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// Get a site's Performance Obligations <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligations">get_performance_obligations api documentation</see>
+        /// </summary>
+        /// <param name="GetPerformanceObligationsParams">Optional Parameters for the request</param>
+        /// <returns>
+        /// A list of Performance Obligations.
+        /// </returns>
+        public Pager<PerformanceObligation> GetPerformanceObligations(RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/performance_obligations", urlParams);
+            return Pager<PerformanceObligation>.Build(url, null, options, this);
+        }
+
+
 
 
 
@@ -4909,11 +5082,11 @@ namespace Recurly
 
 
         /// <summary>
-        /// Fetch an external payment_phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
+        /// Fetch an external payment phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
         /// </summary>
         /// <param name="GetExternalSubscriptionExternalPaymentPhaseParams">Optional Parameters for the request</param>
         /// <returns>
-        /// Details for an external payment_phase.
+        /// Details for an external payment phase.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         public ExternalPaymentPhase GetExternalSubscriptionExternalPaymentPhase(string externalSubscriptionId, string externalPaymentPhaseId, RequestOptions options = null)
@@ -4926,11 +5099,11 @@ namespace Recurly
 
 
         /// <summary>
-        /// Fetch an external payment_phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
+        /// Fetch an external payment phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
         /// </summary>
         /// <param name="GetExternalSubscriptionExternalPaymentPhaseParams">Optional Parameters for the request</param>
         /// <returns>
-        /// Details for an external payment_phase.
+        /// Details for an external payment phase.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         public Task<ExternalPaymentPhase> GetExternalSubscriptionExternalPaymentPhaseAsync(string externalSubscriptionId, string externalPaymentPhaseId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)

--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -2363,5 +2363,41 @@ namespace Recurly
 
         };
 
+        public enum GeneralLedgerAccountType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "liability")]
+            Liability,
+
+            [EnumMember(Value = "revenue")]
+            Revenue,
+
+        };
+
+        public enum OriginTaxAddressSource
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "origin")]
+            Origin,
+
+            [EnumMember(Value = "destination")]
+            Destination,
+
+        };
+
+        public enum DestinationTaxAddressSource
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "destination")]
+            Destination,
+
+            [EnumMember(Value = "origin")]
+            Origin,
+
+        };
+
     }
 }

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -1178,7 +1178,7 @@ namespace Recurly
         /// </summary>
         /// <param name="customFieldDefinitionId">Custom Field Definition ID</param>
         /// <returns>
-        /// An custom field definition.
+        /// A custom field definition.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         CustomFieldDefinition GetCustomFieldDefinition(string customFieldDefinitionId, RequestOptions options = null);
@@ -1188,10 +1188,115 @@ namespace Recurly
         /// </summary>
         /// <param name="customFieldDefinitionId">Custom Field Definition ID</param>
         /// <returns>
-        /// An custom field definition.
+        /// A custom field definition.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         Task<CustomFieldDefinition> GetCustomFieldDefinitionAsync(string customFieldDefinitionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// Create a new general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account">create_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="body">The body of the request.</param>
+        /// <returns>
+        /// A new general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        GeneralLedgerAccount CreateGeneralLedgerAccount(GeneralLedgerAccountCreate body, RequestOptions options = null);
+
+        /// <summary>
+        /// Create a new general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/create_general_ledger_account">create_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="body">The body of the request.</param>
+        /// <returns>
+        /// A new general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<GeneralLedgerAccount> CreateGeneralLedgerAccountAsync(GeneralLedgerAccountCreate body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// List a site's general ledger accounts <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_general_ledger_accounts">list_general_ledger_accounts api documentation</see>
+        /// </summary>
+        /// <param name="ids">Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </param>
+        /// <param name="limit">Limit number of records 1-200.</param>
+        /// <param name="order">Sort order.</param>
+        /// <param name="sort">Sort field. You *really* only want to sort by `updated_at` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </param>
+        /// <param name="accountType">General Ledger Account type by which to filter the response.</param>
+        /// <returns>
+        /// A list of the site's general ledger accounts.
+        /// </returns>
+        Pager<GeneralLedgerAccount> ListGeneralLedgerAccounts(ListGeneralLedgerAccountsParams optionalParams = null, RequestOptions options = null);
+
+
+        /// <summary>
+        /// Fetch a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account">get_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="generalLedgerAccountId">General Ledger Account ID</param>
+        /// <returns>
+        /// A general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        GeneralLedgerAccount GetGeneralLedgerAccount(string generalLedgerAccountId, RequestOptions options = null);
+
+        /// <summary>
+        /// Fetch a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_general_ledger_account">get_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="generalLedgerAccountId">General Ledger Account ID</param>
+        /// <returns>
+        /// A general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<GeneralLedgerAccount> GetGeneralLedgerAccountAsync(string generalLedgerAccountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// Update a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account">update_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="generalLedgerAccountId">General Ledger Account ID</param>
+        /// <param name="body">The body of the request.</param>
+        /// <returns>
+        /// The updated general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        GeneralLedgerAccount UpdateGeneralLedgerAccount(string generalLedgerAccountId, GeneralLedgerAccountUpdate body, RequestOptions options = null);
+
+        /// <summary>
+        /// Update a general ledger account <see href="https://developers.recurly.com/api/v2021-02-25#operation/update_general_ledger_account">update_general_ledger_account api documentation</see>
+        /// </summary>
+        /// <param name="generalLedgerAccountId">General Ledger Account ID</param>
+        /// <param name="body">The body of the request.</param>
+        /// <returns>
+        /// The updated general ledger account.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<GeneralLedgerAccount> UpdateGeneralLedgerAccountAsync(string generalLedgerAccountId, GeneralLedgerAccountUpdate body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// Get a single Performance Obligation. <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation">get_performance_obligation api documentation</see>
+        /// </summary>
+        /// <param name="performanceObligationId">Performance Obligation id.</param>
+        /// <returns>
+        /// A single Performance Obligation.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        PerformanceObligation GetPerformanceObligation(string performanceObligationId, RequestOptions options = null);
+
+        /// <summary>
+        /// Get a single Performance Obligation. <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligation">get_performance_obligation api documentation</see>
+        /// </summary>
+        /// <param name="performanceObligationId">Performance Obligation id.</param>
+        /// <returns>
+        /// A single Performance Obligation.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<PerformanceObligation> GetPerformanceObligationAsync(string performanceObligationId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// Get a site's Performance Obligations <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_performance_obligations">get_performance_obligations api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// A list of Performance Obligations.
+        /// </returns>
+        Pager<PerformanceObligation> GetPerformanceObligations(RequestOptions options = null);
+
 
         /// <summary>
         /// List an invoice template's associated accounts <see href="https://developers.recurly.com/api/v2021-02-25#operation/list_invoice_template_accounts">list_invoice_template_accounts api documentation</see>
@@ -1610,7 +1715,7 @@ namespace Recurly
         /// <summary>
         /// Fetch an external subscription <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</see>
         /// </summary>
-        /// <param name="externalSubscriptionId">External subscription id</param>
+        /// <param name="externalSubscriptionId">External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.</param>
         /// <returns>
         /// Settings for an external subscription.
         /// </returns>
@@ -1620,7 +1725,7 @@ namespace Recurly
         /// <summary>
         /// Fetch an external subscription <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</see>
         /// </summary>
-        /// <param name="externalSubscriptionId">External subscription id</param>
+        /// <param name="externalSubscriptionId">External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.</param>
         /// <returns>
         /// Settings for an external subscription.
         /// </returns>
@@ -3168,23 +3273,23 @@ namespace Recurly
 
 
         /// <summary>
-        /// Fetch an external payment_phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
+        /// Fetch an external payment phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
         /// </summary>
         /// <param name="externalSubscriptionId">External subscription id</param>
         /// <param name="externalPaymentPhaseId">External payment phase ID, e.g. `a34ypb2ef9w1`.</param>
         /// <returns>
-        /// Details for an external payment_phase.
+        /// Details for an external payment phase.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         ExternalPaymentPhase GetExternalSubscriptionExternalPaymentPhase(string externalSubscriptionId, string externalPaymentPhaseId, RequestOptions options = null);
 
         /// <summary>
-        /// Fetch an external payment_phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
+        /// Fetch an external payment phase <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription_external_payment_phase">get_external_subscription_external_payment_phase api documentation</see>
         /// </summary>
         /// <param name="externalSubscriptionId">External subscription id</param>
         /// <param name="externalPaymentPhaseId">External payment phase ID, e.g. `a34ypb2ef9w1`.</param>
         /// <returns>
-        /// Details for an external payment_phase.
+        /// Details for an external payment phase.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         Task<ExternalPaymentPhase> GetExternalSubscriptionExternalPaymentPhaseAsync(string externalSubscriptionId, string externalPaymentPhaseId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);

--- a/Recurly/Resources/AddOn.cs
+++ b/Recurly/Resources/AddOn.cs
@@ -68,6 +68,14 @@ namespace Recurly.Resources
         [JsonProperty("item")]
         public ItemMini Item { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>System-generated unique identifier for an measured unit associated with the add-on.</value>
         [JsonProperty("measured_unit_id")]
         public string MeasuredUnitId { get; set; }
@@ -88,9 +96,25 @@ namespace Recurly.Resources
         [JsonProperty("percentage_tiers")]
         public List<PercentageTiersByCurrency> PercentageTiers { get; set; }
 
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
         /// <value>Plan ID</value>
         [JsonProperty("plan_id")]
         public string PlanId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -38,7 +38,7 @@ namespace Recurly.Resources
 
         /// <value>
         /// * If `item_code`/`item_id` is part of the request and the item
-        /// has a default currency then `currencies` is optional. If the item does
+        /// has a default currency, then `currencies` is optional. If the item does
         /// not have a default currency, then `currencies` is required. If `item_code`/`item_id`
         /// is not present `currencies` is required.
         /// * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
@@ -56,13 +56,21 @@ namespace Recurly.Resources
         [JsonProperty("display_quantity")]
         public bool? DisplayQuantity { get; set; }
 
-        /// <value>Unique code to identify an item. Available when the `Credit Invoices` feature are enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
+        /// <value>Unique code to identify an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
         [JsonProperty("item_code")]
         public string ItemCode { get; set; }
 
         /// <value>System-generated unique identifier for an item. Available when the `Credit Invoices` feature is enabled. If `item_id` and `item_code` are both present, `item_id` will be used.</value>
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
 
         /// <value>System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.</value>
         [JsonProperty("measured_unit_id")]
@@ -90,9 +98,25 @@ namespace Recurly.Resources
         [JsonProperty("percentage_tiers")]
         public List<PercentageTiersByCurrency> PercentageTiers { get; set; }
 
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
         /// <value>Plan ID</value>
         [JsonProperty("plan_id")]
         public string PlanId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/AddOnUpdate.cs
+++ b/Recurly/Resources/AddOnUpdate.cs
@@ -51,6 +51,14 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>System-generated unique identifier for a measured unit to be associated with the add-on. Either `measured_unit_id` or `measured_unit_name` are required when `add_on_type` is `usage`. If `measured_unit_id` and `measured_unit_name` are both present, `measured_unit_id` will be used.</value>
         [JsonProperty("measured_unit_id")]
         public string MeasuredUnitId { get; set; }
@@ -71,11 +79,27 @@ namespace Recurly.Resources
         /// `percentage_tiers` is an array of objects, which must have the set of tiers
         /// per currency and the currency code. The tier_type must be `volume` or `tiered`,
         /// if not, it must be absent. There must be one tier without an `ending_amount` value
-        /// which represents the final tier.  This feature is currently in development and
+        /// which represents the final tier. This feature is currently in development and
         /// requires approval and enablement, please contact support.
         /// </value>
         [JsonProperty("percentage_tiers")]
         public List<PercentageTiersByCurrency> PercentageTiers { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>When this add-on is invoiced, the line item will use this revenue schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type` must be absent in the request as the value will be set from the item.</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/BusinessEntity.cs
+++ b/Recurly/Resources/BusinessEntity.cs
@@ -23,13 +23,34 @@ namespace Recurly.Resources
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("default_liability_gl_account_id")]
+        public string DefaultLiabilityGlAccountId { get; set; }
+
         /// <value>Registration number for the customer used on the invoice.</value>
         [JsonProperty("default_registration_number")]
         public string DefaultRegistrationNumber { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("default_revenue_gl_account_id")]
+        public string DefaultRevenueGlAccountId { get; set; }
+
         /// <value>VAT number for the customer used on the invoice.</value>
         [JsonProperty("default_vat_number")]
         public string DefaultVatNumber { get; set; }
+
+        /// <value>The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".</value>
+        [JsonProperty("destination_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.DestinationTaxAddressSource? DestinationTaxAddressSource { get; set; }
 
         /// <value>Business entity ID</value>
         [JsonProperty("id")]
@@ -46,6 +67,11 @@ namespace Recurly.Resources
         /// <value>Object type</value>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <value>The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".</value>
+        [JsonProperty("origin_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.OriginTaxAddressSource? OriginTaxAddressSource { get; set; }
 
         /// <value>List of countries for which the business entity will be used.</value>
         [JsonProperty("subscriber_location_countries")]

--- a/Recurly/Resources/ExternalPaymentPhase.cs
+++ b/Recurly/Resources/ExternalPaymentPhase.cs
@@ -35,10 +35,6 @@ namespace Recurly.Resources
         [JsonProperty("ends_at")]
         public DateTime? EndsAt { get; set; }
 
-        /// <value>Subscription from an external resource such as Apple App Store or Google Play Store.</value>
-        [JsonProperty("external_subscription")]
-        public ExternalSubscription ExternalSubscription { get; set; }
-
         /// <value>System-generated unique identifier for an external payment phase ID, e.g. `e28zov4fw0v2`.</value>
         [JsonProperty("id")]
         public string Id { get; set; }

--- a/Recurly/Resources/ExternalSubscription.cs
+++ b/Recurly/Resources/ExternalSubscription.cs
@@ -47,6 +47,10 @@ namespace Recurly.Resources
         [JsonProperty("external_id")]
         public string ExternalId { get; set; }
 
+        /// <value>The phases of the external subscription payment lifecycle.</value>
+        [JsonProperty("external_payment_phases")]
+        public List<ExternalPaymentPhase> ExternalPaymentPhases { get; set; }
+
         /// <value>External Product Reference details</value>
         [JsonProperty("external_product_reference")]
         public ExternalProductReferenceMini ExternalProductReference { get; set; }
@@ -54,6 +58,10 @@ namespace Recurly.Resources
         /// <value>System-generated unique identifier for an external subscription ID, e.g. `e28zov4fw0v2`.</value>
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        /// <value>An indication of whether or not the external subscription was created by a historical data import.</value>
+        [JsonProperty("imported")]
+        public bool? Imported { get; set; }
 
         /// <value>An indication of whether or not the external subscription is in a grace period.</value>
         [JsonProperty("in_grace_period")]

--- a/Recurly/Resources/GeneralLedgerAccount.cs
+++ b/Recurly/Resources/GeneralLedgerAccount.cs
@@ -1,0 +1,56 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class GeneralLedgerAccount : Resource
+    {
+
+
+        [JsonProperty("account_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.GeneralLedgerAccountType? AccountType { get; set; }
+
+        /// <value>
+        /// Unique code to identify the ledger account. Each code must start
+        /// with a letter or number. The following special characters are
+        /// allowed: `-_.,:`
+        /// </value>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <value>Created at</value>
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <value>Optional description.</value>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <value>Object type</value>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+        /// <value>Last updated at</value>
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+    }
+}

--- a/Recurly/Resources/GeneralLedgerAccountCreate.cs
+++ b/Recurly/Resources/GeneralLedgerAccountCreate.cs
@@ -1,0 +1,36 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class GeneralLedgerAccountCreate : Request
+    {
+
+
+        [JsonProperty("account_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.GeneralLedgerAccountType? AccountType { get; set; }
+
+        /// <value>
+        /// Unique code to identify the ledger account. Each code must start
+        /// with a letter or number. The following special characters are
+        /// allowed: `-_.,:`
+        /// </value>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <value>Optional description.</value>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+    }
+}

--- a/Recurly/Resources/GeneralLedgerAccountUpdate.cs
+++ b/Recurly/Resources/GeneralLedgerAccountUpdate.cs
@@ -1,0 +1,31 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class GeneralLedgerAccountUpdate : Request
+    {
+
+        /// <value>
+        /// Unique code to identify the ledger account. Each code must start
+        /// with a letter or number. The following special characters are
+        /// allowed: `-_.,:`
+        /// </value>
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        /// <value>Optional description.</value>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+    }
+}

--- a/Recurly/Resources/GiftCard.cs
+++ b/Recurly/Resources/GiftCard.cs
@@ -47,9 +47,25 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>Object type</value>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
 
         /// <value>The product code or SKU of the gift card product.</value>
         [JsonProperty("product_code")]
@@ -74,6 +90,14 @@ namespace Recurly.Resources
         /// <value>The ID of the invoice for the gift card redemption made by the recipient.  Does not have a value until gift card is redeemed.</value>
         [JsonProperty("redemption_invoice_id")]
         public string RedemptionInvoiceId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>The amount of the gift card, which is the amount of the charge to the gifter account and the amount of credit that is applied to the recipient account upon successful redemption.</value>
         [JsonProperty("unit_amount")]

--- a/Recurly/Resources/Item.cs
+++ b/Recurly/Resources/Item.cs
@@ -59,6 +59,14 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>This name describes your item and will appear on the invoice when it's purchased on a one time basis.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
@@ -66,6 +74,22 @@ namespace Recurly.Resources
         /// <value>Object type</value>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/ItemCreate.cs
+++ b/Recurly/Resources/ItemCreate.cs
@@ -47,9 +47,33 @@ namespace Recurly.Resources
         [JsonProperty("external_sku")]
         public string ExternalSku { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>This name describes your item and will appear on the invoice when it's purchased on a one time basis.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/ItemUpdate.cs
+++ b/Recurly/Resources/ItemUpdate.cs
@@ -47,9 +47,33 @@ namespace Recurly.Resources
         [JsonProperty("external_sku")]
         public string ExternalSku { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>This name describes your item and will appear on the invoice when it's purchased on a one time basis.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -72,6 +72,11 @@ namespace Recurly.Resources
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <value>The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".</value>
+        [JsonProperty("destination_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.DestinationTaxAddressSource? DestinationTaxAddressSource { get; set; }
+
         /// <value>The discount applied to the line item.</value>
         [JsonProperty("discount")]
         public decimal? Discount { get; set; }
@@ -115,6 +120,14 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.LegacyCategory? LegacyCategory { get; set; }
 
+        /// <value>
+        /// Unique code to identify the ledger account. Each code must start
+        /// with a letter or number. The following special characters are
+        /// allowed: `-_.,:`
+        /// </value>
+        [JsonProperty("liability_gl_account_code")]
+        public string LiabilityGlAccountCode { get; set; }
+
         /// <value>Object type</value>
         [JsonProperty("object")]
         public string Object { get; set; }
@@ -124,9 +137,22 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.LineItemOrigin? Origin { get; set; }
 
+        /// <value>The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".</value>
+        [JsonProperty("origin_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.OriginTaxAddressSource? OriginTaxAddressSource { get; set; }
+
         /// <value>The invoice where the credit originated. Will only have a value if the line item is a credit created from a previous credit, or if the credit was created from a charge refund.</value>
         [JsonProperty("original_line_item_invoice_id")]
         public string OriginalLineItemInvoiceId { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
 
         /// <value>If the line item is a charge or credit for a plan or add-on, this is the plan's code.</value>
         [JsonProperty("plan_code")]
@@ -167,6 +193,14 @@ namespace Recurly.Resources
         /// <value>A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.</value>
         [JsonProperty("refunded_quantity_decimal")]
         public string RefundedQuantityDecimal { get; set; }
+
+        /// <value>
+        /// Unique code to identify the ledger account. Each code must start
+        /// with a letter or number. The following special characters are
+        /// allowed: `-_.,:`
+        /// </value>
+        [JsonProperty("revenue_gl_account_code")]
+        public string RevenueGlAccountCode { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -44,6 +44,11 @@ namespace Recurly.Resources
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        /// <value>The source of the address that will be used as the destinaion in determining taxes. Available only when the site is on an Elite plan. A value of "destination" refers to the "Customer tax address". A value of "origin" refers to the "Business entity tax address".</value>
+        [JsonProperty("destination_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.DestinationTaxAddressSource? DestinationTaxAddressSource { get; set; }
+
         /// <value>If this date is provided, it indicates the end of a time range.</value>
         [JsonProperty("end_date")]
         public DateTime? EndDate { get; set; }
@@ -56,10 +61,31 @@ namespace Recurly.Resources
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.  Origin `prepayment` is only allowed if `type` is `charge` and `tax_exempt` is left blank or set to true.  This origin creates a charge and opposite credit on the account to be used for future invoices.</value>
         [JsonProperty("origin")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.LineItemCreateOrigin? Origin { get; set; }
+
+        /// <value>The source of the address that will be used as the origin in determining taxes. Available only when the site is on an Elite plan. A value of "origin" refers to the "Business entity tax address". A value of "destination" refers to the "Customer tax address".</value>
+        [JsonProperty("origin_tax_address_source")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.OriginTaxAddressSource? OriginTaxAddressSource { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
 
         /// <value>Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.</value>
         [JsonProperty("product_code")]
@@ -68,6 +94,14 @@ namespace Recurly.Resources
         /// <value>This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.</value>
         [JsonProperty("quantity")]
         public int? Quantity { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]

--- a/Recurly/Resources/ListGeneralLedgerAccountsParams.cs
+++ b/Recurly/Resources/ListGeneralLedgerAccountsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListGeneralLedgerAccountsParams : OptionalParams
+    {
+
+        /// <value>Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </value>
+        [JsonProperty("ids")]
+        public IList<string> Ids { get; set; }
+
+        /// <value>Limit number of records 1-200.</value>
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        /// <value>Sort order.</value>
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        /// <value>Sort field. You *really* only want to sort by `updated_at` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </value>
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        /// <value>General Ledger Account type by which to filter the response.</value>
+        [JsonProperty("account_type")]
+        public Constants.GeneralLedgerAccountType? AccountType { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/PerformanceObligation.cs
+++ b/Recurly/Resources/PerformanceObligation.cs
@@ -1,0 +1,39 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class PerformanceObligation : Resource
+    {
+
+        /// <value>Created At</value>
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <value>Performance Obligation Name</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <value>Last updated at</value>
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+
+    }
+}

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -76,9 +76,25 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.IntervalUnit? IntervalUnit { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
 
         /// <value>
         /// A fixed pricing model has the same price for each billing period.
@@ -93,6 +109,14 @@ namespace Recurly.Resources
         [JsonProperty("ramp_intervals")]
         public List<PlanRampInterval> RampIntervals { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
+
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
@@ -101,6 +125,30 @@ namespace Recurly.Resources
         /// <value>Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.</value>
         [JsonProperty("setup_fee_accounting_code")]
         public string SetupFeeAccountingCode { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_liability_gl_account_id")]
+        public string SetupFeeLiabilityGlAccountId { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_performance_obligation_id")]
+        public string SetupFeePerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_revenue_gl_account_id")]
+        public string SetupFeeRevenueGlAccountId { get; set; }
 
         /// <value>Setup fee revenue schedule type</value>
         [JsonProperty("setup_fee_revenue_schedule_type")]

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -67,13 +67,37 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
         /// <value>Ramp Intervals</value>
         [JsonProperty("ramp_intervals")]
         public List<PlanRampInterval> RampIntervals { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>Revenue schedule type</value>
         [JsonProperty("revenue_schedule_type")]
@@ -83,6 +107,30 @@ namespace Recurly.Resources
         /// <value>Accounting code for invoice line items for the plan's setup fee. If no value is provided, it defaults to plan's accounting code.</value>
         [JsonProperty("setup_fee_accounting_code")]
         public string SetupFeeAccountingCode { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_liability_gl_account_id")]
+        public string SetupFeeLiabilityGlAccountId { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_performance_obligation_id")]
+        public string SetupFeePerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("setup_fee_revenue_gl_account_id")]
+        public string SetupFeeRevenueGlAccountId { get; set; }
 
         /// <value>Setup fee revenue schedule type</value>
         [JsonProperty("setup_fee_revenue_schedule_type")]

--- a/Recurly/Resources/ShippingMethod.cs
+++ b/Recurly/Resources/ShippingMethod.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("id")]
         public string Id { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>The name of the shipping method displayed to customers.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
@@ -42,6 +50,22 @@ namespace Recurly.Resources
         /// <value>Object type</value>
         [JsonProperty("object")]
         public string Object { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>
         /// Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax

--- a/Recurly/Resources/ShippingMethodCreate.cs
+++ b/Recurly/Resources/ShippingMethodCreate.cs
@@ -23,9 +23,33 @@ namespace Recurly.Resources
         [JsonProperty("code")]
         public string Code { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>The name of the shipping method displayed to customers.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>
         /// Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax

--- a/Recurly/Resources/ShippingMethodUpdate.cs
+++ b/Recurly/Resources/ShippingMethodUpdate.cs
@@ -23,9 +23,33 @@ namespace Recurly.Resources
         [JsonProperty("code")]
         public string Code { get; set; }
 
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("liability_gl_account_id")]
+        public string LiabilityGlAccountId { get; set; }
+
         /// <value>The name of the shipping method displayed to customers.</value>
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        /// <value>
+        /// The ID of a performance obligation. Performance obligations are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("performance_obligation_id")]
+        public string PerformanceObligationId { get; set; }
+
+        /// <value>
+        /// The ID of a general ledger account. General ledger accounts are
+        /// only accessible as a part of the Recurly RevRec Standard and
+        /// Recurly RevRec Advanced features.
+        /// </value>
+        [JsonProperty("revenue_gl_account_id")]
+        public string RevenueGlAccountId { get; set; }
 
         /// <value>
         /// Used by Avalara, Vertex, and Recurly’s built-in tax feature. The tax

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -230,6 +230,8 @@ x-tagGroups:
   - shipping_method
   - dunning_campaigns
   - business_entities
+  - general_ledger_account
+  - performance_obligations
 tags:
 - name: site
   x-displayName: Site
@@ -242,7 +244,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices features to be enabled.
+    Recurly's item catalog requires the Credit Invoices feature to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -385,6 +387,55 @@ tags:
   x-displayName: Business Entities
   description: Describes the business address that will be used for invoices and taxes
     depending on settings and subscriber location.
+- name: general_ledger_account
+  x-displayName: General Ledger Account
+  description: |
+    A general ledger account is an account of record used to sort, store
+    and summarize a company's transactions. Recurly supports the balance
+    sheet (Liability) account and income (Revenue) account to be attached
+    to business entities, plans, or at the item level.
+
+    When invoices are created, system can default to the accounts based
+    on the GL Accounts attached at the plan/item level. The accounts can
+    be defaulted from the business entity level as well.
+
+    These accounts will be used in the Revenue Recognition module to create
+    the revenue journals that can be posted into Merchant GL system.
+
+    Revenue and Liability accounts can defined in the system using this
+    API or via the General Ledger Accounting page in the Admin UI and then
+    used at the plan/item level.
+
+    Recurly allows merchants to default the accounts at the following levels:
+    - Business Entities (default)
+    - Plans
+        - Base Price
+        - Setup Fee
+        - Add-ons
+    - Items
+    - Charges
+    - Gift Cards
+    - Shipping Methods
+    - Credits
+
+    If you are interested in Recurly Revenue Recognition features, please
+    contact a Recurly customer service representative.
+- name: performance_obligations
+  x-displayName: Performance Obligations
+  description: |
+    A performance obligation is a promise to provide a distinct good or
+    service or a series of distinct goods or services as defined by the revenue standard.
+    Performance obligations are completed and revenue is recognized either at a point in
+    time or over a period of time, depending on the type of obligation.
+    - Point in time  a company has to go through the criteria and determine if a performance
+    obligation is satisfied over time. If it does not meet those criteria, then the performance
+    obligation is satisfied and revenue recognized at the point in time when control of the good
+    or service is transferred to the customer.
+    - Over a period of time  a performance obligation is satisfied and revenue is recognized over
+    time if at least one of the following are met:
+      - The customer receives and consumes the benefits of the goods or services as they are provided
+      by the entity (routine, recurring services like a cleaning service are an example of a series of
+      services that are substantially the same and have the same pattern of transfer)
 paths:
   "/sites":
     get:
@@ -6566,7 +6617,7 @@ paths:
       - "$ref": "#/components/parameters/custom_field_definition_id"
       responses:
         '200':
-          description: An custom field definition.
+          description: A custom field definition.
           content:
             application/json:
               schema:
@@ -6672,6 +6723,150 @@ paths:
           {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Custom
           Field Definition: %s\", definition.Id)"
+  "/general_ledger_accounts":
+    post:
+      tags:
+      - general_ledger_account
+      operationId: create_general_ledger_account
+      summary: Create a new general ledger account
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountCreate"
+        required: true
+      responses:
+        '201':
+          description: A new general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    get:
+      tags:
+      - general_ledger_account
+      operationId: list_general_ledger_accounts
+      summary: List a site's general ledger accounts
+      description: See the [Pagination Guide](/developers/guides/pagination.html)
+        to learn how to use pagination in the API and Client Libraries.
+      parameters:
+      - "$ref": "#/components/parameters/ids"
+      - "$ref": "#/components/parameters/limit"
+      - "$ref": "#/components/parameters/order"
+      - "$ref": "#/components/parameters/sort_dates"
+      - "$ref": "#/components/parameters/general_ledger_account_type_enum"
+      responses:
+        '200':
+          description: A list of the site's general ledger accounts.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccountList"
+        '404':
+          description: Incorrect site ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/general_ledger_accounts/{general_ledger_account_id}":
+    get:
+      tags:
+      - general_ledger_account
+      operationId: get_general_ledger_account
+      summary: Fetch a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      responses:
+        '200':
+          description: A general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+    put:
+      tags:
+      - general_ledger_account
+      operationId: update_general_ledger_account
+      summary: Update a general ledger account
+      parameters:
+      - "$ref": "#/components/parameters/general_ledger_account_id"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/GeneralLedgerAccountUpdate"
+        required: true
+      responses:
+        '200':
+          description: The updated general ledger account.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GeneralLedgerAccount"
+        '404':
+          description: Incorrect site or general ledger account ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations/{performance_obligation_id}":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligation
+      summary: Get a single Performance Obligation.
+      parameters:
+      - "$ref": "#/components/parameters/performance_obligation_id"
+      responses:
+        '200':
+          description: A single Performance Obligation.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligation"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
+  "/performance_obligations":
+    get:
+      tags:
+      - performance_obligations
+      operationId: get_performance_obligations
+      summary: Get a site's Performance Obligations
+      responses:
+        '200':
+          description: A list of Performance Obligations.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/PerformanceObligationList"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/invoice_templates/{invoice_template_id}/accounts":
     get:
       tags:
@@ -8034,7 +8229,7 @@ paths:
       x-code-samples: []
   "/external_subscriptions/{external_subscription_id}":
     parameters:
-    - "$ref": "#/components/parameters/external_subscription_id"
+    - "$ref": "#/components/parameters/external_subscription_id_fetch"
     get:
       tags:
       - external_subscriptions
@@ -16093,10 +16288,10 @@ paths:
       tags:
       - external_payment_phases
       operationId: get_external_subscription_external_payment_phase
-      summary: Fetch an external payment_phase
+      summary: Fetch an external payment phase
       responses:
         '200':
-          description: Details for an external payment_phase.
+          description: Details for an external payment phase.
           content:
             application/json:
               schema:
@@ -16545,6 +16740,14 @@ components:
       required: true
       schema:
         type: string
+    external_subscription_id_fetch:
+      name: external_subscription_id
+      in: path
+      description: External subscription ID or external_id. For ID no prefix is used
+        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      required: true
+      schema:
+        type: string
     external_subscription_id:
       name: external_subscription_id
       in: path
@@ -16559,6 +16762,25 @@ components:
       required: true
       schema:
         type: string
+    general_ledger_account_id:
+      name: general_ledger_account_id
+      in: path
+      description: General Ledger Account ID
+      required: true
+      schema:
+        type: string
+        title: General Ledger Account ID
+        description: |
+          The ID of a general ledger account. General ledger accounts are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
+    general_ledger_account_type_enum:
+      name: account_type
+      in: query
+      description: General Ledger Account type by which to filter the response.
+      schema:
+        "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
     invoice_template_id:
       name: invoice_template_id
       in: path
@@ -16604,6 +16826,19 @@ components:
       required: true
       schema:
         type: string
+    performance_obligation_id:
+      name: performance_obligation_id
+      in: path
+      description: Performance Obligation id.
+      required: true
+      schema:
+        type: string
+        title: Performance Obligation ID
+        description: |
+          The ID of a performance obligation. Performance obligations are
+          only accessible as a part of the Recurly RevRec Standard and
+          Recurly RevRec Advanced features.
+        maxLength: 13
     plan_id:
       name: plan_id
       in: path
@@ -17858,6 +18093,30 @@ components:
           description: System-generated unique identifier for an measured unit associated
             with the add-on.
           maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -17972,7 +18231,7 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            Invoices` feature is enabled. If `item_id` and `item_code` are both present,
             `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
@@ -18031,6 +18290,30 @@ components:
           title: Plan ID
           maxLength: 13
           readOnly: true
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         accounting_code:
           type: string
           title: Accounting code
@@ -18100,7 +18383,7 @@ components:
           minItems: 1
           description: |
             * If `item_code`/`item_id` is part of the request and the item
-            has a default currency then `currencies` is optional. If the item does
+            has a default currency, then `currencies` is optional. If the item does
             not have a default currency, then `currencies` is required. If `item_code`/`item_id`
             is not present `currencies` is required.
             * If the add-on's `tier_type` is `tiered`, `volume`, or `stairstep`,
@@ -18189,6 +18472,30 @@ components:
             to the `AddOn` then `accounting code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
           description: When this add-on is invoiced, the line item will use this revenue
@@ -18271,7 +18578,7 @@ components:
             `percentage_tiers` is an array of objects, which must have the set of tiers
             per currency and the currency code. The tier_type must be `volume` or `tiered`,
             if not, it must be absent. There must be one tier without an `ending_amount` value
-            which represents the final tier.  This feature is currently in development and
+            which represents the final tier. This feature is currently in development and
             requires approval and enablement, please contact support.
     BillingInfo:
       type: object
@@ -19210,6 +19517,171 @@ components:
             are removed from the accouts or subscriptions, will be hard deleted an
             no longer visible.
           readOnly: true
+    GeneralLedgerAccountId:
+      type: string
+      title: General Ledger Account ID
+      description: |
+        The ID of a general ledger account. General ledger accounts are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    GeneralLedgerAccountCode:
+      type: string
+      title: Accounting code for the ledger account.
+      description: |
+        Unique code to identify the ledger account. Each code must start
+        with a letter or number. The following special characters are
+        allowed: `-_.,:`
+      pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+      maxLength: 255
+    GeneralLedgerAccountDescription:
+      type: string
+      title: Description
+      description: Optional description.
+      maxLength: 255
+    GeneralLedgerAccount:
+      type: object
+      description: Full general ledger account details.
+      properties:
+        id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        object:
+          type: string
+          title: Object type
+          default: general_ledger_account
+          readOnly: true
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+        created_at:
+          type: string
+          format: date-time
+          title: Created at
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          title: Last updated at
+          readOnly: true
+    GeneralLedgerAccountList:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          description: Will always be List.
+        has_more:
+          type: boolean
+          description: Indicates there are more results on subsequent pages.
+        next:
+          type: string
+          description: Path to subsequent page of results.
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/GeneralLedgerAccount"
+    GeneralLedgerAccountCreate:
+      type: object
+      description: Create a new liability or revenue general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+        account_type:
+          "$ref": "#/components/schemas/GeneralLedgerAccountTypeEnum"
+    GeneralLedgerAccountUpdate:
+      type: object
+      description: Update an existing general ledger account.
+      properties:
+        code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        description:
+          type: string
+          title: Description
+          description: Optional description.
+          maxLength: 255
+    PerformanceObligationId:
+      type: string
+      title: Performance Obligation ID
+      description: |
+        The ID of a performance obligation. Performance obligations are
+        only accessible as a part of the Recurly RevRec Standard and
+        Recurly RevRec Advanced features.
+      maxLength: 13
+    PerformanceObligation:
+      type: object
+      description: Performance obligation details
+      properties:
+        id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        name:
+          title: Performance Obligation Name
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          readOnly: true
+          format: date-time
+        updated_at:
+          title: Last updated at
+          type: string
+          readOnly: true
+          format: date-time
+    PerformanceObligationList:
+      type: object
+      description: List of Performance Obligations
+      properties:
+        object:
+          title: Object type
+          type: string
+        data:
+          title: Performance Obligation
+          type: array
+          items:
+            "$ref": "#/components/schemas/PerformanceObligation"
     ItemMini:
       type: object
       title: Item mini details
@@ -19294,6 +19766,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19378,6 +19874,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -19450,6 +19970,30 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         avalara_transaction_type:
           type: integer
           title: Avalara Transaction Type
@@ -20269,6 +20813,32 @@ components:
           format: float
           title: Discount
           description: The discount applied to the line item.
+        liability_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        revenue_gl_account_code:
+          type: string
+          title: Accounting code for the ledger account.
+          description: |
+            Unique code to identify the ledger account. Each code must start
+            with a letter or number. The following special characters are
+            allowed: `-_.,:`
+          pattern: "/^[A-Za-z0-9](( *)?[\\-A-Za-z0-9_.,:])*$/"
+          maxLength: 255
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax:
           type: number
           format: float
@@ -20310,6 +20880,10 @@ components:
           maxLength: 50
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         proration_rate:
           type: number
           format: float
@@ -20470,6 +21044,30 @@ components:
             is part of the request then `accounting_code` must be absent.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         tax_exempt:
           type: boolean
           title: Tax exempt?
@@ -20537,6 +21135,10 @@ components:
           format: date-time
           title: End date
           description: If this date is provided, it indicates the end of a time range.
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
       required:
       - currency
       - unit_amount
@@ -20834,6 +21436,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21050,6 +21700,54 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        setup_fee_performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         setup_fee_revenue_schedule_type:
           title: Setup fee revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -21508,6 +22206,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -21580,6 +22302,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
       required:
       - code
       - name
@@ -21618,6 +22364,30 @@ components:
             - `FR010200` – Delivery by Company Vehicle After Passage of Title
             - `NT` – Non-Taxable
           maxLength: 50
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
     ShippingFeeCreate:
       type: object
       properties:
@@ -23980,8 +24750,6 @@ components:
         object:
           type: string
           title: Object type
-        external_subscription:
-          "$ref": "#/components/schemas/ExternalSubscription"
         started_at:
           type: string
           format: date-time
@@ -24279,6 +25047,12 @@ components:
           "$ref": "#/components/schemas/AccountMini"
         external_product_reference:
           "$ref": "#/components/schemas/ExternalProductReferenceMini"
+        external_payment_phases:
+          type: array
+          title: External payment phases
+          description: The phases of the external subscription payment lifecycle.
+          items:
+            "$ref": "#/components/schemas/ExternalPaymentPhase"
         external_id:
           type: string
           title: External Id
@@ -24351,6 +25125,12 @@ components:
           title: Test
           description: An indication of whether or not the external subscription was
             purchased in a sandbox environment.
+          default: false
+        imported:
+          type: boolean
+          title: Imported
+          description: An indication of whether or not the external subscription was
+            created by a historical data import.
           default: false
         created_at:
           type: string
@@ -24682,6 +25462,10 @@ components:
           description: Address information for the business entity that will be used
             for calculating taxes.
           "$ref": "#/components/schemas/Address"
+        origin_tax_address_source:
+          "$ref": "#/components/schemas/OriginTaxAddressSourceEnum"
+        destination_tax_address_source:
+          "$ref": "#/components/schemas/DestinationTaxAddressSourceEnum"
         default_vat_number:
           type: string
           title: Default VAT number
@@ -24699,6 +25483,22 @@ components:
           items:
             type: string
             title: Country code
+        default_liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        default_revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -24797,6 +25597,30 @@ components:
           description: The delivery details for the gift card.
           readOnly: true
           "$ref": "#/components/schemas/GiftCardDelivery"
+        performance_obligation_id:
+          type: string
+          title: Performance Obligation ID
+          description: |
+            The ID of a performance obligation. Performance obligations are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        liability_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
+        revenue_gl_account_id:
+          type: string
+          title: General Ledger Account ID
+          description: |
+            The ID of a general ledger account. General ledger accounts are
+            only accessible as a part of the Recurly RevRec Standard and
+            Recurly RevRec Advanced features.
+          maxLength: 13
         created_at:
           type: string
           format: date-time
@@ -25978,3 +26802,30 @@ components:
       type: string
       enum:
       - paid
+    GeneralLedgerAccountTypeEnum:
+      type: string
+      enum:
+      - liability
+      - revenue
+    OriginTaxAddressSourceEnum:
+      type: string
+      title: Origin tax address source
+      description: The source of the address that will be used as the origin in determining
+        taxes. Available only when the site is on an Elite plan. A value of "origin"
+        refers to the "Business entity tax address". A value of "destination" refers
+        to the "Customer tax address".
+      default: origin
+      enum:
+      - origin
+      - destination
+    DestinationTaxAddressSourceEnum:
+      type: string
+      title: Destination tax address source
+      description: The source of the address that will be used as the destinaion in
+        determining taxes. Available only when the site is on an Elite plan. A value
+        of "destination" refers to the "Customer tax address". A value of "origin"
+        refers to the "Business entity tax address".
+      default: destination
+      enum:
+      - destination
+      - origin


### PR DESCRIPTION
**Taxable Address Control**
* GET external_subscription by external-id
* Add `destination_tax_address_source` and `origin_tax_address_source` to line_item and business_entity resources

**RevRec**
*  list_general_ledger_accounts
* get_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* update_general_ledger_account by `liability_gl_account_id` or `revenue_gl_account_id`
* get_performance_obligations
* get_performance_obligation by `performance_obligation_id`
* Add `default_liability_gl_account_id` and `default_revenue_gl_account_id` to business_entity resource
* Add `liability_gl_account_id`, `revenue_gl_account_id`, and `performance_obligation_id` to the following resources
    - add_on
    - business_entity
    - gift_card
    - item
    - shipping_method
* Add `liability_gl_account_code` and `revenue_gl_account_code` to line_item resource