### PR TITLE
Adds vertex_transaction_type to purchases invoices and adjustments

### DIFF
--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -284,6 +284,10 @@ namespace Recurly
                         TaxCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "vertex_transaction_type":
+                        VertexTransactionType = reader.ReadElementContentAsString();
+                        break;
+
                     case "tax_type":
                         TaxType = reader.ReadElementContentAsString();
                         break;

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -93,11 +93,6 @@ namespace Recurly
         }
         private List<CustomField> _customFields;
 
-        /// <summary>
-        /// Optional vertex transaction type for tax purposes.
-        /// </summary>
-        public string VertexTransactionType { get; set; }
-
         private const string UrlPrefix = "/accounts/";
         private const string UrlPostfix = "/adjustments/";
 
@@ -284,10 +279,6 @@ namespace Recurly
                         TaxCode = reader.ReadElementContentAsString();
                         break;
 
-                    case "vertex_transaction_type":
-                        VertexTransactionType = reader.ReadElementContentAsString();
-                        break;
-
                     case "tax_type":
                         TaxType = reader.ReadElementContentAsString();
                         break;
@@ -414,8 +405,6 @@ namespace Recurly
 
             if (TaxCode != null)
                 xmlWriter.WriteElementString("tax_code", TaxCode);
-            if (VertexTransactionType != null)
-                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
             if (StartDate != DateTime.MinValue)
                 xmlWriter.WriteElementString("start_date", StartDate.ToString("s"));
             if (EndDate.HasValue)

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -93,6 +93,11 @@ namespace Recurly
         }
         private List<CustomField> _customFields;
 
+        /// <summary>
+        /// Optional vertex transaction type for tax purposes.
+        /// </summary>
+        public string VertexTransactionType { get; set; }
+
         private const string UrlPrefix = "/accounts/";
         private const string UrlPostfix = "/adjustments/";
 
@@ -279,6 +284,10 @@ namespace Recurly
                         TaxCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "vertex_transaction_type":
+                        VertexTransactionType = reader.ReadElementContentAsString();
+                        break;
+
                     case "tax_type":
                         TaxType = reader.ReadElementContentAsString();
                         break;
@@ -405,6 +414,8 @@ namespace Recurly
 
             if (TaxCode != null)
                 xmlWriter.WriteElementString("tax_code", TaxCode);
+            if (VertexTransactionType != null)
+                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
             if (StartDate != DateTime.MinValue)
                 xmlWriter.WriteElementString("start_date", StartDate.ToString("s"));
             if (EndDate.HasValue)

--- a/Library/Adjustment.cs
+++ b/Library/Adjustment.cs
@@ -93,6 +93,11 @@ namespace Recurly
         }
         private List<CustomField> _customFields;
 
+        /// <summary>
+        /// Optional vertex transaction type for tax purposes.
+        /// </summary>
+        public string VertexTransactionType { get; set; }
+
         private const string UrlPrefix = "/accounts/";
         private const string UrlPostfix = "/adjustments/";
 
@@ -405,6 +410,8 @@ namespace Recurly
 
             if (TaxCode != null)
                 xmlWriter.WriteElementString("tax_code", TaxCode);
+            if (VertexTransactionType != null)
+                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
             if (StartDate != DateTime.MinValue)
                 xmlWriter.WriteElementString("start_date", StartDate.ToString("s"));
             if (EndDate.HasValue)

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -829,8 +829,6 @@ namespace Recurly
                 xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
             if (GatewayCode != null)
                 xmlWriter.WriteElementString("gateway_code", GatewayCode);
-            if (VertexTransactionType != null)
-                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
             if (PoNumber != null)
                 xmlWriter.WriteElementString("po_number", PoNumber);
 

--- a/Library/Invoice.cs
+++ b/Library/Invoice.cs
@@ -140,6 +140,7 @@ namespace Recurly
         public string TermsAndConditions { get; set; }
         public string VatReverseChargeNotes { get; set; }
         public string GatewayCode { get; set; }
+        public string VertexTransactionType { get; set; }
         public DateTime? AttemptNextCollectionAt { get; set; }
         public string RecoveryReason { get; set; }
         public string AllLineItemsLink { get; set; }
@@ -793,6 +794,9 @@ namespace Recurly
             xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
             xmlWriter.WriteElementString("po_number", PoNumber);
 
