### PR TITLE
Add support for Webhook Signature Verification

### DIFF
--- a/Recurly.Tests/WebhooksTests.cs
+++ b/Recurly.Tests/WebhooksTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace Recurly.Tests
+{
+    public class WebhooksTests
+    {
+        public const string Secret = "354fab5bd35f5a0d50845ee7e30165244468b13c2c343f104e4e730a59326d9d";
+        public const string SecretAlt = "244468b13c2c343f104e4e730a59326d9d354fab5bd35f5a0d50845ee7e30165";
+        public const string Body = "{\"id\":\"rjxwmwedwqug\",\"object_type\":\"account\",\"site_id\":\"qc326l1hl8k9\",\"event_type\":\"created\",\"event_time\":\"2022-09-13T21:18:40Z\",\"account_code\":\"adfas23zzz14123\"}";
+
+        public const string OldTimetamp = "1663103925004";
+        public const string ExpectedSignatureAtOldTimestamp = "ad24699f3beaa24c9af2cc7ada3ce4c835da0090194241b9d3add83d27f14bc3";
+        public const string ExpectedSignatureAltAtOldTimestamp = "FCE309484E6A8360250DF367CCA0BCFC9FFFDC420AEAC2D97B9ED4560D8E4485";
+
+        public static readonly string OldHeader = $"{OldTimetamp},{ExpectedSignatureAtOldTimestamp}";
+
+        [Fact]
+        public void ValidSignature()
+        {
+            var ts = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 1000; // Jump back in time by 1s
+            var secret = Secret;
+            var header = ts.ToString();
+            using (var hmac = new HMACSHA256())
+            {
+                hmac.Key = Encoding.UTF8.GetBytes(secret);
+                header += "," + BitConverter.ToString(hmac.ComputeHash(
+                    Encoding.UTF8.GetBytes($"{ts}.{Body}"))).Replace("-", "");
+            }
+
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body),
+                "signature should validate");
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                throwOnFailure: true),
+                "signature should validate and not throw");
+        }
+        [Fact]
+        public void ValidSignatureAlt()
+        {
+            var ts = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 1000; // Jump back in time by 1s
+            var secret = SecretAlt;
+            var header = ts.ToString();
+            using (var hmac = new HMACSHA256())
+            {
+                header += "," + ExpectedSignatureAtOldTimestamp;
+
+                hmac.Key = Encoding.UTF8.GetBytes(secret);
+                header += "," + BitConverter.ToString(hmac.ComputeHash(
+                    Encoding.UTF8.GetBytes($"{ts}.{Body}"))).Replace("-", "");
+
+                header += "," + ExpectedSignatureAltAtOldTimestamp;
+            }
+
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body),
+                "signature should validate");
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                throwOnFailure: true),
+                "signature should validate and not throw");
+        }
+
+        /// <summary>
+        /// Tests just the signature computation and comparison, ignoring
+        /// the timestamp component by specifying a huge tolerance.
+        /// </summary>
+        [Fact]
+        public void ValidSignatureIgnoringTimestamp()
+        {
+            var header = OldHeader;
+            var secret = Secret;
+            var tolerance = long.MaxValue;
+
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                tolerance: tolerance),
+                "signature should validate");
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                tolerance: tolerance,
+                throwOnFailure: true),
+                "signature should validate and not throw");
+        }
+        [Fact]
+        public void ValidSignatureAltIgnoringTimestamp()
+        {
+            var header = $"{OldHeader},{ExpectedSignatureAltAtOldTimestamp}";
+            var secret = SecretAlt;
+
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                tolerance: long.MaxValue),
+                "signature should validate");
+            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                tolerance: long.MaxValue,
+                throwOnFailure: true),
+                "signature should validate and not throw");
+        }
+
+        [Fact]
+        public void InvalidTimestamp()
+        {
+            var header = OldHeader;
+            var secret = Secret;
+
+            // Test with and without throwOnFailure
+            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body),
+                "signature verification should fail");
+            
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                    throwOnFailure: true));
+            Assert.False(ex.Data.Contains("expected"),
+                "exception should not contain `expected` data");
+            Assert.False(ex.Data.Contains("actual"),
+                "exception should not contain `actual` data");
+        }
+
+        [Fact]
+        public void InvalidSignature()
+        {
+            var ts = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 1000; // Jump back in time by 1s
+            var secret = Secret;
+            var header = ts.ToString();
+            using (var hmac = new HMACSHA256())
+            {
+                hmac.Key = Encoding.UTF8.GetBytes(secret);
+                var badSig = new string((BitConverter.ToString(hmac.ComputeHash(
+                    Encoding.UTF8.GetBytes($"{ts}.{Body}"))).Replace("-", ""))
+                    .Reverse()
+                    .ToArray());
+                header += "," + badSig;
+            }
+
+            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body),
+                "signature should not validate");
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                    throwOnFailure: true));
+            Assert.True(ex.Data.Contains("expected"),
+                "exception should contain `expected` data");
+            Assert.True(ex.Data.Contains("actual"),
+                "exception should contain `actual` data");
+        }
+
+        [Fact]
+        public void InvalidSecretKey()
+        {
+            var header = OldHeader;
+            var secret = SecretAlt;
+
+            // Test with and without throwOnFailure
+            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body,
+                tolerance: long.MaxValue));
+            
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                    tolerance: long.MaxValue,
+                    throwOnFailure: true));
+            Assert.True(ex.Data.Contains("expected"),
+                "exception should contain `expected` data");
+            Assert.True(ex.Data.Contains("actual"),
+                "exception should contain `actual` data");
+        }
+    }
+}

