### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -480,6 +480,9 @@ namespace Recurly
             [EnumMember(Value = "stripe_payment_method")]
             StripePaymentMethod,
 
+            [EnumMember(Value = "upi_vpa")]
+            UpiVpa,
+
         };
 
         public enum GatewayTransactionType

--- a/Recurly/Resources/PaymentGatewayReferences.cs
+++ b/Recurly/Resources/PaymentGatewayReferences.cs
@@ -15,12 +15,12 @@ namespace Recurly.Resources
     public class PaymentGatewayReferences : Request
     {
 
-        /// <value>The type of reference token. Required if token is passed in for Stripe Gateway.</value>
+        /// <value>The type of reference token. Required if token is passed in for Stripe Gateway or Ebanx UPI.</value>
         [JsonProperty("reference_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.PaymentGatewayReferences? ReferenceType { get; set; }
 
-        /// <value>Reference value used when the external token was created. If Stripe gateway is used, this value will need to be accompanied by its reference_type.</value>
+        /// <value>Reference value used when the external token was created. If a Stripe gateway or Ebanx gateway is used, this value will need to be accompanied by its reference_type.</value>
         [JsonProperty("token")]
         public string Token { get; set; }
 

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -142,7 +142,7 @@ namespace Recurly.Resources
         [JsonProperty("shipping")]
         public SubscriptionShippingCreate Shipping { get; set; }
 
-        /// <value>If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.</value>
+        /// <value>If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.</value>
         [JsonProperty("starts_at")]
         public DateTime? StartsAt { get; set; }
 

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -64,7 +64,7 @@ namespace Recurly.Resources
         [JsonProperty("shipping")]
         public SubscriptionShippingPurchase Shipping { get; set; }
 
-        /// <value>If set, the subscription will begin in the future on this date. The subscription will apply the setup fee and trial period, unless the plan has no trial.</value>
+        /// <value>If set, the subscription will begin on this specified date. The subscription will apply the setup fee and trial period, unless the plan has no trial.</value>
         [JsonProperty("starts_at")]
         public DateTime? StartsAt { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21322,8 +21322,8 @@ components:
           type: string
           title: Token
           description: Reference value used when the external token was created. If
-            Stripe gateway is used, this value will need to be accompanied by its
-            reference_type.
+            a Stripe gateway or Ebanx gateway is used, this value will need to be
+            accompanied by its reference_type.
         reference_type:
           type: string
           title: Reference Type
@@ -23682,7 +23682,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -23855,7 +23855,7 @@ components:
           type: string
           format: date-time
           title: Start date
-          description: If set, the subscription will begin in the future on this date.
+          description: If set, the subscription will begin on this specified date.
             The subscription will apply the setup fee and trial period, unless the
             plan has no trial.
         next_bill_date:
@@ -26564,11 +26564,12 @@ components:
     PaymentGatewayReferencesEnum:
       type: string
       description: The type of reference token. Required if token is passed in for
-        Stripe Gateway.
+        Stripe Gateway or Ebanx UPI.
       enum:
       - stripe_confirmation_token
       - stripe_customer
       - stripe_payment_method
+      - upi_vpa
     GatewayTransactionTypeEnum:
       type: string
       enum:


### PR DESCRIPTION
- Adding the new `upi_vpa` payment gateway reference type
- Updated starts_at description to allow backdating subscriptions.