+            if (VertexTransactionType != null)
+                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
+
             if (CollectionMethod == Collection.Manual)
             {
                 xmlWriter.WriteElementString("collection_method", "manual");
@@ -825,6 +829,8 @@ namespace Recurly
                 xmlWriter.WriteElementString("vat_reverse_charge_notes", VatReverseChargeNotes);
             if (GatewayCode != null)
                 xmlWriter.WriteElementString("gateway_code", GatewayCode);
+            if (VertexTransactionType != null)
+                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
             if (PoNumber != null)
                 xmlWriter.WriteElementString("po_number", PoNumber);
 

--- a/Library/Purchase.cs
+++ b/Library/Purchase.cs
@@ -138,6 +138,11 @@ namespace Recurly
         /// </summary>
         public string TransactionType { get; set; }
 
+        /// <summary>
+        /// Optional vertex transaction type for tax purposes.
+        /// </summary>
+        public string VertexTransactionType { get; set; }
+
         #region Constructors
 
         internal Purchase()
@@ -280,6 +285,9 @@ namespace Recurly
 
             if (TransactionType != null)
                 xmlWriter.WriteElementString("transaction_type", TransactionType);
+
+            if (VertexTransactionType != null)
+                xmlWriter.WriteElementString("vertex_transaction_type", VertexTransactionType);
 
             if (NetTerms.HasValue)
                 xmlWriter.WriteElementString("net_terms", NetTerms.Value.ToString());

--- a/Test/AdjustmentTest.cs
+++ b/Test/AdjustmentTest.cs
@@ -281,5 +281,23 @@ namespace Recurly.Test
             xml.Should().Contain("<revenue_gl_account_id>sxo2b1hpjrye</revenue_gl_account_id>");
             xml.Should().Contain("<performance_obligation_id>7pu</performance_obligation_id>");
         }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void AdjustmentWithVertexTransactionType()
+        {
+            var adjustment = new Adjustment
+            {
+                VertexTransactionType = "lease"
+            };
+
+            // Verify the request serializes vertex_transaction_type correctly
+            var xmlOutput = new System.Text.StringBuilder();
+            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
+            {
+                adjustment.WriteXml(xmlWriter);
+            }
+            var xml = xmlOutput.ToString();
+            Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
+        }
     }
 }

--- a/Test/AdjustmentTest.cs
+++ b/Test/AdjustmentTest.cs
@@ -298,6 +298,24 @@ namespace Recurly.Test
             }
             var xml = xmlOutput.ToString();
             Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
+
+            // Verify that vertex_transaction_type can be deserialized from responses
+            var mockResponse = GetMockAdjustmentResponse();
+            Assert.NotNull(mockResponse);
+            Assert.Equal(mockResponse.State, Adjustment.AdjustmentState.Invoiced);
+            Assert.Equal("lease", mockResponse.VertexTransactionType);
+        }
+
+        private Adjustment GetMockAdjustmentResponse()
+        {
+            // Mock the Adjustment response using a fixture with vertex_transaction_type
+            var adjustment = new Adjustment();
+            var xmlFixture = FixtureImporter.Get(FixtureType.Adjustments, "show-with-vertex-200").Xml;
+            using (var reader = new XmlTextReader(new System.IO.StringReader(xmlFixture)))
+            {
+                adjustment.ReadXml(reader);
+            }
+            return adjustment;
         }
     }
 }

--- a/Test/Fixtures/FixtureImporter.cs
+++ b/Test/Fixtures/FixtureImporter.cs
@@ -98,6 +98,8 @@ namespace Recurly.Test.Fixtures
         PerformanceObligations,
         [Description("plans")]
         Plans,
+        [Description("purchases")]
+        Purchases,
         [Description("shipping_methods")]
         ShippingMethods,
     }