--- a/Recurly.Tests/WebhooksTests.cs
+++ b/Recurly.Tests/WebhooksTests.cs
@@ -31,20 +31,23 @@ namespace Recurly.Tests
                     Encoding.UTF8.GetBytes($"{ts}.{Body}"))).Replace("-", "");
             }
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body),
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 throwOnFailure: true),
                 "signature should validate and not throw");
         }
         [Fact]
-        public void ValidSignatureAlt()
+        public void ValidSignatureFromMultiSigHeader()
         {
             var ts = DateTimeOffset.Now.ToUnixTimeMilliseconds() - 1000; // Jump back in time by 1s
             var secret = SecretAlt;
             var header = ts.ToString();
             using (var hmac = new HMACSHA256())
             {
+                // To simulate multiple sigs in the header
+                // we just prepend and append any old sigs
+
                 header += "," + ExpectedSignatureAtOldTimestamp;
 
                 hmac.Key = Encoding.UTF8.GetBytes(secret);
@@ -54,9 +57,9 @@ namespace Recurly.Tests
                 header += "," + ExpectedSignatureAltAtOldTimestamp;
             }
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body),
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 throwOnFailure: true),
                 "signature should validate and not throw");
         }
@@ -72,24 +75,24 @@ namespace Recurly.Tests
             var secret = Secret;
             var tolerance = long.MaxValue;
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 tolerance: tolerance),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 tolerance: tolerance,
                 throwOnFailure: true),
                 "signature should validate and not throw");
         }
         [Fact]
-        public void ValidSignatureAltIgnoringTimestamp()
+        public void ValidAltSignatureIgnoringTimestamp()
         {
             var header = $"{OldHeader},{ExpectedSignatureAltAtOldTimestamp}";
             var secret = SecretAlt;
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 tolerance: long.MaxValue),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 tolerance: long.MaxValue,
                 throwOnFailure: true),
                 "signature should validate and not throw");
@@ -102,11 +105,11 @@ namespace Recurly.Tests
             var secret = Secret;
 
             // Test with and without throwOnFailure
-            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body),
+            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret),
                 "signature verification should fail");
             
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                Webhooks.VerifyWebhookSignature(header, Body, secret,
                     throwOnFailure: true));
             Assert.False(ex.Data.Contains("expected"),
                 "exception should not contain `expected` data");
