### PR TITLE
fix: Update dotnet-format install to a published NuGet version

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -3,7 +3,7 @@ set -e
 
 if ! command -v dotnet-format; then
   echo "Installing dotnet formatter..."
-  dotnet tool install -g dotnet-format --version 4.0.0
+  dotnet tool install -g dotnet-format --version 5.1.250801
 fi
 
 dotnet build


### PR DESCRIPTION
Update dotnet-format to 5.1.250801, the latest published version, which targets netcoreapp2.1 and is compatible with the .NET 2.2 SDK used in CI.