--- a/Test/Fixtures/adjustments/show-with-vertex-200.xml
+++ b/Test/Fixtures/adjustments/show-with-vertex-200.xml
@@ -1,0 +1,28 @@
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment href="https://api.recurly.com/v2/adjustments/abcdef1234567890" type="charge">
+  <account href="https://api.recurly.com/v2/accounts/account"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1234"/>
+  <subscription href="https://api.recurly.com/v2/subscriptions/1234567890abcdef"/>
+  <uuid>abcdef1234567890</uuid>
+  <state>invoiced</state>
+  <description>$12 Annual Subscription</description>
+  <item_code></item_code>
+  <accounting_code></accounting_code>
+  <product_code nil="nil"></product_code>
+  <origin>plan</origin>
+  <unit_amount_in_cents type="integer">1200</unit_amount_in_cents>
+  <quantity type="integer">1</quantity>
+  <discount_in_cents type="integer">0</discount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">1200</total_in_cents>
+  <currency>USD</currency>
+  <taxable type="boolean">false</taxable>
+  <tax_code></tax_code>
+  <vertex_transaction_type>lease</vertex_transaction_type>
+  <start_date type="datetime">2011-04-30T07:00:00Z</start_date>
+  <end_date type="datetime">2011-04-30T07:00:00Z</end_date>
+  <created_at type="datetime">2011-08-31T03:30:00Z</created_at>
+</adjustment>

--- a/Test/Fixtures/purchases/invoice-with-vertex-201.xml
+++ b/Test/Fixtures/purchases/invoice-with-vertex-201.xml
@@ -27,7 +27,6 @@ Content-Type: application/xml; charset=utf-8
         <total_in_cents type="integer">580</total_in_cents>
         <currency>USD</currency>
         <tax_exempt type="boolean">false</tax_exempt>
-        <vertex_transaction_type>lease</vertex_transaction_type>
         <created_at type="datetime">2025-11-25T22:00:00Z</created_at>
         <updated_at type="datetime">2025-11-25T22:00:00Z</updated_at>
       </adjustment>

--- a/Test/Fixtures/purchases/invoice-with-vertex-201.xml
+++ b/Test/Fixtures/purchases/invoice-with-vertex-201.xml
@@ -1,0 +1,57 @@
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection href="https://api.recurly.com/v2/invoice_collections/012345678901234567890123456789ab">
+  <charge_invoice href="https://api.recurly.com/v2/invoices/012345678901234567890123456789ab">
+    <account href="https://api.recurly.com/v2/accounts/test-account-123"/>
+    <uuid>012345678901234567890123456789ab</uuid>
+    <state>paid</state>
+    <invoice_number type="integer">1000</invoice_number>
+    <po_number>PO-12345</po_number>
+    <vat_number nil="nil"></vat_number>
+    <subtotal_in_cents type="integer">580</subtotal_in_cents>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">580</total_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2025-11-25T22:00:00Z</created_at>
+    <updated_at type="datetime">2025-11-25T22:00:00Z</updated_at>
+    <line_items type="array">
+      <adjustment type="charge">
+        <uuid>adj123456789</uuid>
+        <description>Test Adjustment</description>
+        <product_code>test-product</product_code>
+        <unit_amount_in_cents type="integer">580</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">580</total_in_cents>
+        <currency>USD</currency>
+        <tax_exempt type="boolean">false</tax_exempt>
+        <vertex_transaction_type>lease</vertex_transaction_type>
+        <created_at type="datetime">2025-11-25T22:00:00Z</created_at>
+        <updated_at type="datetime">2025-11-25T22:00:00Z</updated_at>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/tx123456789" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/test-account-123"/>
+        <uuid>tx123456789</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">580</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference nil="nil"></reference>
+        <source>purchase</source>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <created_at type="datetime">2025-11-25T22:00:00Z</created_at>
+        <updated_at type="datetime">2025-11-25T22:00:00Z</updated_at>
+      </transaction>
+    </transactions>
+  </charge_invoice>
+  <credit_invoices type="array">
+  </credit_invoices>
+</invoice_collection>

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -598,7 +598,7 @@ namespace Recurly.Test
                 VertexTransactionType = "lease"
             };
 
-            // Verify the request serializes vertex_transaction_type correctly
+            // Verify the request serializes vertex_transaction_type correctly (create only, not update)
             var xmlOutput = new System.Text.StringBuilder();
             using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
             {
@@ -607,23 +607,6 @@ namespace Recurly.Test
             var xml = xmlOutput.ToString();
             Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
         }
-
-        [RecurlyFact(TestEnvironment.Type.Unit)]
-        public void InvoiceWithVertexTransactionTypeUpdate()
-        {
-            var invoice = new Invoice
-            {
-                VertexTransactionType = "rental"
-            };
-
-            // Verify the update request serializes vertex_transaction_type correctly
-            var xmlOutput = new System.Text.StringBuilder();
-            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
-            {
-                invoice.WriteUpdateXml(xmlWriter);
-            }
-            var xml = xmlOutput.ToString();
-            Assert.Contains("<vertex_transaction_type>rental</vertex_transaction_type>", xml);
-        }
     }
 }
