### PR TITLE
 Fixing the ListEntitlements return type

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -5190,7 +5190,7 @@ namespace Recurly
         /// <returns>
         /// A list of the entitlements granted to an account.
         /// </returns>
-        public Pager<Entitlements> ListEntitlements(string accountId, ListEntitlementsParams optionalParams = null, RequestOptions options = null)
+        public Pager<Entitlement> ListEntitlements(string accountId, ListEntitlementsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var queryParams = (optionalParams ?? new ListEntitlementsParams()).ToDictionary();

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -3342,7 +3342,7 @@ namespace Recurly
         /// <returns>
         /// A list of the entitlements granted to an account.
         /// </returns>
-        Pager<Entitlements> ListEntitlements(string accountId, ListEntitlementsParams optionalParams = null, RequestOptions options = null);
+        Pager<Entitlement> ListEntitlements(string accountId, ListEntitlementsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>


### PR DESCRIPTION
I know the `IClient` and `Client` files are auto-generated, but this should show what's wrong with the return type for this method.

Fixing this should resolve #853.