### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -579,6 +579,9 @@ namespace Recurly
             [EnumMember(Value = "year")]
             Year,
 
+            [EnumMember(Value = "billing_period")]
+            BillingPeriod,
+
         };
 
         public enum FreeTrialUnit
@@ -2630,6 +2633,24 @@ namespace Recurly
 
             [EnumMember(Value = "merchant")]
             Merchant,
+
+        };
+
+        public enum SourceRecordType
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "account")]
+            Account,
+
+            [EnumMember(Value = "plan")]
+            Plan,
+
+            [EnumMember(Value = "product")]
+            Product,
+
+            [EnumMember(Value = "subscription")]
+            Subscription,
 
         };
 

--- a/Recurly/Resources/Address.cs
+++ b/Recurly/Resources/Address.cs
@@ -23,7 +23,7 @@ namespace Recurly.Resources
         [JsonProperty("country")]
         public string Country { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/Recurly/Resources/AddressWithName.cs
+++ b/Recurly/Resources/AddressWithName.cs
@@ -27,7 +27,7 @@ namespace Recurly.Resources
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/Recurly/Resources/Coupon.cs
+++ b/Recurly/Resources/Coupon.cs
@@ -124,11 +124,11 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.CouponState? State { get; set; }
 
-        /// <value>If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.</value>
+        /// <value>If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.</value>
         [JsonProperty("temporal_amount")]
         public int? TemporalAmount { get; set; }
 
-        /// <value>If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.</value>
+        /// <value>If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.</value>
         [JsonProperty("temporal_unit")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.TemporalUnit? TemporalUnit { get; set; }

--- a/Recurly/Resources/CouponCreate.cs
+++ b/Recurly/Resources/CouponCreate.cs
@@ -120,11 +120,11 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.RedemptionResource? RedemptionResource { get; set; }
 
-        /// <value>If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.</value>
+        /// <value>If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.</value>
         [JsonProperty("temporal_amount")]
         public int? TemporalAmount { get; set; }
 
-        /// <value>If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.</value>
+        /// <value>If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.</value>
         [JsonProperty("temporal_unit")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.TemporalUnit? TemporalUnit { get; set; }

--- a/Recurly/Resources/CustomField.cs
+++ b/Recurly/Resources/CustomField.cs
@@ -19,6 +19,15 @@ namespace Recurly.Resources
         [JsonProperty("name")]
         public string Name { get; set; }
 
+        /// <value>The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.</value>
+        [JsonProperty("source_record_id")]
+        public string SourceRecordId { get; set; }
+
+        /// <value>The type of record this custom field was automatically copied from. Only present when the field was copied from another record.</value>
+        [JsonProperty("source_record_type")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Constants.SourceRecordType? SourceRecordType { get; set; }
+
         /// <value>Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.</value>
         [JsonProperty("value")]
         public string Value { get; set; }

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -56,6 +56,10 @@ namespace Recurly.Resources
         [JsonProperty("currency")]
         public string Currency { get; set; }
 
+        /// <value>A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.</value>
+        [JsonProperty("custom_fields")]
+        public List<CustomField> CustomFields { get; set; }
+
         /// <value>This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.</value>
         [JsonProperty("customer_notes")]
         public string CustomerNotes { get; set; }

--- a/Recurly/Resources/InvoiceAddress.cs
+++ b/Recurly/Resources/InvoiceAddress.cs
@@ -31,7 +31,7 @@ namespace Recurly.Resources
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/Recurly/Resources/ShippingAddress.cs
+++ b/Recurly/Resources/ShippingAddress.cs
@@ -43,7 +43,7 @@ namespace Recurly.Resources
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/Recurly/Resources/ShippingAddressCreate.cs
+++ b/Recurly/Resources/ShippingAddressCreate.cs
@@ -35,7 +35,7 @@ namespace Recurly.Resources
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/Recurly/Resources/ShippingAddressUpdate.cs
+++ b/Recurly/Resources/ShippingAddressUpdate.cs
@@ -35,7 +35,7 @@ namespace Recurly.Resources
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
 
-        /// <value>Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration</value>
+        /// <value>Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.</value>
         [JsonProperty("geo_code")]
         public string GeoCode { get; set; }
 

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).