+

--- a/Test/InvoiceTest.cs
+++ b/Test/InvoiceTest.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
+using System.Xml;
 using FluentAssertions;
+using Recurly.Test.Fixtures;
 using Xunit;
 
 namespace Recurly.Test
@@ -586,6 +588,42 @@ namespace Recurly.Test
 
             Assert.Equal(response.NetTerms, 45);
             Assert.Equal(response.NetTermsType, NetTermsType.EOM);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void InvoiceWithVertexTransactionType()
+        {
+            var invoice = new Invoice
+            {
+                VertexTransactionType = "lease"
+            };
+
+            // Verify the request serializes vertex_transaction_type correctly
+            var xmlOutput = new System.Text.StringBuilder();
+            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
+            {
+                invoice.WriteXml(xmlWriter);
+            }
+            var xml = xmlOutput.ToString();
+            Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void InvoiceWithVertexTransactionTypeUpdate()
+        {
+            var invoice = new Invoice
+            {
+                VertexTransactionType = "rental"
+            };
+
+            // Verify the update request serializes vertex_transaction_type correctly
+            var xmlOutput = new System.Text.StringBuilder();
+            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
+            {
+                invoice.WriteUpdateXml(xmlWriter);
+            }
+            var xml = xmlOutput.ToString();
+            Assert.Contains("<vertex_transaction_type>rental</vertex_transaction_type>", xml);
         }
     }
 }

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using FluentAssertions;
+using Recurly.Test.Fixtures;
 using Xunit;
 
 namespace Recurly.Test
@@ -277,6 +279,57 @@ namespace Recurly.Test
             Assert.NotNull(response.ChargeInvoice);
             Assert.Equal(response.ChargeInvoice.NetTerms, 45);
             response.ChargeInvoice.NetTermsType.Should().Be(NetTermsType.EOM);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void PurchaseWithVertexTransactionType()
+        {
+            // Create an actual purchase with vertex_transaction_type
+            var account = NewAccountWithBillingInfo();
+
+            var adjustment = account.NewAdjustment("Test Adjustment", 580);
+            adjustment.Currency = "USD";
+            adjustment.Quantity = 1;
+            adjustment.UnitAmountInCents = 580;
+            adjustment.VertexTransactionType = "lease";
+
+            var purchase = new Purchase(account.AccountCode, "USD");
+            purchase.Account = account;
+            purchase.Adjustments.Add(adjustment);
+
+            // Verify the request serializes vertex_transaction_type correctly
+            var xmlOutput = new System.Text.StringBuilder();
+            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
+            {
+                adjustment.WriteEmbeddedXml(xmlWriter);
+            }
+            var xml = xmlOutput.ToString();
+            Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
+
+            // Simulate what Purchase.Invoice(purchase) would return by using a fixture
+            // This mocks the API response without making an actual HTTP call
+            var mockResponse = GetMockInvoiceCollectionResponse();
+
+            // Assert the mocked response contains vertex_transaction_type
+            Assert.NotNull(mockResponse.ChargeInvoice);
+            Assert.Equal(mockResponse.ChargeInvoice.State, Invoice.InvoiceState.Paid);
+            Assert.NotNull(mockResponse.ChargeInvoice.Adjustments);
+            Assert.Single(mockResponse.ChargeInvoice.Adjustments);
+            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].VertexTransactionType, "lease");
+            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].UnitAmountInCents, 580);
+            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].Description, "Test Adjustment");
+        }
+
+        private InvoiceCollection GetMockInvoiceCollectionResponse()
+        {
+            // Mock the Purchase.Invoice response using a fixture
+            var collection = new InvoiceCollection();
+            var xmlFixture = FixtureImporter.Get(FixtureType.Purchases, "invoice-with-vertex-201").Xml;
+            using (var reader = new XmlTextReader(new System.IO.StringReader(xmlFixture)))
+            {
+                collection.ReadXml(reader);
+            }
+            return collection;
         }
     }
 }

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -291,33 +291,26 @@ namespace Recurly.Test
             adjustment.Currency = "USD";
             adjustment.Quantity = 1;
             adjustment.UnitAmountInCents = 580;
