### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -1715,7 +1715,7 @@ namespace Recurly
         /// <summary>
         /// Fetch an external subscription <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</see>
         /// </summary>
-        /// <param name="externalSubscriptionId">External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.</param>
+        /// <param name="externalSubscriptionId">External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.</param>
         /// <returns>
         /// Settings for an external subscription.
         /// </returns>
@@ -1725,7 +1725,7 @@ namespace Recurly
         /// <summary>
         /// Fetch an external subscription <see href="https://developers.recurly.com/api/v2021-02-25#operation/get_external_subscription">get_external_subscription api documentation</see>
         /// </summary>
-        /// <param name="externalSubscriptionId">External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.</param>
+        /// <param name="externalSubscriptionId">External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.</param>
         /// <returns>
         /// Settings for an external subscription.
         /// </returns>

--- a/Recurly/Resources/ExternalSubscription.cs
+++ b/Recurly/Resources/ExternalSubscription.cs
@@ -99,5 +99,9 @@ namespace Recurly.Resources
         [JsonProperty("updated_at")]
         public DateTime? UpdatedAt { get; set; }
 
+        /// <value>Universally Unique Identifier created automatically.</value>
+        [JsonProperty("uuid")]
+        public string Uuid { get; set; }
+
     }
 }

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value