@@ -130,10 +133,10 @@ namespace Recurly.Tests
                 header += "," + badSig;
             }
 
-            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body),
+            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret),
                 "signature should not validate");
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                Webhooks.VerifyWebhookSignature(header, Body, secret,
                     throwOnFailure: true));
             Assert.True(ex.Data.Contains("expected"),
                 "exception should contain `expected` data");
@@ -148,11 +151,11 @@ namespace Recurly.Tests
             var secret = SecretAlt;
 
             // Test with and without throwOnFailure
-            Assert.False(Webhooks.VerifyWebhookSignature(header, secret, Body,
+            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret,
                 tolerance: long.MaxValue));
             
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, secret, Body,
+                Webhooks.VerifyWebhookSignature(header, Body, secret,
                     tolerance: long.MaxValue,
                     throwOnFailure: true));
             Assert.True(ex.Data.Contains("expected"),

--- a/Recurly.Tests/WebhooksTests.cs
+++ b/Recurly.Tests/WebhooksTests.cs
@@ -31,9 +31,9 @@ namespace Recurly.Tests
                     Encoding.UTF8.GetBytes($"{ts}.{Body}"))).Replace("-", "");
             }
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret),
+            Assert.True(Webhooks.VerifySignature(header, Body, secret),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 throwOnFailure: true),
                 "signature should validate and not throw");
         }
@@ -57,9 +57,9 @@ namespace Recurly.Tests
                 header += "," + ExpectedSignatureAltAtOldTimestamp;
             }
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret),
+            Assert.True(Webhooks.VerifySignature(header, Body, secret),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 throwOnFailure: true),
                 "signature should validate and not throw");
         }
@@ -75,10 +75,10 @@ namespace Recurly.Tests
             var secret = Secret;
             var tolerance = long.MaxValue;
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 tolerance: tolerance),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 tolerance: tolerance,
                 throwOnFailure: true),
                 "signature should validate and not throw");
@@ -89,10 +89,10 @@ namespace Recurly.Tests
             var header = $"{OldHeader},{ExpectedSignatureAltAtOldTimestamp}";
             var secret = SecretAlt;
 
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 tolerance: long.MaxValue),
                 "signature should validate");
-            Assert.True(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.True(Webhooks.VerifySignature(header, Body, secret,
                 tolerance: long.MaxValue,
                 throwOnFailure: true),
                 "signature should validate and not throw");
@@ -105,11 +105,11 @@ namespace Recurly.Tests
             var secret = Secret;
 
             // Test with and without throwOnFailure
-            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret),
+            Assert.False(Webhooks.VerifySignature(header, Body, secret),
                 "signature verification should fail");
             
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, Body, secret,
+                Webhooks.VerifySignature(header, Body, secret,
                     throwOnFailure: true));
             Assert.False(ex.Data.Contains("expected"),
                 "exception should not contain `expected` data");
@@ -133,10 +133,10 @@ namespace Recurly.Tests
                 header += "," + badSig;
             }
 
-            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret),
+            Assert.False(Webhooks.VerifySignature(header, Body, secret),
                 "signature should not validate");
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, Body, secret,
+                Webhooks.VerifySignature(header, Body, secret,
                     throwOnFailure: true));
             Assert.True(ex.Data.Contains("expected"),
                 "exception should contain `expected` data");
@@ -151,11 +151,11 @@ namespace Recurly.Tests
             var secret = SecretAlt;
 
             // Test with and without throwOnFailure
