### PR TITLE
ci: Remediate Node.js 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 on: [push]
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on: [push]
-concurrency: 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
@@ -11,9 +13,9 @@ jobs:
       matrix:
         dotnet: [2.2.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6.0.2
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v5.3.0
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - run: ./scripts/build


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions on node20 or earlier will be forced to run with Node.js 24 starting June 2, 2026, and node20 will be removed from runners on September 16, 2026.

### Fix
Updated the following actions to Node.js 24-compatible versions:
- \`actions/checkout\` from v3 (node16) to v6.0.2 (node24)
- \`actions/setup-dotnet\` from v2 (node16) to v5.3.0 (node24)

### Files Changed
- \`.github/workflows/ci.yml\` — updated action versions

## Testing

### What was validated
Both updated actions were confirmed to have downloaded and executed successfully under Node.js 24:
- \`actions/checkout@v6.0.2\` (SHA: \`de0fac2e4500dabe0009e67214ff5f5447ce83dd\`) — ran successfully
- \`actions/setup-dotnet@v5.3.0\` (SHA: \`9a946fdbd5fb07b82b2f5a4466058b876ab72bb2\`) — ran successfully

The \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` flag was added for validation and removed in the cleanup commit before this PR is merged.

Checks passing: CodeQL (actions + csharp), Label Checker.

### Pre-existing CI failures (unrelated to this PR)

**CI / Dotnet 2.2.x tests** and **CI / Build (matrix)** are failing due to a pre-existing issue in \`scripts/build\`:

\`\`\`bash
dotnet tool install -g dotnet-format --version 4.0.0
\`\`\`

The \`dotnet-format\` package was retired from NuGet — version 4.0.0 never existed (the last published version was 3.0.2). The formatting functionality was integrated as \`dotnet format\` built-in starting with .NET 6 SDK. This failure occurs regardless of which version of \`actions/checkout\` or \`actions/setup-dotnet\` is used and predates this PR.

## Workaround Items
None — all updated actions have native Node.js 24 support.