### PR TITLE
Add constant apple_pay_merchant_token

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -1491,6 +1491,9 @@ namespace Recurly
             [EnumMember(Value = "apple_pay")]
             ApplePay,
 
+            [EnumMember(Value = "apple_pay_merchant_token")]
+            ApplePayMerchantToken,
+
             [EnumMember(Value = "bank_account_info")]
             BankAccountInfo,
 


### PR DESCRIPTION
When updating work on supporting payment methods, we need to update to utilize `apple_pay_merchant_token` moving forward.