### PR TITLE
fix: Lock down CI to unbutu-22-04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Dotnet ${{ matrix.dotnet }} tests
     strategy:
       matrix:


### PR DESCRIPTION
Fixing issue when installing the `dotnet-format` package in development/testing environments