-            Assert.False(Webhooks.VerifyWebhookSignature(header, Body, secret,
+            Assert.False(Webhooks.VerifySignature(header, Body, secret,
                 tolerance: long.MaxValue));
             
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                Webhooks.VerifyWebhookSignature(header, Body, secret,
+                Webhooks.VerifySignature(header, Body, secret,
                     tolerance: long.MaxValue,
                     throwOnFailure: true));
             Assert.True(ex.Data.Contains("expected"),

--- a/Recurly/Webhooks.cs
+++ b/Recurly/Webhooks.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Recurly
+{
+    public static class Webhooks
+    {
+        /// <summary>
+        /// Default signature timestamp difference tolerance in milliseconds.
+        /// </summary>
+        public const long DefaultTolerance = 5 * 60 * 1000;
+        public static readonly byte PeriodByte = Convert.ToByte('.');
+
+        internal const string WebhookErrParsing = "webhook signature header parsing failed";
+	    internal const string WebhookErrToleranceExceeded = "webhook tolerance exceeded";
+	    internal const string WebhookErrSignatureMismatch = "webhook signatures do not match";
+        private static readonly char[] HeaderSplitChars = new[] { ',' };
+
+        /// <summary>
+        /// Verifies the header-provided signature for a JSON Webhook payload.
+        /// </summary>
+        /// <remarks>
+        /// Recurly webhook signature verification is based on
+        /// <see href="https://docs.recurly.com/v1.3/docs/signature-verification"
+        ///     >this documentation</see>.
+        /// </remarks>
+        /// <param name="header">value of the <code>recurly-signature</code></param>
+        /// <param name="secret">endpoint-specific secret key of a configured webhook</param>
+        /// <param name="body">complete, raw HTTP body of the Webhook payload</param>
+        /// <param name="tolerance">difference tolerance between current timestamp and
+        ///     header-provided timestamp</param>
+        /// <param name="throwOnFailure">if true, then an exception will be thrown
+        ///     if the signature fails validation for any reason, defaults to false</param>
+        /// <returns>true if the validation succeeds, false if the validation fails for any
+        ///     reason and <code>throwOnFailure</code> parameter is false</returns>
+        public static bool VerifyWebhookSignature(string header, string secret, string body,
+            long tolerance = DefaultTolerance,
+            bool throwOnFailure = false)
+        {
+            var secretBytes = Encoding.UTF8.GetBytes(secret);
+            var headerParts = header.Split(HeaderSplitChars, 2);
+            if (headerParts.Length < 2)
+            {
+                return throwOnFailure
+                    ? throw new FormatException(WebhookErrParsing)
+                    : false;
+            }
+
+            var headerTimestamp = headerParts[0];
+            var headerSigs = headerParts[1].Split(HeaderSplitChars);
+            if (!long.TryParse(headerTimestamp, out var sigUnixTimestamp))
+            {
+                return throwOnFailure
+                    ? throw new FormatException(WebhookErrParsing)
+                    : false;
+            }
+
+            var sigTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(sigUnixTimestamp);
+            var curTimestamp = DateTimeOffset.UtcNow;
+            if ((curTimestamp - sigTimestamp).TotalMilliseconds > tolerance)
+            {
+                return throwOnFailure
+                    ? throw new InvalidOperationException(WebhookErrToleranceExceeded)
+                    : false;
+            }
+
+            var dataSize = headerTimestamp.Length + 1 + body.Length;
+            var dataBuffer = new byte[dataSize];
+
+            string hashHex = null;
+            using (var hmac = new HMACSHA256(secretBytes))
+            using (var stream = new MemoryStream(dataBuffer))
+            {
+                var tsBytes = Encoding.UTF8.GetBytes(headerTimestamp);
+                var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+                stream.Write(tsBytes, 0, tsBytes.Length);
+                stream.WriteByte(PeriodByte);
+                stream.Write(bodyBytes, 0, bodyBytes.Length);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                var hashBytes = hmac.ComputeHash(stream);
+                hashHex = BitConverter.ToString(hashBytes).Replace("-", "");
+            }
+
+            for (var i = 0; i < headerSigs.Length; i++)
+            {
+                if (string.Equals(hashHex, headerSigs[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return throwOnFailure
+                ? throw new InvalidOperationException(WebhookErrSignatureMismatch + ";" + hashHex)
+                {
+                    Data =
+                    {
+                        ["expected"] = headerParts[1],
+                        ["actual"] = hashHex,
+                    },
+                }
+                : false;
+        }
+    }
+}

--- a/Recurly/Webhooks.cs
+++ b/Recurly/Webhooks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -12,11 +13,12 @@ namespace Recurly
         /// Default signature timestamp difference tolerance in milliseconds.
         /// </summary>
         public const long DefaultTolerance = 5 * 60 * 1000;
-        public static readonly byte PeriodByte = Convert.ToByte('.');
 
         internal const string WebhookErrParsing = "webhook signature header parsing failed";
-	    internal const string WebhookErrToleranceExceeded = "webhook tolerance exceeded";
-	    internal const string WebhookErrSignatureMismatch = "webhook signatures do not match";
+        internal const string WebhookErrToleranceExceeded = "webhook tolerance exceeded";
+        internal const string WebhookErrSignatureMismatch = "webhook signatures do not match";
+
+        private static readonly byte PeriodByte = Convert.ToByte('.');
         private static readonly char[] HeaderSplitChars = new[] { ',' };
 
         /// <summary>
@@ -28,29 +30,76 @@ namespace Recurly
         ///     >this documentation</see>.
         /// </remarks>
         /// <param name="header">value of the <code>recurly-signature</code></param>
-        /// <param name="secret">endpoint-specific secret key of a configured webhook</param>
         /// <param name="body">complete, raw HTTP body of the Webhook payload</param>
+        /// <param name="secret">endpoint-specific secret key of a configured webhook</param>
         /// <param name="tolerance">difference tolerance between current timestamp and
         ///     header-provided timestamp</param>
         /// <param name="throwOnFailure">if true, then an exception will be thrown
         ///     if the signature fails validation for any reason, defaults to false</param>
         /// <returns>true if the validation succeeds, false if the validation fails for any
         ///     reason and <code>throwOnFailure</code> parameter is false</returns>
-        public static bool VerifyWebhookSignature(string header, string secret, string body,
+        public static bool VerifyWebhookSignature(string header, string body, string secret,
             long tolerance = DefaultTolerance,
             bool throwOnFailure = false)
         {
             var secretBytes = Encoding.UTF8.GetBytes(secret);
+            return VerifyWebhookSignature(header, body, secretBytes, tolerance, throwOnFailure);
+        }
+        /// <summary>
+        /// Verifies the header-provided signature for a JSON Webhook payload.
+        /// </summary>
+        /// <remarks>
+        /// Recurly webhook signature verification is based on
+        /// <see href="https://docs.recurly.com/v1.3/docs/signature-verification"
+        ///     >this documentation</see>.
+        /// </remarks>
+        /// <param name="header">value of the <code>recurly-signature</code></param>
+        /// <param name="body">complete, raw HTTP body of the Webhook payload</param>
+        /// <param name="secret">endpoint-specific secret key of a configured webhook</param>
+        /// <param name="tolerance">difference tolerance between current timestamp and
+        ///     header-provided timestamp</param>
+        /// <param name="throwOnFailure">if true, then an exception will be thrown
+        ///     if the signature fails validation for any reason, defaults to false</param>
+        /// <returns>true if the validation succeeds, false if the validation fails for any
+        ///     reason and <code>throwOnFailure</code> parameter is false</returns>
+        public static bool VerifyWebhookSignature(string header, string body, byte[] secretBytes,
+            long tolerance = DefaultTolerance,
+            bool throwOnFailure = false)
+        {
+            if (!ValidateTimestamp(header, tolerance, throwOnFailure,
+                out var headerTimestamp, out var headerSigs))
+            {
+                return false;
+            }
+
+            var hashHex = ComputeHash(headerTimestamp, body, secretBytes);
+            foreach (var sig in headerSigs.Split(HeaderSplitChars))
+            {
+                if (string.Equals(hashHex, sig, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return ReturnOrThrowSignatureMismatch(throwOnFailure, headerSigs, hashHex);
+        }
+
+        private static bool ValidateTimestamp(string header, long tolerance, bool throwOnFailure,
+            out string headerTimestamp, out string headerSigs)
+        {
             var headerParts = header.Split(HeaderSplitChars, 2);
             if (headerParts.Length < 2)
             {
+                headerTimestamp = null;
+                headerSigs = null;
+
                 return throwOnFailure
                     ? throw new FormatException(WebhookErrParsing)
                     : false;
             }
 
-            var headerTimestamp = headerParts[0];
-            var headerSigs = headerParts[1].Split(HeaderSplitChars);
+            headerTimestamp = headerParts[0];
+            headerSigs = headerParts[1];
             if (!long.TryParse(headerTimestamp, out var sigUnixTimestamp))
             {
                 return throwOnFailure
@@ -67,43 +116,48 @@ namespace Recurly
                     : false;
             }
 
-            var dataSize = headerTimestamp.Length + 1 + body.Length;
+            return true;
+        }
+
+        private static string ComputeHash(string timestamp, string body, byte[] secretBytes)
+        {
+            var timestampBytes = Encoding.UTF8.GetBytes(timestamp);
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+            var dataSize = timestampBytes.Length + 1 + bodyBytes.Length;
             var dataBuffer = new byte[dataSize];
 
-            string hashHex = null;
             using (var hmac = new HMACSHA256(secretBytes))
             using (var stream = new MemoryStream(dataBuffer))
             {
-                var tsBytes = Encoding.UTF8.GetBytes(headerTimestamp);
-                var bodyBytes = Encoding.UTF8.GetBytes(body);
-
-                stream.Write(tsBytes, 0, tsBytes.Length);
+                stream.Write(timestampBytes, 0, timestampBytes.Length);
                 stream.WriteByte(PeriodByte);
                 stream.Write(bodyBytes, 0, bodyBytes.Length);
 
                 stream.Seek(0, SeekOrigin.Begin);
                 var hashBytes = hmac.ComputeHash(stream);
-                hashHex = BitConverter.ToString(hashBytes).Replace("-", "");
-            }
+                var hashHex = BitConverter.ToString(hashBytes).Replace("-", "");
 
-            for (var i = 0; i < headerSigs.Length; i++)
+                return hashHex;
+            }
+        }
+
+        private static bool ReturnOrThrowSignatureMismatch(bool throwOnFailure,
+            string expected, string actual)
+        {
+            if (throwOnFailure)
             {
-                if (string.Equals(hashHex, headerSigs[i], StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            return throwOnFailure
-                ? throw new InvalidOperationException(WebhookErrSignatureMismatch + ";" + hashHex)
+                throw new InvalidOperationException(WebhookErrSignatureMismatch)
                 {
                     Data =
                     {
-                        ["expected"] = headerParts[1],
-                        ["actual"] = hashHex,
+                        [nameof(expected)] = expected,
+                        [nameof(actual)] = actual,
                     },
-                }
-                : false;
+                };
+            }
+
+            return false;
         }
     }
 }

--- a/Recurly/Webhooks.cs
+++ b/Recurly/Webhooks.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -38,13 +36,14 @@ namespace Recurly
         ///     if the signature fails validation for any reason, defaults to false</param>
         /// <returns>true if the validation succeeds, false if the validation fails for any
         ///     reason and <code>throwOnFailure</code> parameter is false</returns>
-        public static bool VerifyWebhookSignature(string header, string body, string secret,
+        public static bool VerifySignature(string header, string body, string secret,
             long tolerance = DefaultTolerance,
             bool throwOnFailure = false)
         {
             var secretBytes = Encoding.UTF8.GetBytes(secret);
             return VerifyWebhookSignature(header, body, secretBytes, tolerance, throwOnFailure);
         }
+
         /// <summary>
         /// Verifies the header-provided signature for a JSON Webhook payload.
         /// </summary>


### PR DESCRIPTION
Adding comparable capability to the [Go](https://github.com/recurly/recurly-client-go/blob/v3-v2021-02-25/webhook.go) and [Ruby](https://github.com/recurly/recurly-client-ruby/blob/3d87bad0aa7ce3d1fd9647ec7e26b187585b4398/lib/recurly/webhooks.rb) implementations but adapted for .NET style and tests.
