### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -146,6 +146,10 @@ namespace Recurly.Resources
         [JsonProperty("previous_invoice_id")]
         public string PreviousInvoiceId { get; set; }
 
+        /// <value>Reference Only Currency Conversion</value>
+        [JsonProperty("reference_only_currency_conversion")]
+        public ReferenceOnlyCurrencyConversion ReferenceOnlyCurrencyConversion { get; set; }
+
         /// <value>The refundable amount on a charge invoice. It will be null for all other invoices.</value>
         [JsonProperty("refundable_amount")]
         public decimal? RefundableAmount { get; set; }

--- a/Recurly/Resources/ReferenceOnlyCurrencyConversion.cs
+++ b/Recurly/Resources/ReferenceOnlyCurrencyConversion.cs
@@ -1,0 +1,31 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class ReferenceOnlyCurrencyConversion : Resource
+    {
+
+        /// <value>3-letter ISO 4217 currency code.</value>
+        [JsonProperty("currency")]
+        public string Currency { get; set; }
+
+        /// <value>The subtotal converted to the currency.</value>
+        [JsonProperty("subtotal_in_cents")]
+        public decimal? SubtotalInCents { get; set; }
+
+        /// <value>The tax converted to the currency.</value>
+        [JsonProperty("tax_in_cents")]
+        public decimal? TaxInCents { get; set; }
+
+    }
+}

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -20276,6 +20276,8 @@ components:
           format: float
           title: Tax
           description: The total tax on this invoice.
+        reference_only_currency_conversion:
+          "$ref": "#/components/schemas/ReferenceOnlyCurrencyConversion"
         total:
           type: number
           format: float
@@ -22289,6 +22291,25 @@ components:
           title: Updated at
           format: date-time
           readOnly: true
+    ReferenceOnlyCurrencyConversion:
+      type: object
+      title: Reference Only Currency Conversion
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        subtotal_in_cents:
+          type: number
+          format: float
+          title: Subtotal In Cents
+          description: The subtotal converted to the currency.
+        tax_in_cents:
+          type: number
+          format: float
+          title: Tax In Cents
+          description: The tax converted to the currency.
     ShippingAddressCreate:
       type: object
       properties:


### PR DESCRIPTION
This PR adds `reference_only_currency_conversion` values to Invoice responses.

```json
  "reference_only_currency_conversion": {
    "currency": "str",
    "subtotal_in_cents": 0,
    "tax_in_cents": 0
  },
  ```