-            adjustment.VertexTransactionType = "lease";
 
             var purchase = new Purchase(account.AccountCode, "USD");
             purchase.Account = account;
+            purchase.VertexTransactionType = "lease";
             purchase.Adjustments.Add(adjustment);
 
             // Verify the request serializes vertex_transaction_type correctly
             var xmlOutput = new System.Text.StringBuilder();
             using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
             {
-                adjustment.WriteEmbeddedXml(xmlWriter);
+                purchase.WriteXml(xmlWriter);
             }
             var xml = xmlOutput.ToString();
             Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
 
-            // Simulate what Purchase.Invoice(purchase) would return by using a fixture
-            // This mocks the API response without making an actual HTTP call
+            // Verify that a valid InvoiceCollection can be deserialized
+            // (vertex_transaction_type is only sent in requests, not returned in responses)
             var mockResponse = GetMockInvoiceCollectionResponse();
-
-            // Assert the mocked response contains vertex_transaction_type
             Assert.NotNull(mockResponse.ChargeInvoice);
             Assert.Equal(mockResponse.ChargeInvoice.State, Invoice.InvoiceState.Paid);
-            Assert.NotNull(mockResponse.ChargeInvoice.Adjustments);
-            Assert.Single(mockResponse.ChargeInvoice.Adjustments);
-            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].VertexTransactionType, "lease");
-            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].UnitAmountInCents, 580);
-            Assert.Equal(mockResponse.ChargeInvoice.Adjustments[0].Description, "Test Adjustment");
         }
 
         private InvoiceCollection GetMockInvoiceCollectionResponse()

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -313,6 +313,45 @@ namespace Recurly.Test
             Assert.Equal(mockResponse.ChargeInvoice.State, Invoice.InvoiceState.Paid);
         }
 
+        [RecurlyFact(TestEnvironment.Type.Unit)]
+        public void PurchaseWithAdjustmentsContainingVertexTransactionType()
+        {
+            // Create a purchase with adjustments that have vertex_transaction_type
+            var account = NewAccountWithBillingInfo();
+
+            var adjustment1 = account.NewAdjustment("Adjustment with lease type", 580);
+            adjustment1.Currency = "USD";
+            adjustment1.Quantity = 1;
+            adjustment1.VertexTransactionType = "lease";
+
+            var adjustment2 = account.NewAdjustment("Adjustment with rental type", 1200);
+            adjustment2.Currency = "USD";
+            adjustment2.Quantity = 2;
+            adjustment2.UnitAmountInCents = 600;
+            adjustment2.VertexTransactionType = "rental";
+
+            var purchase = new Purchase(account.AccountCode, "USD");
+            purchase.Account = account;
+            purchase.Adjustments.Add(adjustment1);
+            purchase.Adjustments.Add(adjustment2);
+
+            // Verify the request serializes vertex_transaction_type correctly for each adjustment
+            var xmlOutput = new System.Text.StringBuilder();
+            using (var xmlWriter = new XmlTextWriter(new System.IO.StringWriter(xmlOutput)))
+            {
+                purchase.WriteXml(xmlWriter);
+            }
+            var xml = xmlOutput.ToString();
+
+            // Should contain vertex_transaction_type for both adjustments
+            Assert.Contains("<vertex_transaction_type>lease</vertex_transaction_type>", xml);
+            Assert.Contains("<vertex_transaction_type>rental</vertex_transaction_type>", xml);
+
+            // Verify both adjustments are in the XML with their properties
+            Assert.Contains("<unit_amount_in_cents>580</unit_amount_in_cents>", xml);
+            Assert.Contains("<unit_amount_in_cents>600</unit_amount_in_cents>", xml);
+        }
+
         private InvoiceCollection GetMockInvoiceCollectionResponse()
         {
             // Mock the Purchase.Invoice response using a fixture

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -134,6 +134,9 @@
     <Content Include="Fixtures\adjustments\show-404.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\adjustments\show-with-vertex-200.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\billinginfo\destroy-204.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -224,6 +224,9 @@
     <Content Include="Fixtures\plans\show-200.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Fixtures\purchases\invoice-with-vertex-201.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Fixtures\subscriptions\show-200-inactive.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This change adds Vertex Transaction Type support for Purchases, Invoices, and Adjustments for the V2 client.